### PR TITLE
Fix create pre fs snapshot

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -134,10 +134,10 @@ module Yast2
     #
     # @see FsSnapshot.create
     # @see FsSnapshot.create_snapshot?
-    def self.create_pre(description)
+    def self.create_pre(description, cleanup: nil, important: false)
       return nil unless create_snapshot?(:around)
 
-      create(:pre, description)
+      create(:pre, description, cleanup: cleanup, important: important)
     end
 
     # Creates a new 'post' snapshot unless disabled by user

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -12,6 +12,8 @@ describe Yast2::FsSnapshot do
   FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | grep \"^root \" >/dev/null"
   LIST_SNAPSHOTS = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list"
 
+  let(:dummy_snapshot) { double("snapshot") }
+
   before do
     # reset configured cache
     described_class.instance_variable_set("@configured", nil)
@@ -112,7 +114,6 @@ describe Yast2::FsSnapshot do
 
       context "when snapshot creation is successful" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
 
         it "returns the created snapshot" do
           expect(described_class).to receive(:find).with(2)
@@ -124,7 +125,6 @@ describe Yast2::FsSnapshot do
 
       context "when a cleanup strategy is set" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
 
         it "creates a snapshot with that strategy" do
@@ -137,7 +137,6 @@ describe Yast2::FsSnapshot do
 
       context "when a snapshot is important" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_IMPORTANT }
 
         it "creates a snapshot marked as important" do
@@ -150,7 +149,6 @@ describe Yast2::FsSnapshot do
 
       context "when it's both important and a cleanup strategy is set" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
 
         it "creates a snapshot with that strategy that is marked as important" do
@@ -214,7 +212,6 @@ describe Yast2::FsSnapshot do
 
       context "when snapshot creation is successful" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
 
         it "returns the created snapshot" do
           expect(described_class).to receive(:find).with(2)
@@ -226,7 +223,6 @@ describe Yast2::FsSnapshot do
 
       context "when a cleanup strategy is set" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
 
         it "creates a pre snapshot with that strategy" do
@@ -239,7 +235,6 @@ describe Yast2::FsSnapshot do
 
       context "when a snapshot is important" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT }
 
         it "creates a pre snapshot marked as important" do
@@ -252,7 +247,6 @@ describe Yast2::FsSnapshot do
 
       context "when it's both important and a cleanup strategy is set" do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
-        let(:dummy_snapshot) { double("snapshot") }
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
 
         it "creates a pre snapshot with that strategy that is marked as important" do
@@ -299,7 +293,6 @@ describe Yast2::FsSnapshot do
       let(:create_snapshot) { true }
 
       let(:pre_snapshot) { double("snapshot", snapshot_type: :pre, number: 2) }
-      let(:dummy_snapshot) { double("snapshot") }
       let(:snapshots) { [pre_snapshot] }
       let(:output) { { "stdout" => "3", "exit" => 0 } }
 

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -194,10 +194,11 @@ describe Yast2::FsSnapshot do
     context "when snapper is configured" do
       let(:configured) { true }
       let(:create_snapshot) { true }
+      let(:snapshot_command) { CREATE_PRE_SNAPSHOT }
 
       before do
         allow(Yast::SCR).to receive(:Execute)
-          .with(path(".target.bash_output"), CREATE_PRE_SNAPSHOT)
+          .with(path(".target.bash_output"), snapshot_command)
           .and_return(output)
       end
 
@@ -219,6 +220,45 @@ describe Yast2::FsSnapshot do
           expect(described_class).to receive(:find).with(2)
             .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description")
+          expect(snapshot).to be(dummy_snapshot)
+        end
+      end
+
+      context "when a cleanup strategy is set" do
+        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:dummy_snapshot) { double("snapshot") }
+        let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
+
+        it "creates a pre snapshot with that strategy" do
+          expect(described_class).to receive(:find).with(2)
+            .and_return(dummy_snapshot)
+          snapshot = described_class.create_pre("some-description", cleanup: :number)
+          expect(snapshot).to be(dummy_snapshot)
+        end
+      end
+
+      context "when a snapshot is important" do
+        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:dummy_snapshot) { double("snapshot") }
+        let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT }
+
+        it "creates a pre snapshot marked as important" do
+          expect(described_class).to receive(:find).with(2)
+            .and_return(dummy_snapshot)
+          snapshot = described_class.create_pre("some-description", important: true)
+          expect(snapshot).to be(dummy_snapshot)
+        end
+      end
+
+      context "when it's both important and a cleanup strategy is set" do
+        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:dummy_snapshot) { double("snapshot") }
+        let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
+
+        it "creates a pre snapshot with that strategy that is marked as important" do
+          expect(described_class).to receive(:find).with(2)
+            .and_return(dummy_snapshot)
+          snapshot = described_class.create_pre("some-description", important: true, cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
       end


### PR DESCRIPTION
`Yast2::FsSnapshot.create_pre`, as used in https://github.com/yast/yast-update/blob/7aea14b5c5a8632f8bd86855df245ba16b90902f/src/modules/RootPart.rb#L1808, is supposed to receive `cleanup` and `important` parameters (instead of only the description). This commit should fix this issue.