### PR TITLE
Allow other client interpreters.

### DIFF
--- a/scripts/yast2
+++ b/scripts/yast2
@@ -421,7 +421,17 @@ else
     snapshot_pre $module
     #  break out on errors, #343258
     while [ $exit_code = 0 ]; do
-	$ybindir/y2base $module "$@" "$SELECTED_GUI" $Y2_GEOMETRY $Y2UI_ARGS
+        client=$(find_client "$module")
+        case $client in
+        *.ycp)
+          $ybindir/y2base $client "$@" "$SELECTED_GUI" $Y2_GEOMETRY $Y2UI_ARGS
+          ;;
+        *.rb)
+          $ybindir/r2d2base $client "$@" "$SELECTED_GUI" $Y2_GEOMETRY $Y2UI_ARGS
+          ;;
+        *)
+          echo "client '$client' not found" && exit 1
+        esac
 	exit_code=$?
 	if [ -z "$REDO_FILE" -o ! -f "$REDO_FILE" ]; then
 	    break

--- a/scripts/yast2-funcs
+++ b/scripts/yast2-funcs
@@ -148,6 +148,39 @@ function clr_inst_gtk_env()
     :
 }
 
+function find_client()
+{
+    local CLIENT_NAME="$1"
+    #now recognized client suffix, order is preference
+    local SUFFIX_ARRAY=('.ycp' '.rb')
+    #client can be in these location. order set preferences
+    local LOCATION_ARRAY=('/y2update')
+    IFS=':' read -a y2dir <<< "$Y2DIR"
+    for dir in "${y2dir[@]}"
+    do
+        LOCATION_ARRAY+=("$dir")
+    done
+    if [ -n "$HOME" ]
+    then
+        LOCATION_ARRAY+=("$HOME/.yast2")
+    fi
+    # NOTE cannot use compile option YAST2DIR so expand it to production version
+    LOCATION_ARRAY+=("/usr/share/YaST2")
+
+    for location in "${LOCATION_ARRAY[@]}"
+    do
+        for suffix in "${SUFFIX_ARRAY[@]}"
+        do
+            local result="${location}/clients/${CLIENT_NAME}${suffix}"
+            if [ -e $result ]
+            then
+                echo $result
+                return
+            fi
+        done
+    done
+}
+
 
 ### Local Variables: ***
 ### mode: shell-script ***


### PR DESCRIPTION
Before this commit yast2 call only y2base that can call only yast clients.
This commit adds ability to detect also other formats and call their client provider.
For now added only support for rb files with its r2d2base interpret.

!!!Not for opensuse 12.3!!!
