### PR TITLE
Implemented possibility to temporarily disable creating filesystem snapshots

### DIFF
--- a/library/general/src/modules/Linuxrc.rb
+++ b/library/general/src/modules/Linuxrc.rb
@@ -31,6 +31,10 @@ require "yast"
 
 module Yast
   class LinuxrcClass < Module
+    # Disables filesystem snapshots (fate#317973)
+    # Possible values: all, post, pre, single
+    DISABLE_SNAPSHOTS = "disable_snapshots"
+
     def main
       Yast.import "Mode"
       Yast.import "Stage"

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -109,13 +109,16 @@ module Yast2
       end
     end
 
-    # Creates a new 'single' snapshot
+    # Creates a new 'single' snapshot unless disabled by user
     #
     # @param description [String] Snapshot's description.
     # @return [FsSnapshot] The created snapshot.
     #
     # @see FsSnapshot.create
+    # @see FsSnapshot.create_snapshot?
     def self.create_single(description)
+      return nil unless create_snapshot?(:single)
+
       create(:single, description)
     end
 
@@ -125,11 +128,14 @@ module Yast2
     # @return [FsSnapshot] The created snapshot.
     #
     # @see FsSnapshot.create
+    # @see FsSnapshot.create_snapshot?
     def self.create_pre(description)
+      return nil unless create_snapshot?(:around)
+
       create(:pre, description)
     end
 
-    # Creates a new 'post' snapshot
+    # Creates a new 'post' snapshot unless disabled by user
     #
     # Each 'post' snapshot corresponds with a 'pre' one.
     #
@@ -138,8 +144,12 @@ module Yast2
     # @return [FsSnapshot] The created snapshot.
     #
     # @see FsSnapshot.create
+    # @see FsSnapshot.create_snapshot?
     def self.create_post(description, previous_number)
+      return nil unless create_snapshot?(:around)
+
       previous = find(previous_number)
+
       if previous
         create(:post, description, previous)
       else
@@ -148,7 +158,7 @@ module Yast2
       end
     end
 
-    # Creates a new snapshot
+    # Creates a new snapshot unless disabled by user
     #
     # It raises an exception if Snapper is not configured or if snapshot
     # creation fails.

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -98,14 +98,14 @@ module Yast2
       # Feature is not defined on Linuxrc commandline
       return true if disable_snapshots.nil? || disable_snapshots.empty?
 
-      disable_snapshots = disable_snapshots.downcase.tr("-_.", "").split(",").map(&:to_sym)
+      disable_snapshots = disable_snapshots.downcase.tr("-_.", "").split(",")
 
       if [:around, :single].include?(snapshot_type)
-        return false if disable_snapshots.include?(:all)
-        return !disable_snapshots.include?(snapshot_type)
+        return false if disable_snapshots.include?("all")
+        return !disable_snapshots.include?(snapshot_type.to_s)
       else
         raise ArgumentError, "Unsupported snapshot type #{snapshot_type.inspect}, " \
-          << "supported are :around and :single"
+              "supported are :around and :single"
       end
     end
 

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -84,7 +84,7 @@ describe Yast2::FsSnapshot do
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
-      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:single).and_return(create_snapshot)
     end
 
     context "when snapper is configured" do
@@ -146,7 +146,7 @@ describe Yast2::FsSnapshot do
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
-      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:around).and_return(create_snapshot)
     end
 
     context "when snapper is configured" do
@@ -209,7 +209,7 @@ describe Yast2::FsSnapshot do
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
-      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:around).and_return(create_snapshot)
     end
 
     context "when snapper is configured" do
@@ -408,7 +408,7 @@ describe Yast2::FsSnapshot do
     end
 
     context "when single value is defined on Linuxrc commandline" do
-      it "returns whether given snapshot is requested" do
+      it "returns whether given snapshot type is allowed" do
         allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("around")
         expect(described_class.create_snapshot?(:around)).to eq(false)
         expect(described_class.create_snapshot?(:single)).to eq(true)
@@ -424,7 +424,7 @@ describe Yast2::FsSnapshot do
     end
 
     context "when more values are defined on Linuxrc commandline" do
-      it "returns whether given snapshot is not withing disabled snapshots" do
+      it "returns whether given snapshot type is not within disabled snapshots types" do
         allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("single,around")
         expect(described_class.create_snapshot?(:around)).to eq(false)
         expect(described_class.create_snapshot?(:single)).to eq(false)
@@ -435,9 +435,8 @@ describe Yast2::FsSnapshot do
       end
     end
 
-
     context "when no value is defined on Linuxrc commandline" do
-      it "returns that any snapshots are requested" do
+      it "returns that any snapshots are allowed" do
         allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return(nil)
         expect(described_class.create_snapshot?(:around)).to eq(true)
         expect(described_class.create_snapshot?(:single)).to eq(true)
@@ -454,6 +453,5 @@ describe Yast2::FsSnapshot do
         expect { described_class.create_snapshot?(:some) }.to raise_error(ArgumentError, /:some/)
       end
     end
-
   end
 end

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -365,4 +365,59 @@ describe Yast2::FsSnapshot do
       end
     end
   end
+
+  describe ".create_snapshot?" do
+    before do
+      Yast.import "Linuxrc"
+    end
+
+    context "when single value is defined on Linuxrc commandline" do
+      it "returns whether given snapshot is requested" do
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("around")
+        expect(described_class.create_snapshot?(:around)).to eq(false)
+        expect(described_class.create_snapshot?(:single)).to eq(true)
+
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("single")
+        expect(described_class.create_snapshot?(:around)).to eq(true)
+        expect(described_class.create_snapshot?(:single)).to eq(false)
+
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("all")
+        expect(described_class.create_snapshot?(:around)).to eq(false)
+        expect(described_class.create_snapshot?(:single)).to eq(false)
+      end
+    end
+
+    context "when more values are defined on Linuxrc commandline" do
+      it "returns whether given snapshot is not withing disabled snapshots" do
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("single,around")
+        expect(described_class.create_snapshot?(:around)).to eq(false)
+        expect(described_class.create_snapshot?(:single)).to eq(false)
+
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("all,around")
+        expect(described_class.create_snapshot?(:around)).to eq(false)
+        expect(described_class.create_snapshot?(:single)).to eq(false)
+      end
+    end
+
+
+    context "when no value is defined on Linuxrc commandline" do
+      it "returns that any snapshots are requested" do
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return(nil)
+        expect(described_class.create_snapshot?(:around)).to eq(true)
+        expect(described_class.create_snapshot?(:single)).to eq(true)
+
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("")
+        expect(described_class.create_snapshot?(:around)).to eq(true)
+        expect(described_class.create_snapshot?(:single)).to eq(true)
+      end
+    end
+
+    context "when called with unsupported parameter value" do
+      it "throws an ArgumentError exception" do
+        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("all")
+        expect { described_class.create_snapshot?(:some) }.to raise_error(ArgumentError, /:some/)
+      end
+    end
+
+  end
 end

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -84,10 +84,12 @@ describe Yast2::FsSnapshot do
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
+      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).and_return(create_snapshot)
     end
 
     context "when snapper is configured" do
       let(:configured) { true }
+      let(:create_snapshot) { true }
 
       before do
         allow(Yast::SCR).to receive(:Execute)
@@ -120,10 +122,20 @@ describe Yast2::FsSnapshot do
 
     context "when snapper is not configured" do
       let(:configured) { false }
+      let(:create_snapshot) { true }
 
       it "raises an exception" do
         expect { described_class.create_single("some-description") }
           .to raise_error(Yast2::SnapperNotConfigured)
+      end
+    end
+
+    context "when creating snapshots is disabled" do
+      let(:configured) { false }
+      let(:create_snapshot) { false }
+
+      it "returns nil" do
+        expect(described_class.create_single("some-description")).to eq(nil)
       end
     end
   end
@@ -134,10 +146,12 @@ describe Yast2::FsSnapshot do
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
+      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).and_return(create_snapshot)
     end
 
     context "when snapper is configured" do
       let(:configured) { true }
+      let(:create_snapshot) { true }
 
       before do
         allow(Yast::SCR).to receive(:Execute)
@@ -170,10 +184,20 @@ describe Yast2::FsSnapshot do
 
     context "when snapper is not configured" do
       let(:configured) { false }
+      let(:create_snapshot) { true }
 
       it "raises an exception" do
         expect { described_class.create_pre("some-description") }
           .to raise_error(Yast2::SnapperNotConfigured)
+      end
+    end
+
+    context "when creating snapshots is disabled" do
+      let(:configured) { false }
+      let(:create_snapshot) { false }
+
+      it "returns nil" do
+        expect(described_class.create_pre("some-description")).to eq(nil)
       end
     end
   end
@@ -185,10 +209,12 @@ describe Yast2::FsSnapshot do
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
+      allow(Yast2::FsSnapshot).to receive(:create_snapshot?).and_return(create_snapshot)
     end
 
     context "when snapper is configured" do
       let(:configured) { true }
+      let(:create_snapshot) { true }
 
       let(:pre_snapshot) { double("snapshot", snapshot_type: :pre, number: 2) }
       let(:dummy_snapshot) { double("snapshot") }
@@ -239,10 +265,20 @@ describe Yast2::FsSnapshot do
 
     context "when snapper is not configured" do
       let(:configured) { false }
+      let(:create_snapshot) { true }
 
       it "raises an exception" do
         expect { described_class.create_post("some-description", 1) }
           .to raise_error(Yast2::SnapperNotConfigured)
+      end
+    end
+
+    context "when creating snapshots is disabled" do
+      let(:configured) { false }
+      let(:create_snapshot) { false }
+
+      it "returns nil" do
+        expect(described_class.create_post("some-description", 999)).to eq(nil)
       end
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jun  2 16:42:43 CEST 2015 - locilka@suse.com
+
+- Implemented possibility to temporarily disable creating
+  snapshots via parameter on Linuxrc commandline:
+    disable_snapshots=(single|around|all)
+  or using their comma-separated combination (fate#317973)
+- 3.1.129
+
+-------------------------------------------------------------------
 Tue Jun  2 11:26:50 UTC 2015 - jreidinger@suse.com
 
 - reduce count of extending inst-sys with snapper for snapshotting

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.128
+Version:        3.1.129
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- User can define the behavior on Linuxrc commandline disable_snapshots=(single|around|all)
- Also any comma-separated combination is allowed
- Including full-coverage test case
- Thanks to Linuxrc.get_value user can define this as any other Linuxrc parameter (with dots, hyphens, underscores and case insensitive)
- Values behave the very same as the parameter name