### PR TITLE
Fixed ip_test for 32bit (i586) arch.

### DIFF
--- a/library/types/test/ip_test.rb
+++ b/library/types/test/ip_test.rb
@@ -119,7 +119,10 @@ describe "Yast::IP" do
 
     RESULT_MAP_INT.each_pair do |k,v|
       it "returns #{v} for #{k}" do
-        expect( IP.ToInteger(k)).to be_equal v
+        # in 32bits arch IP#ToInteger returns Bignum, so equal? returns false
+        # and eql? has to be used
+        # in 64bits arch the result is Fixnum and the problem do not appear
+        expect( IP.ToInteger(k)).to be_eql v
       end
     end
 


### PR DESCRIPTION
In 64bit system IP#ToInteger returns 'Fixnum'. However it returns
'Bignum' in 32bit system. So, equal? method returns false in 32bit
system and has to be replaced by eql?.
