### PR TITLE
- prevent accessing /etc/os-release during tests from Product.rb

### DIFF
--- a/library/packages/src/modules/Product.rb
+++ b/library/packages/src/modules/Product.rb
@@ -202,7 +202,9 @@ module Yast
           )
           Builtins.y2milestone("PATTERNS: %1", @patterns)
         end
-      elsif !Mode.config
+      # not during testing: Misc::CustomSysconfigRead used by OSRelease creates agent in runtime,
+      # mocking IniParser not possible
+      elsif !Mode.config && !Mode.test
         @short_name = OSRelease.ReleaseName
         @version = OSRelease.ReleaseVersion
         @name = Ops.add(Ops.add(@short_name, " "), @version)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 22 11:22:26 CEST 2013 - jsuchome@suse.cz
+
+- prevent accessing /etc/os-release during tests from Product.rb
+  constructor
+- 3.0.5 
+
+-------------------------------------------------------------------
 Thu Aug 22 08:17:06 CEST 2013 - jsuchome@suse.cz
 
 - replace SuSERelease with OSRelease, which uses /etc/os-release


### PR DESCRIPTION
  constructor
- 3.0.5
