### PR TITLE
Document the responsibility of NetworkInterfaces.

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -41,20 +41,19 @@ module Yast
     # Supported hotplug types
     HOTPLUG_TYPES = ["pcmcia", "usb"]
 
-    # @method Name=
-    # @method Name
-    # @example eth0, eth1:blah, lo, ...
+    # @attribute Name
+    # @return [String]
     #
-    # Current device identifier
+    # Current device identifier, like eth0, eth1:blah, lo, ...
     #
     # {#Add}, {#Edit} and {#Delete} copy the requested device info
     # (via {#Select}) to {#Name} and {#Current}, {#Commit} puts it back.
 
-    # @method Current=
-    # @method Current
-    # @example { "BOOTPROTO"=>"dhcp", "STARTMODE"=>"auto" }
+    # @attribute Current
+    # @return [Hash<String>]
     #
     # Current device information
+    # like { "BOOTPROTO"=>"dhcp", "STARTMODE"=>"auto" }
     #
     # {#Add}, {#Edit} and {#Delete} copy the requested device info
     # (via {#Select}) to {#Name} and {#Current}, {#Commit} puts it back.


### PR DESCRIPTION
I needed to find this out while fixing [bnc#883836](https://bugzilla.novell.com/show_bug.cgi?id=883836) (WIP).
http://www.rubydoc.info/github/yast/yast-yast2/Yast/NetworkInterfacesClass will have the new docs once it is merged.
To see it locally, run `yardoc` and `xdg-open doc/autodocs/Yast/NetworkInterfacesClass.html`

Notice how to document YCP variables. Comments inside `main` wouldn't work.
