### PR TITLE
Be less verbose at Travis to have shorter log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,10 @@ before_install:
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
     - sh ./travis_setup.sh -p "rake yast2-core yast2-devtools yast2-testsuite yast2-ruby-bindings yast2 yast2-pkg-bindings" -g "rspec:2.14.1 yast-rake gettext rubocop:0.28.0"
 script:
-    - rake check:syntax
     - rake check:pot
     - rubocop
-    - make -f Makefile.cvs
-    - make
-    - sudo make install
-    - make check
+    - make -s -f Makefile.cvs
+    - make -s
+    - sudo make -s install
+    - make -s check
 


### PR DESCRIPTION
- removed `rake check:syntax`, not needed anymore, the syntax is checked by rubocop
- use `-s` (silent) make option

The log size has been decreased from [~4600 lines](https://travis-ci.org/yast/yast-yast2/builds/48464147) to [~2500 lines](https://travis-ci.org/yast/yast-yast2/builds/48468523), which is a huge difference (almost half of the original size!).