### PR TITLE
"yast2" script - handle also the reboot flag (bsc#942461)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 20 08:18:47 UTC 2015 - lslezak@suse.cz
+
+- "yast2" script - handle also the reboot flag the same way as
+  the installation script (bsc#942461)
+
+-------------------------------------------------------------------
 Mon Aug 10 07:37:45 UTC 2015 - mfilka@suse.com
 
 - bnc#916013

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -437,6 +437,12 @@ else
 	fi
     done
     snapshot_post $module
+
+    # check the reboot flag
+    if [ -f /var/lib/YaST2/reboot ];then
+        rm -f /var/lib/YaST2/reboot
+        /sbin/shutdown -r now
+    fi
 fi
 
 if [ "$UID" = 0 ]; then


### PR DESCRIPTION
...the same way as the installation script

### Notes ###

- The installation script handles the reboot this way: https://github.com/yast/yast-installation/blob/master/startup/YaST2.call#L368, in installed system the support is missing
- No version change (yet), it's needed for online migration, it will be released as part of the "online migration" update later (or sooner if some other urgent issue appears until that)