### PR TITLE
Add handling of CLI to Report module

### DIFF
--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -547,6 +547,8 @@ module Yast
 
 
     # Display and record error string.
+    #
+    # @note Displaying can be globally disabled using Display* methods.
     # @param [String] error_string error text, it can contain new line characters ("\n")
     # @return [nil]
     def Error(error_string)


### PR DESCRIPTION
Report module was in original used only for installation, but it makes
sense to use it for all reporting independent on used mode.
