### PR TITLE
Firewall keeps imported data

### DIFF
--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -1453,10 +1453,10 @@ module Yast
     #
     # @param	map <string, any> with configuration
     def Import(import_settings)
-      import_settings = deep_copy(import_settings)
-      SetModified()
-
       @SETTINGS = deep_copy(import_settings)
+      @configuration_has_been_read = true
+
+      SetModified()
 
       nil
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug 26 19:25:07 UTC 2015 - mfilka@suse.com
+
+- bnc#897129
+  - AutoYaST will no longer ignore firewall settings if
+    keep_install_network is enabled
+- 3.1.108.8
+
+-------------------------------------------------------------------
 Wed Aug 26 15:27:51 CEST 2015 - schubi@suse.de
 
 - Checking cpuinfo_flags correctly while evaluating kernel packages

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.108.7
+Version:        3.1.108.8
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
bnc#897129

alternative approach to https://github.com/yast/yast-network/pull/275

notes, see above PR for details I refer to:
- the issue is that when SuSEFirewall#Import is followed by SuSEFirewall#Read than the later overwrites imported data
- keep_install_network should address only network setup (setup which can be done by yast2-network or <networking /> section in case of AY profile; just my POV)
- keep_install_network can be a bit misleading in above PR. Its semantic is that network configuration used in linuxrc should be transferred to target. In case of firewall it makes no sense - linuxrc do not allow to setup firewall and in the above PR it is used to force AY setup.
- in my POV, SuSEFirewall should take care of protecting imported data.