### PR TITLE
Add new PowerPC - PowerNV platform

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -221,6 +221,11 @@ module Yast
         # Cell and Maple based boards have no CHRP in /proc/cpuinfo
         # Pegasos and Cell do have CHRP in /proc/cpuinfo, but Pegasos2 should no be handled as CHRP
         # Efika is handled like Pegasos for the time being
+        # Treat PowerNV as CHRP. It is harmless for now. Patch for hwinfo is sent but it is better to be safe
+        if @_board_compatible == "PowerNV"
+          @_board_compatible = "CHRP"
+        end
+
         if ppc && (@_board_compatible == nil || @_board_compatible == "CHRP")
           device_type = Convert.to_map(
             SCR.Execute(
@@ -242,11 +247,21 @@ module Yast
             model,
             device_type
           )
+          compatible = Convert.to_map(
+            SCR.Execute(
+              path(".target.bash_output"),
+              "echo -n `cat /proc/device-tree/compatible`",
+              {}
+            )
+          )
           # catch remaining IBM boards
           if Builtins.issubstring(
               Ops.get_string(device_type, "stdout", ""),
               "chrp"
-            )
+	     ) || Builtins.issubstring(
+              Ops.get_string(compatible, "stdout", ""),
+	      "ibm,powernv"
+	     )
             @_board_compatible = "CHRP"
           end
           # Maple has its own way of pretenting OF1275 compliance

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jan  7 10:05:55 UTC 2015 - dvaleev@suse.com
+
+- Treat PowerNV platform as CHRP
+
+-------------------------------------------------------------------
 Thu Dec  4 09:51:50 UTC 2014 - jreidinger@suse.com
 
 - remove X-KDE-Library from desktop file (bnc#899104)


### PR DESCRIPTION
Threat PowerNV as CHRP for now. The major difference is PowerNV doesn't
have bootloader, firmware parses grub.cfg and doing kexec. But having
bootlaoder (PReP partition) is harmless.

Signed-off-by: Dinar Valeev <dvaleev@suse.com>