### PR TITLE
use "/usr/bin/rspec" instead of "/usr/bin/env rspec"

### DIFF
--- a/library/general/test/linuxrc_test.rb
+++ b/library/general/test/linuxrc_test.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env rspec
+#! /usr/bin/rspec
 
 ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
 

--- a/library/network/test/load_ipv6_cfg_test.rb
+++ b/library/network/test/load_ipv6_cfg_test.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env rspec
+#! /usr/bin/rspec
 
 top_srcdir = File.expand_path("../../../..", __FILE__)
 inc_dirs = Dir.glob("#{top_srcdir}/library/*/src")

--- a/library/network/test/network_interfaces_helpers_test.rb
+++ b/library/network/test/network_interfaces_helpers_test.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env rspec
+#!/usr/bin/rspec
 
 top_srcdir = File.expand_path("../../../..", __FILE__)
 inc_dirs = Dir.glob("#{top_srcdir}/library/*/src")

--- a/library/system/test/kernel_test.rb
+++ b/library/system/test/kernel_test.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env rspec
+#! /usr/bin/rspec
 
 ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
 

--- a/library/types/test/ip_test.rb
+++ b/library/types/test/ip_test.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env rspec --format=doc
+#! /usr/bin/rspec --format=doc
 
 ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
 

--- a/library/types/test/ipv4_netmask_test.rb
+++ b/library/types/test/ipv4_netmask_test.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env rspec --format=doc
+#! /usr/bin/rspec --format=doc
 
 ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
 


### PR DESCRIPTION
fixes infinite loop in 12.3 build
