### PR TITLE
PackageSystem.ycp - do not initialize the target system in the first ins...

### DIFF
--- a/library/packages/src/PackageSystem.ycp
+++ b/library/packages/src/PackageSystem.ycp
@@ -76,6 +76,14 @@ include "packages/common.ycp";
  * This may become superfluous.
  */
 global void EnsureTargetInit() {
+    // do not initialize the target system in the first installation stage when
+    // running in instsys, there is no RPM DB in the RAM disk image (bnc#742420)
+    if (Stage::initial() && !Mode::live_installation())
+    {
+        y2milestone("Skipping target initialization in first stage installation");
+        return;
+    }
+
     PackageLock::Check ();
     // always initizalize target, it should be cheap according to #45356
     target_initialized = Pkg::TargetInit ("/", false);

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jul 29 11:21:23 UTC 2013 - lslezak@suse.cz
+
+- PackageSystem.ycp - do not initialize the target system in the
+  first installation stage when running in instsys, there is no RPM
+  DB in the RAM disk image (bnc#742420#c7)
+
+-------------------------------------------------------------------
 Thu Jul 18 11:57:12 UTC 2013 - mfilka@suse.com
 
 - added net device type detection based on sysfs


### PR DESCRIPTION
...tallation stage

when running in instsys, there is no RPM DB in the RAM disk image (bnc#742420#c7)
