### PR TITLE
Fix value_for typo

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -93,7 +93,7 @@ module Yast2
     # @param [Symbol] one of :around (for :post and :pre snapshots) or :single
     # @return [Boolean] if snapshot should be created
     def self.create_snapshot?(snapshot_type)
-      disable_snapshots = Yast::Linuxrc.get_value(Yast::LinuxrcClass::DISABLE_SNAPSHOTS)
+      disable_snapshots = Yast::Linuxrc.value_for(Yast::LinuxrcClass::DISABLE_SNAPSHOTS)
 
       # Feature is not defined on Linuxrc commandline
       return true if disable_snapshots.nil? || disable_snapshots.empty?

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -409,15 +409,15 @@ describe Yast2::FsSnapshot do
 
     context "when single value is defined on Linuxrc commandline" do
       it "returns whether given snapshot type is allowed" do
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("around")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("around")
         expect(described_class.create_snapshot?(:around)).to eq(false)
         expect(described_class.create_snapshot?(:single)).to eq(true)
 
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("single")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("single")
         expect(described_class.create_snapshot?(:around)).to eq(true)
         expect(described_class.create_snapshot?(:single)).to eq(false)
 
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("all")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("all")
         expect(described_class.create_snapshot?(:around)).to eq(false)
         expect(described_class.create_snapshot?(:single)).to eq(false)
       end
@@ -425,11 +425,11 @@ describe Yast2::FsSnapshot do
 
     context "when more values are defined on Linuxrc commandline" do
       it "returns whether given snapshot type is not within disabled snapshots types" do
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("single,around")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("single,around")
         expect(described_class.create_snapshot?(:around)).to eq(false)
         expect(described_class.create_snapshot?(:single)).to eq(false)
 
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("all,around")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("all,around")
         expect(described_class.create_snapshot?(:around)).to eq(false)
         expect(described_class.create_snapshot?(:single)).to eq(false)
       end
@@ -437,11 +437,11 @@ describe Yast2::FsSnapshot do
 
     context "when no value is defined on Linuxrc commandline" do
       it "returns that any snapshots are allowed" do
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return(nil)
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return(nil)
         expect(described_class.create_snapshot?(:around)).to eq(true)
         expect(described_class.create_snapshot?(:single)).to eq(true)
 
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("")
         expect(described_class.create_snapshot?(:around)).to eq(true)
         expect(described_class.create_snapshot?(:single)).to eq(true)
       end
@@ -449,7 +449,7 @@ describe Yast2::FsSnapshot do
 
     context "when called with unsupported parameter value" do
       it "throws an ArgumentError exception" do
-        allow(Yast::Linuxrc).to receive(:get_value).with(/snapshot/).and_return("all")
+        allow(Yast::Linuxrc).to receive(:value_for).with(/snapshot/).and_return("all")
         expect { described_class.create_snapshot?(:some) }.to raise_error(ArgumentError, /:some/)
       end
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun  4 12:04:32 UTC 2015 - igonzalezsosa@suse.com
+
+- Fix a typo when calling Linuxrc.value_for method
+- 3.1.130
+
+-------------------------------------------------------------------
 Tue Jun  2 16:42:43 CEST 2015 - locilka@suse.com
 
 - Implemented possibility to temporarily disable creating

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.129
+Version:        3.1.130
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
Just call `value_for` instead of `get_value`.