### PR TITLE
Keep routing state when disabling/stopping firewall

### DIFF
--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -90,6 +90,7 @@ module Yast
         "FW_LOG_DROP_CRIT"           => "yes",
         "FW_PROTECT_FROM_INT"        => "no",
         "FW_ROUTE"                   => "no",
+        "FW_STOP_KEEP_ROUTING_STATE" => "no",
         "FW_MASQUERADE"              => "no",
         "FW_ALLOW_FW_TRACEROUTE"     => "yes",
         "FW_ALLOW_PING_FW"           => "yes",
@@ -1185,8 +1186,10 @@ module Yast
       SetModified()
 
       if set_route
+        Ops.set(@SETTINGS, "FW_STOP_KEEP_ROUTING_STATE", "yes")
         Ops.set(@SETTINGS, "FW_ROUTE", "yes")
       else
+        Ops.set(@SETTINGS, "FW_STOP_KEEP_ROUTING_STATE", "no")
         Ops.set(@SETTINGS, "FW_ROUTE", "no")
       end
 

--- a/library/network/test/susefirewall_test.rb
+++ b/library/network/test/susefirewall_test.rb
@@ -85,4 +85,24 @@ describe Yast::SuSEFirewall do
       expect(Yast::SuSEFirewall.GetModified()).to eq(true)
     end
   end
+
+  describe "#SetSupportRoute" do
+    context "when enabling routing" do
+      it "sets FW_ROUTE and FW_STOP_KEEP_ROUTING_STATE to 'yes'" do
+        subject.SetSupportRoute(true)
+        settings = subject.Export
+        expect(settings["FW_ROUTE"]).to eq("yes")
+        expect(settings["FW_STOP_KEEP_ROUTING_STATE"]).to eq("yes")
+      end
+    end
+
+    context "when disabling routing" do
+      it "sets FW_ROUTE and FW_STOP_KEEP_ROUTING_STATE to 'no'" do
+        subject.SetSupportRoute(false)
+        settings = subject.Export
+        expect(settings["FW_ROUTE"]).to eq("no")
+        expect(settings["FW_STOP_KEEP_ROUTING_STATE"]).to eq("no")
+      end
+    end
+  end
 end


### PR DESCRIPTION
I guess that a simpler solution should be just setting `FW_STOP_KEEP_ROUTING_STATE` always to `yes`. But this time I preferred to enable this option only when is needed. What do you think?