### PR TITLE
Fixed firewall proposal in installation (iSCSI-related)

### DIFF
--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -252,6 +252,7 @@ module Yast
 
     # Function opens service for network interfaces given as the third parameter.
     # Fallback ports are used if the given service is uknown.
+    # If interfaces are not assigned to any firewall zone, all zones will be used.
     #
     # @see OpenServiceOnNonDialUpInterfaces for more info.
     #
@@ -263,11 +264,14 @@ module Yast
       interfaces = deep_copy(interfaces)
       zones = SuSEFirewall.GetZonesOfInterfaces(interfaces)
 
+      # Interfaces might not be assigned to any zone yet, use all zones
+      zones = SuSEFirewall.GetKnownFirewallZones() if zones.empty?
+
       if SuSEFirewallServices.IsKnownService(service)
         log.info "Opening service #{service} on interfaces #{interfaces} (zones #{zones})"
         SuSEFirewall.SetServicesForZones([service], zones, true)
       else
-        log.warn "Unknown service #{service}"
+        log.warn "Unknown service #{service}, enabling fallback ports"
         EnableFallbackPorts(fallback_ports, zones)
       end
 

--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -244,7 +244,7 @@ module Yast
 
       zones.each do |one_zone|
         unless known_zones.include?(one_zone)
-          log.error "Unknown firewall zone #{one_zone}"
+          raise "Unknown firewall zone #{one_zone}"
           next
         end
         fallback_ports.each do |one_port|

--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -65,8 +65,10 @@ module Yast
 
       @ssh_service = "service:sshd"
 
-      @iscsi_target_service = "service:iscsitarget"
+      # bsc#916376 iSCSI Target Daemon
+      @iscsi_target_service = "service:target"
 
+      # bsc#916376 Fallback ports used when iSCSI service file is not installed
       @iscsi_target_fallback_ports = ["iscsi-target"]
     end
 

--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -64,12 +64,6 @@ module Yast
       @vnc_service = "service:xorg-x11-server"
 
       @ssh_service = "service:sshd"
-
-      # bsc#916376 iSCSI Target Daemon
-      @iscsi_target_service = "service:target"
-
-      # bsc#916376 Fallback ports used when iSCSI service file is not installed
-      @iscsi_target_fallback_ports = ["iscsi-target"]
     end
 
     # <!-- SuSEFirewall LOCAL VARIABLES //-->
@@ -452,8 +446,6 @@ module Yast
         SuSEFirewall.AddXenSupport
       end
 
-      # BNC #766300 - Automatically propose opening iscsi-target port
-      # when installing with withiscsi=1
       propose_iscsi if Linuxrc.useiscsi
 
       SetKnownInterfaces(SuSEFirewall.GetListOfKnownInterfaces)
@@ -769,9 +761,7 @@ module Yast
 
     # Proposes firewall settings for iSCSI
     def propose_iscsi
-      log.info "iSCSI has been used during installation, opening #{@iscsi_target_service} service"
-
-      OpenServiceOnNonDialUpInterfaces(@iscsi_target_service, @iscsi_target_fallback_ports)
+      log.info "iSCSI has been used during installation, proposing FW full_init_on_boot"
 
       # bsc#916376: ports need to be open already during boot
       SuSEFirewall.full_init_on_boot(true)

--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -231,7 +231,7 @@ module Yast
     # @param [Array<String>] zones
     def EnableFallbackPorts(fallback_ports, zones)
       known_zones = SuSEFirewall.GetKnownFirewallZones()
-      unknown_zones = zones.reject{|zone| known_zones.include?(zone)}
+      unknown_zones = zones - known_zones
       raise "Unknown firewall zones #{unknown_zones}" unless unknown_zones.empty?
 
       log.info "Enabling fallback ports: #{fallback_ports} in zones: #{zones}"

--- a/library/network/test/susefirewall_proposal_test.rb
+++ b/library/network/test/susefirewall_proposal_test.rb
@@ -29,36 +29,10 @@ describe Yast::SuSEFirewallProposal do
   end
 
   describe "#propose_iscsi" do
-    before(:each) do
-      allow(Yast::SuSEFirewall).to receive(:GetAllNonDialUpInterfaces).and_return(["eth44", "eth55"])
-      allow(Yast::SuSEFirewall).to receive(:GetZonesOfInterfaces).and_return(["EXT"])
-      allow(Yast::SuSEFirewallServices).to receive(:IsKnownService).and_return(true)
-    end
+    it "proposes full firewall initialization on boot" do
+      expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
 
-    context "when firewall service exists on the current system" do
-      before do
-        allow(Yast::SuSEFirewallServices).to receive(:IsKnownService).and_return(true)
-      end
-
-      it "proposes opening iscsi-target firewall service and full firewall initialization on boot" do
-        expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
-        expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with(["service:target"], ["EXT"], true).and_return(true)
-
-        Yast::SuSEFirewallProposal.propose_iscsi
-      end
-    end
-
-    context "when firewall service does not exist on the current system" do
-      before do
-        allow(Yast::SuSEFirewallServices).to receive(:IsKnownService).and_return(false)
-      end
-
-      it "proposes opening fallback ports in firewall and full firewall initialization on boot" do
-        expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
-        expect(Yast::SuSEFirewallProposal).to receive(:EnableFallbackPorts).with(["iscsi-target"], ["EXT"]).and_return(nil)
-
-        Yast::SuSEFirewallProposal.propose_iscsi
-      end
+      Yast::SuSEFirewallProposal.propose_iscsi
     end
   end
 

--- a/library/network/test/susefirewall_proposal_test.rb
+++ b/library/network/test/susefirewall_proposal_test.rb
@@ -8,22 +8,24 @@ Yast.import "SuSEFirewallProposal"
 Yast.import "Linuxrc"
 
 describe Yast::SuSEFirewallProposal do
+  subject { Yast::SuSEFirewallProposal }
+
   describe "#ProposeFunctions" do
     context "when iscsi is used" do
       it "calls the iscsi proposal" do
         allow(Yast::Linuxrc).to receive(:useiscsi).and_return(true)
-        expect(Yast::SuSEFirewallProposal).to receive(:propose_iscsi).and_return(nil)
+        expect(subject).to receive(:propose_iscsi).and_return(nil)
 
-        Yast::SuSEFirewallProposal.ProposeFunctions
+        subject.ProposeFunctions
       end
     end
 
     context "when iscsi is not used" do
       it "does not call the iscsi proposal" do
         allow(Yast::Linuxrc).to receive(:useiscsi).and_return(false)
-        expect(Yast::SuSEFirewallProposal).not_to receive(:propose_iscsi)
+        expect(subject).not_to receive(:propose_iscsi)
 
-        Yast::SuSEFirewallProposal.ProposeFunctions
+        subject.ProposeFunctions
       end
     end
   end
@@ -32,11 +34,13 @@ describe Yast::SuSEFirewallProposal do
     it "proposes full firewall initialization on boot" do
       expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
 
-      Yast::SuSEFirewallProposal.propose_iscsi
+      subject.propose_iscsi
     end
   end
 
   describe "#EnableFallbackPorts" do
+    let(:fallback_ports) { ["port1", "port2"] }
+
     before(:each) do
       allow(Yast::SuSEFirewall).to receive(:GetKnownFirewallZones).and_return(["EXT", "INT", "DMZ"])
     end
@@ -45,15 +49,14 @@ describe Yast::SuSEFirewallProposal do
       it "opens given ports in firewall in given zones" do
         expect(Yast::SuSEFirewall).to receive(:AddService).with(/port.*/, "TCP", /(EXT|DMZ)/).exactly(4).times
 
-        Yast::SuSEFirewallProposal.EnableFallbackPorts(["port1","port2"], ["EXT", "DMZ"])
+        subject.EnableFallbackPorts(fallback_ports, ["EXT", "DMZ"])
       end
     end
 
     context "when opening ports in unknown firewall zones" do
       it "throws an exception" do
-        expect {
-          Yast::SuSEFirewallProposal.EnableFallbackPorts(["port1","port2"], ["UNKNOWN_ZONE1", "UZ2"])
-        }.to raise_error(/UNKNOWN_ZONE1.*UZ2/)
+        method_call = proc { subject.EnableFallbackPorts(fallback_ports, ["UNKNOWN_ZONE1", "UZ2"]) }
+        expect { method_call.call }.to raise_error(/UNKNOWN_ZONE1.*UZ2/)
       end
     end
   end
@@ -76,7 +79,7 @@ describe Yast::SuSEFirewallProposal do
     context "when network interfaces are assigned to some zone(s)" do
       it "open service in firewall in zones that include given interfaces" do
         expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with([firewall_service], interfaces_zones, true)
-        Yast::SuSEFirewallProposal.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
+        subject.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
       end
     end
 
@@ -84,22 +87,22 @@ describe Yast::SuSEFirewallProposal do
       it "opens service in firewall in all zones" do
         allow(Yast::SuSEFirewall).to receive(:GetZonesOfInterfaces).and_return([])
         expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with([firewall_service], all_zones, true)
-        Yast::SuSEFirewallProposal.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
+        subject.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
       end
     end
 
     context "when given firewall service is known" do
       it "opens service in firewall in zones that include given interfaces" do
         expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with([firewall_service], interfaces_zones, true)
-        Yast::SuSEFirewallProposal.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
+        subject.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
       end
     end
 
     context "when given service is unknown" do
       it "opens given fallback ports in zones that include given interfaces" do
         allow(Yast::SuSEFirewallServices).to receive(:IsKnownService).and_return(false)
-        expect(Yast::SuSEFirewallProposal).to receive(:EnableFallbackPorts).with(fallback_ports, interfaces_zones)
-        Yast::SuSEFirewallProposal.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
+        expect(subject).to receive(:EnableFallbackPorts).with(fallback_ports, interfaces_zones)
+        subject.OpenServiceInInterfaces(firewall_service, fallback_ports, network_interfaces)
       end
     end
   end

--- a/library/network/test/susefirewall_proposal_test.rb
+++ b/library/network/test/susefirewall_proposal_test.rb
@@ -43,4 +43,26 @@ describe Yast::SuSEFirewallProposal do
       Yast::SuSEFirewallProposal.propose_iscsi
     end
   end
+
+  describe "#EnableFallbackPorts" do
+    before(:each) do
+      allow(Yast::SuSEFirewall).to receive(:GetKnownFirewallZones).and_return(["EXT", "INT", "DMZ"])
+    end
+
+    context "when opening ports in known firewall zones" do
+      it "opens given ports in firewall in given zones" do
+        expect(Yast::SuSEFirewall).to receive(:AddService).with(/port.*/, "TCP", /(EXT|DMZ)/).exactly(4).times
+
+        Yast::SuSEFirewallProposal.EnableFallbackPorts(["port1","port2"], ["EXT", "DMZ"])
+      end
+    end
+
+    context "when opening ports in unknown firewall zones" do
+      it "throws an exception" do
+        expect {
+          Yast::SuSEFirewallProposal.EnableFallbackPorts(["port1","port2"], ["UNKNOWN_ZONE"])
+        }.to raise_error(/UNKNOWN_ZONE/)
+      end
+    end
+  end
 end

--- a/library/network/test/susefirewall_proposal_test.rb
+++ b/library/network/test/susefirewall_proposal_test.rb
@@ -38,7 +38,7 @@ describe Yast::SuSEFirewallProposal do
 
     it "proposes opening iscsi-target firewall service and full firewall initialization on boot" do
       expect(Yast::SuSEFirewall).to receive(:full_init_on_boot).and_return(true)
-      expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with(["service:iscsitarget"], ["EXT"], true).and_return(true)
+      expect(Yast::SuSEFirewall).to receive(:SetServicesForZones).with(["service:target"], ["EXT"], true).and_return(true)
 
       Yast::SuSEFirewallProposal.propose_iscsi
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
-Tue May 19 16:23:47 CEST 2015 - locilka@suse.com
+Mon May 25 14:04:51 CEST 2015 - locilka@suse.com
 
 - Fixed proposal to open fallback ports for services (bsc#916376)
+- Removed opening iSCSI ports from firewall proposal (bsc#916376)
 - 3.1.108.5
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 19 16:23:47 CEST 2015 - locilka@suse.com
+
+- Fixed proposal to open fallback ports for services (bsc#916376)
+- 3.1.108.5
+
+-------------------------------------------------------------------
 Mon May 18 10:32:24 CEST 2015 - locilka@suse.com
 
 - Making SuSEFirewallProposal.propose_iscsi function public

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.108.4
+Version:        3.1.108.5
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- It's not needed to open any ports in firewall, only enable early initialization (bsc#916376)
- As a side effect, I've fixed functionality to open fallback ports when firewall service does not exist
- If network interfaces are not assigned to any zone (e.g., in initial stage of installation) fallback ports are open in all zones (worked the same way for firewall services)
- Including extensive test case
