### PR TITLE
Add missing documentation to ProposalClient

### DIFF
--- a/library/general/src/lib/installation/proposal_client.rb
+++ b/library/general/src/lib/installation/proposal_client.rb
@@ -49,6 +49,23 @@ module Installation
   #
   # * main program calls each sub-module to write the settings to the system
   #
+  # ## The `Write` method
+  #
+  # In addition to the methods defined (and documented) in
+  # {Installation::ProposalClient}, there's a method called `Write` which will
+  # write the proposed (and probably modified) settings to the system.
+  #
+  # It is up to the proposal dispatcher how it remembers the settings. The
+  # errors must be reported using the Report:: module to have the possibility
+  # to control the behaviour from the main program.
+  #
+  # This `Write` method is optional. The dispatcher module is required to allow
+  # this method to be called without returning an error value if it is not
+  # there.
+  #
+  # #### Return Values
+  #
+  # Returns true, if the settings were written successfully.
   class ProposalClient < Yast::Client
     include Yast::Logger
 
@@ -146,6 +163,24 @@ module Installation
     #     Help text for this module which appears in the standard dialog
     #     help (particular helps for modules sorted by presentation order).
     #
+    #   * **`"trigger"`** [Hash, nil] defines circumstances when the proposal
+    #     should be called again at the end. For intance, when partitioning or
+    #     software selection changes. Mandatory keys of the trigger are:
+    #       * **`"expect"`** [Hash] containing _string_ `class` and _string_
+    #         `method` that will be called and its result compared with `value`.
+    #       * **`"value"`** [Object] expected value, if evaluated code does not
+    #         match the `value`, proposal will be called again.
+    #
+    # @example Triggers definition
+    #     {
+    #       "trigger" => {
+    #         "expect" => {
+    #           "class"  => "Yast::Packages",
+    #           "method" => "CountSizeToBeDownloaded"
+    #         },
+    #         "value" => 88883333
+    #       }
+    #     }
     def make_proposal(_attrs)
       raise NotImplementedError, "Calling abstract method 'make_proposal'"
     end

--- a/library/general/src/lib/installation/proposal_client.rb
+++ b/library/general/src/lib/installation/proposal_client.rb
@@ -164,7 +164,7 @@ module Installation
     #     help (particular helps for modules sorted by presentation order).
     #
     #   * **`"trigger"`** [Hash, nil] defines circumstances when the proposal
-    #     should be called again at the end. For intance, when partitioning or
+    #     should be called again at the end. For instance, when partitioning or
     #     software selection changes. Mandatory keys of the trigger are:
     #       * **`"expect"`** [Hash] containing _string_ `class` and _string_
     #         `method` that will be called and its result compared with `value`.


### PR DESCRIPTION
* This documentation was living until now in yast-installation module.
* The missing documentation is taken from http://www.rubydoc.info/github/yast/yast-installation/file/doc/proposal_api.md