### PR TITLE
Remove support for the unmaintained GTK UI plugin

### DIFF
--- a/library/general/src/fillup/sysconfig.yast2
+++ b/library/general/src/fillup/sysconfig.yast2
@@ -13,7 +13,7 @@
 #       presence and adapt accordingly
 WANTED_SHELL="auto"
 
-## Type: list(auto,qt,gtk,ncurses)
+## Type: list(auto,qt,ncurses)
 ## Default: "auto"
 # Default UI backend for YaST
 # selects the GUI plugin to be used to render yast widgets

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 26 09:31:55 UTC 2014 - gber@opensuse.org
+
+- remove support for the unmaintained GTK UI plugin (bnc#901511)
+- 3.1.111
+
+-------------------------------------------------------------------
 Wed Nov 12 14:04:51 UTC 2014 - lslezak@suse.cz
 
 - removed RegistrationStatus.pm module (obsolete, not supported

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.110
+Version:        3.1.111
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -140,37 +140,25 @@ select_gui_frontend()
 {
     if [ "$WANTED_GUI" = "auto" ]; then
 	probe_desktop_gui
-	WANTED_GUI=$DESKTOP_GUI
+	WANTED_GUI=qt
 	GUI_SELECTION=auto
     fi
 
     if [ "$WANTED_GUI" = "gtk" ]; then
-	if check_gtk; then
-	    SELECTED_GUI=gtk
-	else
-	    if check_qt; then
-		SELECTED_GUI=qt
-		WANTED_GUI=qt
-		if [ "$GUI_SELECTION" != "auto" ]; then
-		    echo >&2 "GTK GUI wanted but not found, falling back to Qt."
-		fi
-	    else
-		echo >&2 "GTK GUI wanted but not found, falling back to ncurses."
+	if check_qt; then
+	    SELECTED_GUI=qt
+	    WANTED_GUI=qt
+	    if [ "$GUI_SELECTION" != "auto" ]; then
+		echo >&2 "The GTK GUI has been retired, falling back to Qt."
 	    fi
+	else
+	    echo >&2 "The GTK GUI has been retired, falling back to ncurses."
 	fi
     elif [ "$WANTED_GUI" = "qt" ]; then
 	if check_qt; then
 	    SELECTED_GUI=qt
 	else
-	    if check_gtk; then
-		SELECTED_GUI=gtk
-		WANTED_GUI=gtk
-		if [ "$GUI_SELECTION" != "auto" ]; then
-		    echo >&2 "Qt GUI wanted but not found, falling back to GTK."
-		fi
-	    else
-		echo >&2 "Qt GUI wanted but not found, falling back to ncurses."
-	    fi
+	    echo >&2 "Qt GUI wanted but not found, falling back to ncurses."
 	fi
     elif [ "$SELECTED_GUI" != "gtk" -a "$WANTED_GUI" != "ncurses" ]; then
 	echo >&2 "Unknown GUI '$WANTED_GUI', falling back to ncurses."
@@ -391,11 +379,9 @@ if [ "$SELECTED_GUI" = "ncurses" ]; then
 	echo "Something is wrong with the YaST user interface, NCurses selected but no terminal available." >&2
 	exit_code=1		# also skips y2base later
     fi
-elif [ "$SELECTED_GUI" = "qt" -o "$SELECTED_GUI" = "gtk" ]; then
+elif [ "$SELECTED_GUI" = "qt" ]; then
 
-    if [ "$SELECTED_GUI" = "qt" ]; then
-	set_qt_home_dir
-    fi
+    set_qt_home_dir
 
     # find which control center shell we want, if there is none we
     # fall back to the built-in ycp menu

--- a/scripts/yast2-funcs
+++ b/scripts/yast2-funcs
@@ -69,14 +69,6 @@ function check_qt()
 }
 
 #
-# check if the gtk plugin and all necessary libraries are present
-#
-function check_gtk()
-{
-    check_libyui_plugin gtk || check_plugin libpy2gtk.so.2 "the gtk frontend"
-}
-
-#
 # check if the ncurses plugin and all necessary libraries are present
 #
 function check_ncurses()


### PR DESCRIPTION
This removes support for the GTK UI plugin but leaves support for the GTK control center in, as requested in https://github.com/yast/yast-yast2/pull/301.
