### PR TITLE
Starting the Installer (YaST2.First-Stage) directly from yast2

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun 25 15:50:46 CEST 2015 - locilka@suse.com
+
+- Starting the Installer (YaST2.First-Stage) directly from yast2
+  startup script if we are in inst-sys (FATE#317637, bnc#877447)
+- 3.1.135
+
+-------------------------------------------------------------------
 Mon Jun 22 14:52:04 UTC 2015 - cwh@suse.com
 
 - bnc#922765

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.134
+Version:        3.1.135
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -14,10 +14,11 @@
 # the configuration and administration menu.
 
 # FATE#317637, bsc#877447: In installation system, we call the installer
-# program directly
+# script directly and then exit
 if [ -f /.instsys.config ]; then
   echo "Starting Installer"
-  exit `/usr/lib/YaST2/startup/YaST2.First-Stage`
+  /usr/lib/YaST2/startup/YaST2.First-Stage
+  exit $?
 fi
 
 export PATH=/sbin:/usr/sbin:$PATH

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -13,6 +13,13 @@
 # wise ncurses. It starts then the module 'menu' which implements
 # the configuration and administration menu.
 
+# FATE#317637, bsc#877447: In installation system, we call the installer
+# program directly
+if [ -f /.instsys.config ]; then
+  echo "Starting Installer"
+  exit `/usr/lib/YaST2/startup/YaST2.First-Stage`
+fi
+
 export PATH=/sbin:/usr/sbin:$PATH
 
 # make sure the system ruby is used, bnc#845897


### PR DESCRIPTION
- FATE#317637, bnc#877447
- Explanation and discussion at http://lists.opensuse.org/yast-devel/2015-06/msg00024.html
- Tested IRL with dud=${path_to}/yast2.rpm - the package is downloaded, used, new message "Starting Installer" is shown and then Installation starts as usually