### PR TITLE
Do not write /etc/sysconfig/kernel:INITRD_MODULES (bnc#895084)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep  5 14:32:23 UTC 2014 - lslezak@suse.cz
+
+- do not write /etc/sysconfig/kernel:INITRD_MODULES, it has been
+  dropped (bnc#895084)
+- 3.1.105
+
+-------------------------------------------------------------------
 Thu Sep  4 12:32:06 UTC 2014 - mvidner@suse.com
 
 - Use a more flexible rubygem requirement syntax (bnc#895069)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.104
+Version:        3.1.105
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- `INITRD_MODULES` has been dropped
- It would need some more cleanup (removing the related methods and variables), but I do not want to break something in RC3, so I just removed the write call and left the rest untouched.
- 3.1.105
