### PR TITLE
handle GPG keys in AutoUpgrade the same as in AutoYaST (bnc#820166)

### DIFF
--- a/library/packages/src/PackageCallbacks.ycp
+++ b/library/packages/src/PackageCallbacks.ycp
@@ -2930,7 +2930,8 @@ global void InitPackageCallbacks() {
 
     // @see bugzilla #183821
     // Do not register these callbacks in case of AutoInstallation
-    if (Mode::autoinst() != true) {
+    // And for AutoUpgrade neither (bnc#820166)
+    if (!(Mode::autoinst() || Mode::autoupgrade())) {
 	// Signature-related callbacks
 	Pkg::CallbackAcceptUnsignedFile		(SignatureCheckCallbacks::AcceptUnsignedFile);
 	Pkg::CallbackAcceptUnknownGpgKey	(SignatureCheckCallbacks::AcceptUnknownGpgKey);

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 12:41:09 UTC 2013 - jsrain@suse.cz
+
+- handle GPG keys in AutoUpgrade the same as in AutoYaST
+  (bnc#820166)
+- 2.17.128
+
+-------------------------------------------------------------------
 Tue May 14 11:43:45 UTC 2013 - mfilka@suse.com
 
 - bnc#819327


### PR DESCRIPTION
Conflicts:
    VERSION
    package/yast2.changes
