### PR TITLE
Add deep_copy calls missing because of a Y2R bug

### DIFF
--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -116,7 +116,9 @@ module Yast
         )
       }
 
-      @Functions = Mode.config ? @FunctionsAI : @FunctionsSystem
+      @Functions = Mode.config ?
+        deep_copy(@FunctionsAI) :
+        deep_copy(@FunctionsSystem)
 
       @last_op_canceled = false
 

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -154,7 +154,7 @@ module Yast
         Builtins.y2milestone("Reading config file %1", @conf_file)
         read_conf = Convert.to_map(SCR.Read(path(".target.ycp"), @conf_file))
 
-        @config = read_conf != nil ? read_conf : {}
+        @config = read_conf != nil ? deep_copy(read_conf) : {}
         Builtins.y2milestone("Current config: %1", @config)
       else
         Builtins.y2milestone(


### PR DESCRIPTION
See https://github.com/yast/y2r/issues/47.
