### PR TITLE
Fix Travis locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,13 @@ before_install:
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
     - sh ./travis_setup.sh -p "rake yast2-core yast2-devtools yast2-testsuite yast2-ruby-bindings yast2 yast2-pkg-bindings" -g "rspec:2.14.1 yast-rake gettext simplecov coveralls rubocop:0.29.1"
 script:
-    - export LANG=C
-    - export LC_ALL=C
     - rake check:pot
     - rubocop
     - make -s -f Makefile.cvs
     - make -s
     - sudo make -s install
-    - make -s check
-    # make test coverage report
-    - COVERAGE=1 rake test:unit
+    # English messages, UTF-8, "C" locale for numeric formatting tests
+    - LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C make -s check
+    # English messages, UTF-8, "C" locale for numeric formatting tests, enable test coverage report
+    - LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C COVERAGE=1 rake test:unit
 


### PR DESCRIPTION
Fixed sending coveralls report at Travis - it failed when the commit author name contained an UTF-8 (non-ASCII) character.

I also moved the locale setting just to the tests to not potentially influence the other commands (to be compatible with the other Travis scripts).

(BTW locally it works without the `LC_ALL=` setting but failed without it at Travis. It took me some time to figure this out...)