### PR TITLE
Fix `make check`

### DIFF
--- a/library/types/test/Makefile.am
+++ b/library/types/test/Makefile.am
@@ -1,5 +1,7 @@
-TESTS = ipv4_netmask_test.rb
+TESTS = \
+  ip_test.rb \
+  ipv4_netmask_test.rb
 TEST_EXTENSIONS = .rb
-RB_LOG_COMPILER = ruby
+RB_LOG_COMPILER = rspec
 VERBOSE = 1
 EXTRA_DIST = $(TESTS)


### PR DESCRIPTION
fixes breakage introduced by efdc5b9fd9346dc894a43f19f5c3d59466c24ce7

Moral: run the full rake osc:build (which runs make check)
