### PR TITLE
Added test for reading of .etc.xinetd_conf.services [beware dependencies!]

### DIFF
--- a/library/general/test/agents_test/netd_agent_test.rb
+++ b/library/general/test/agents_test/netd_agent_test.rb
@@ -1,0 +1,42 @@
+require_relative "../test_helper"
+require 'yast'
+
+module Yast
+  describe ".etc.xinetd_conf.services" do
+
+    before :each do
+      root = File.join(File.dirname(__FILE__), "test_root")
+      set_root_path(root)
+    end
+
+    after :each do
+      reset_root_path
+    end
+
+    describe ".Read" do
+      let(:content) {SCR.Read(Path.new(".etc.xinetd_conf.services"))}
+
+      it "reads content of /etc/xinetd.d and returns array" do
+        expect(content).to be_a(Array)
+      end
+
+      it "returns one entry per file" do
+        expect(content.size).to eq(2)
+      end
+
+      it "returns proper service names" do
+        services = content.map {|i| i["service"]}.sort
+        expect(services).to eq(%w(echo services))
+      end
+
+      it "only skips parsing of options specific to each service" do
+        expected = [
+          "\ttype\t\t= INTERNAL\n\tid\t\t= echo-stream\n\tFLAGS\t\t= IPv6 IPv4\n",
+          "\ttype\t\t= INTERNAL UNLISTED\n\tport\t\t= 9098\n\tonly_from\t= 127.0.0.1\n\tFLAGS\t\t= IPv6 IPv4\n"
+        ]
+        unparsed = content.map {|i| i["unparsed"]}.sort
+        expect(unparsed).to eq(expected)
+      end
+    end
+  end
+end

--- a/library/general/test/agents_test/proc_meminfo_agent_test.rb
+++ b/library/general/test/agents_test/proc_meminfo_agent_test.rb
@@ -5,31 +5,27 @@ require "yast"
 
 describe ".proc.meminfo" do
 
-  AGENT_PATH = Yast::Path.new(".proc.meminfo")
   before :each do
     root = File.join(File.dirname(__FILE__), "test_root")
-    check_version = false
-    handle = Yast::WFM.SCROpen("chroot=#{root}:scr", check_version)
-    Yast::WFM.SCRSetDefault(handle)
+    set_root_path(root)
   end
 
   after :each do
-    Yast::WFM.SCRClose(Yast::WFM.SCRGetDefault)
+    reset_root_path
   end
 
   describe ".Read" do
+    let(:content) { Yast::SCR.Read(Yast::Path.new(".proc.meminfo")) }
+
     it "read content of /proc/meminfo return hash" do
-      content = Yast::SCR.Read(AGENT_PATH)
       expect(content).to be_a(Hash)
     end
 
     it "returned hash contain memtotal key" do
-      content = Yast::SCR.Read(AGENT_PATH)
       expect(content).to include("memtotal" => 1021032)
     end
 
     it "returned hash contain memfree key" do
-      content = Yast::SCR.Read(AGENT_PATH)
       expect(content).to include("memfree" => 83408)
     end
   end

--- a/library/general/test/agents_test/test_root/etc/xinetd.conf
+++ b/library/general/test/agents_test/test_root/etc/xinetd.conf
@@ -1,0 +1,61 @@
+#
+# This is the master xinetd configuration file. Settings in the
+# default section will be inherited by all service configurations
+# unless explicitly overridden in the service configuration. See
+# xinetd.conf in the man pages for a more detailed explanation of
+# these attributes.
+
+defaults
+{
+# The next two items are intended to be a quick access place to
+# temporarily enable or disable services.
+#
+#	enabled		=
+#	disabled	=
+
+# Previous default in SUSE - please don't forget to use the logrotate. The 
+# sample configuration is in /usr/share/packages/doc/xinetd/logrotate
+#       log_type        = FILE /var/log/xinetd.log 
+
+# Define general logging characteristics.
+	log_type	= SYSLOG daemon info 
+	log_on_failure	= HOST ATTEMPT
+	log_on_success	= HOST EXIT DURATION
+
+# Define access restriction defaults
+#
+#	no_access	=
+#	only_from	= localhost
+#	max_load	= 0
+	cps		= 50 10
+	instances	= 30
+	per_source	= 10
+
+#
+# The specification of an interface is interesting, if we are on a firewall.
+# For example, if you only want to provide services from an internal
+# network interface, you may specify your internal interfaces IP-Address.
+#
+#	bind	= 127.0.0.1
+
+# Address and networking defaults
+#
+#	bind		=
+#	mdns		= yes
+	v6only		= no
+
+# setup environmental attributes
+#
+#	passenv		=
+	groups		= yes
+	umask		= 002
+
+# Generally, banners are not used. This sets up their global defaults
+#
+#	banner		=
+#	banner_fail	=
+#	banner_success	=
+}
+
+includedir /etc/xinetd.d
+ 

--- a/library/general/test/agents_test/test_root/etc/xinetd.d/echo
+++ b/library/general/test/agents_test/test_root/etc/xinetd.d/echo
@@ -1,0 +1,14 @@
+# default: off
+# description: An echo server. This is the tcp version.
+
+service echo
+{
+	type		= INTERNAL
+	id		= echo-stream
+	socket_type	= stream
+	protocol	= tcp
+	user		= root
+	wait		= no
+	disable		= yes
+	FLAGS		= IPv6 IPv4
+}                                                                               

--- a/library/general/test/agents_test/test_root/etc/xinetd.d/services
+++ b/library/general/test/agents_test/test_root/etc/xinetd.d/services
@@ -1,0 +1,14 @@
+# default: off
+# description: An internal xinetd service, listing active services.
+
+service services
+{
+	type		= INTERNAL UNLISTED
+	port		= 9098
+	socket_type	= stream
+	protocol	= tcp
+	wait		= no
+	disable		= yes
+	only_from	= 127.0.0.1
+	FLAGS		= IPv6 IPv4
+}                                                                               

--- a/library/general/test/test_helper.rb
+++ b/library/general/test/test_helper.rb
@@ -3,3 +3,12 @@ top_srcdir = File.expand_path("../../../..", __FILE__)
 inc_dirs = Dir.glob("#{top_srcdir}/library/*/src")
 ENV["Y2DIR"] = inc_dirs.join(":")
 
+def set_root_path(directory)
+  check_version = false
+  handle = Yast::WFM.SCROpen("chroot=#{directory}:scr", check_version)
+  Yast::WFM.SCRSetDefault(handle)
+end
+
+def reset_root_path
+  Yast::WFM.SCRClose(Yast::WFM.SCRGetDefault)
+end


### PR DESCRIPTION
Tests to the fixes introduced by https://github.com/yast/yast-yast2/pull/289, so should be merged afterwards.

In addition, it also depends on yast/yast-core#82 which fixes a problem affecting the loading of files in the tests.
