### PR TITLE
Make iscsi_proposal public

### DIFF
--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -771,8 +771,6 @@ module Yast
       { "output" => output, "warning" => warning }
     end
 
-  private
-
     # Proposes firewall settings for iSCSI
     def propose_iscsi
       log.info "iSCSI has been used during installation, opening #{@iscsi_target_service} service"
@@ -781,6 +779,8 @@ module Yast
 
       # bsc#916376: ports need to be open already during boot
       SuSEFirewall.full_init_on_boot(true)
+
+      nil
     end
 
     publish function: :OpenServiceOnNonDialUpInterfaces, type: "void (string, list <string>)"
@@ -791,6 +791,7 @@ module Yast
     publish function: :Reset, type: "void ()"
     publish function: :Propose, type: "void ()"
     publish function: :ProposalSummary, type: "map <string, string> ()"
+    publish function: :propose_iscsi, type: "void ()"
   end
 
   SuSEFirewallProposal = SuSEFirewallProposalClass.new

--- a/library/network/test/susefirewall_proposal_test.rb
+++ b/library/network/test/susefirewall_proposal_test.rb
@@ -9,6 +9,26 @@ Yast.import "Linuxrc"
 
 describe Yast::SuSEFirewallProposal do
   describe "#ProposeFunctions" do
+    context "when iscsi is used" do
+      it "calls the iscsi proposal" do
+        allow(Yast::Linuxrc).to receive(:useiscsi).and_return(true)
+        expect(Yast::SuSEFirewallProposal).to receive(:propose_iscsi).and_return(nil)
+
+        Yast::SuSEFirewallProposal.ProposeFunctions
+      end
+    end
+
+    context "when iscsi is not used" do
+      it "does not call the iscsi proposal" do
+        allow(Yast::Linuxrc).to receive(:useiscsi).and_return(false)
+        expect(Yast::SuSEFirewallProposal).not_to receive(:propose_iscsi)
+
+        Yast::SuSEFirewallProposal.ProposeFunctions
+      end
+    end
+  end
+
+  describe "#propose_iscsi" do
     before(:each) do
       allow(Yast::SuSEFirewall).to receive(:GetAllNonDialUpInterfaces).and_return(["eth44", "eth55"])
       allow(Yast::SuSEFirewall).to receive(:GetZonesOfInterfaces).and_return(["EXT"])
@@ -16,15 +36,11 @@ describe Yast::SuSEFirewallProposal do
       allow(Yast::SuSEFirewallProposal).to receive(:ServiceEnabled).and_return(true)
     end
 
-    context "when iscsi is used" do
-      it "proposes opening iscsi-target firewall service and full firewall initialization on boot" do
-        allow(Yast::Linuxrc).to receive(:useiscsi).and_return("initial")
+    it "proposes opening iscsi-target firewall service and full firewall initialization on boot" do
+      expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
+      expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with(["service:iscsitarget"], ["EXT"], true).and_return(true)
 
-        expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
-        expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with(["service:iscsitarget"], ["EXT"], true).and_return(true)
-
-        Yast::SuSEFirewallProposal.ProposeFunctions
-      end
+      Yast::SuSEFirewallProposal.propose_iscsi
     end
   end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 18 10:32:24 CEST 2015 - locilka@suse.com
+
+- Making SuSEFirewallProposal.propose_iscsi function public
+  (bsc#916376)
+- 3.1.108.4
+
+-------------------------------------------------------------------
 Wed May 13 15:03:50 CEST 2015 - locilka@suse.com
 
 - Propose SuSEfirewal2 to fully initialize (e.g. open ports)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.108.3
+Version:        3.1.108.4
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- We have found out that there are two firewall proposals: one used in second stage, but the other one used in first stage. I'm sharing the functionality by using SuSEFirewallProposal
- The first stage proposal lives at yast/yast2-network
