### PR TITLE
Added Linuxrc.value_for

### DIFF
--- a/library/general/src/modules/Linuxrc.rb
+++ b/library/general/src/modules/Linuxrc.rb
@@ -222,18 +222,18 @@ module Yast
       feature_key = polish(feature_key)
       install_inf_features = deep_copy(@install_inf)
 
-      # Some values written on Linuxrc commandline are not know to Linuxrc
+      # Some values written on Linuxrc commandline are not known to Linuxrc
       # Unless they are also mentioned as `PTOptions`, they will appear as "Cmdline" entry
-      cmdline_values = install_inf_features.fetch("Cmdline", "").split.map do |cmdline_entry|
+      install_inf_features.fetch("Cmdline", "").split.map do |cmdline_entry|
         key_val = cmdline_entry.split("=")
         install_inf_features[key_val[0]] = key_val[1]
       end
 
-      matching_keys = install_inf_features.keys.select{|key| polish(key) == feature_key}
+      matching_keys = install_inf_features.keys.select { |key| polish(key) == feature_key }
       return nil if matching_keys.empty?
 
       # The last key wins as in Linuxrc
-      matching_keys.map{|key| install_inf_features[key]}.last
+      matching_keys.map { |key| install_inf_features[key] }.last
     end
 
     publish function: :ResetInstallInf, type: "void ()"
@@ -260,7 +260,6 @@ module Yast
     def polish(key)
       key.downcase.tr("-_\.", "")
     end
-
   end
 
   Linuxrc = LinuxrcClass.new

--- a/library/general/test/linuxrc_test.rb
+++ b/library/general/test/linuxrc_test.rb
@@ -191,12 +191,12 @@ describe Yast::Linuxrc do
   describe "#value_for" do
     context "when key is defined in install.inf (Linuxrc commandline)" do
       it "returns value for given key" do
-        load_install_inf({
-          "test_1" => "123",
+        load_install_inf(
+          "test_1"    => "123",
           "T-E-S-T-2" => "456",
-          "TeSt3" => "678",
-          "Cmdline" => "test4=890 test5=10,11,12",
-        })
+          "TeSt3"     => "678",
+          "Cmdline"   => "test4=890 test5=10,11,12"
+        )
 
         expect(subject.value_for("test_1")).to eq("123")
         expect(subject.value_for("TEsT2")).to eq("456")

--- a/library/general/test/linuxrc_test.rb
+++ b/library/general/test/linuxrc_test.rb
@@ -187,4 +187,30 @@ describe Yast::Linuxrc do
       expect(subject.keys.sort).to eq(DEFAULT_INSTALL_INF.keys.sort)
     end
   end
+
+  describe "#value_for" do
+    context "when key is defined in install.inf (Linuxrc commandline)" do
+      it "returns value for given key" do
+        load_install_inf({
+          "test_1" => "123",
+          "T-E-S-T-2" => "456",
+          "TeSt3" => "678",
+          "Cmdline" => "test4=890 test5=10,11,12",
+        })
+
+        expect(subject.value_for("test_1")).to eq("123")
+        expect(subject.value_for("TEsT2")).to eq("456")
+        expect(subject.value_for("T_e_St_3")).to eq("678")
+        expect(subject.value_for("T.e.s.t-4")).to eq("890")
+        expect(subject.value_for("test5")).to eq("10,11,12")
+      end
+    end
+
+    context "when key is not defined in install.inf (Linuxrc commandline)" do
+      it "returns nil" do
+        load_install_inf
+        expect(subject.value_for("this-key-is-not-defined")).to eq(nil)
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun  1 16:23:37 CEST 2015 - locilka@suse.com
+
+- Added Linuxrc.value_for (fate#317973)
+- 3.1.127
+
+-------------------------------------------------------------------
 Wed May 27 14:36:47 UTC 2015 - jreidinger@suse.com
 
 - Add persistent storage for fs pre snapshots (fate#317973)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.126
+Version:        3.1.127
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- We need to read Linuxrc commandline to find out whether Yast should create pre/post-install snapshots during Upgrade/Installation
- This new functionality enables us to simply call Linuxrc.value_for("disable_snapshots") and it will have the same result independently on the way how it's written on Linuxrc commandline - users don't need to follow strict guidelines and usually do not follow them (matches are case-insensiteve, dots, hyphens and underscores are ignored)