### PR TITLE
Don't log an error when fs snapshot has no date/time

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -201,7 +201,7 @@ module Yast2
       lines.map do |line|
         data = line.split("|").map(&:strip)
         begin
-          timestamp = DateTime.parse(data[3])
+          timestamp = data[3] == "" ? nil : DateTime.parse(data[3])
         rescue ArgumentError
           log.warn("Error when parsing date/time: #{timestamp}")
           timestamp = nil


### PR DESCRIPTION
Avoid logging an error when date/time is just an empty string.