### PR TITLE
fixed syntax error in Popup.Feedback()

### DIFF
--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -1184,7 +1184,7 @@ module Yast
       ShowFeedback(headline, message)
       yield
     ensure
-      ClearFeedback
+      ClearFeedback()
     end
 
     # Show a simple message and wait until user clicked "OK".

--- a/library/general/test/Makefile.am
+++ b/library/general/test/Makefile.am
@@ -1,7 +1,8 @@
 TESTS = \
   asciifile_test.rb \
   linuxrc_test.rb \
-  hooks_test.rb
+  hooks_test.rb \
+  popup_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/library/general/test/popup_test.rb
+++ b/library/general/test/popup_test.rb
@@ -1,0 +1,42 @@
+#! /usr/bin/env rspec
+
+ENV["Y2DIR"] = File.expand_path("../../src", __FILE__)
+
+require "yast"
+include Yast
+
+Yast.import "Popup"
+
+describe "Popup" do
+  let(:ui) { double("Yast::UI") }
+
+  before do
+    # generic UI stubs for the progress dialog
+    stub_const("Yast::UI", ui)
+  end
+
+  describe ".Feedback" do
+    before do
+      expect(ui).to receive(:OpenDialog)
+      expect(ui).to receive(:CloseDialog)
+      allow(ui).to receive(:BusyCursor)
+      allow(ui).to receive(:GetDisplayInfo).and_return({})
+    end
+
+    it "opens a popup dialog and closes it at the end" do
+      # just pass an empty block
+      Popup.Feedback("Label", "Message") {}
+    end
+
+    it "closes the popup even when an exception occurs in the block" do
+      # raise an exception in the block
+      expect{Popup.Feedback("Label", "Message") { raise "TEST"}}.to raise_error(RuntimeError, "TEST")
+    end
+
+    it "raises exception when the block parameter is missing" do
+      # no block passed
+      expect{Popup.Feedback("Label", "Message")}.to raise_error(LocalJumpError)
+    end
+  end
+
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 26 17:02:08 UTC 2014 - lslezak@suse.cz
+
+- fixed syntax error in Popup.Feedback()
+- 3.1.30
+
+-------------------------------------------------------------------
 Wed Mar 26 16:25:32 UTC 2014 - vmoravec@suse.com
 
 - Deprecate and refactor Service module with SystemdService backend

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.29
+Version:        3.1.30
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- 3.1.27

Stupid bug, `ClearFeedback` is treated as a constant, not as a function name (because of the uppercase letter at the beginning...).  I didn't test it, shame on me :-1: 

As a punishment  I added a test case for this ...
