### PR TITLE
Make sure the system ruby is used

### DIFF
--- a/scripts/yast2
+++ b/scripts/yast2
@@ -15,6 +15,9 @@
 
 export PATH=/sbin:/usr/sbin:$PATH
 
+# make sure the system ruby is used, bnc#845897
+unset GEM_HOME GEM_PATH RUBYLIB RUBYPATH RUBYOPT
+
 # we need input methods for many locales bnc#776567
 
 export QT_IM_MODULE=xim GTK_IM_MODULE=xim


### PR DESCRIPTION
This fixes https://bugzilla.novell.com/show_bug.cgi?id=845897, where YaST would use the user's RVM ruby even when run with `xdg-su`.
