### PR TITLE
Properly format the package license (bsc#819311)

### DIFF
--- a/library/packages/src/modules/PackagesUI.rb
+++ b/library/packages/src/modules/PackagesUI.rb
@@ -31,6 +31,7 @@
 #
 # $Id$
 require "yast"
+require "cgi"
 
 module Yast
   class PackagesUIClass < Module
@@ -150,7 +151,7 @@ module Yast
           HSpacing(size_x),
           # dialog heading, %1 is package name
           Heading(Builtins.sformat(_("Confirm Package License: %1"), package)),
-          HBox(VSpacing(size_y), RichText(Id(:lic), license)),
+          HBox(VSpacing(size_y), RichText(Id(:lic), format_license(license))),
           VSpacing(1),
           HBox(
             PushButton(Id(:help), Label.HelpButton),
@@ -213,6 +214,23 @@ module Yast
       end
 
       ret
+    end
+
+    # format the license so it's displayed the same way as in the libyui-qt-pkg dialog,
+    # (see https://github.com/libyui/libyui-qt-pkg/blob/master/src/YQPkgObjList.cc#L1411
+    # https://github.com/libyui/libyui-qt-pkg/blob/master/src/YQPkgTextDialog.cc#L295 )
+    # @param [String] license the raw license text obtained from libzypp
+    # @return [String] formatted license for displaying in a RichText widget
+    def format_license(license)
+      # check the flag for a preformatted HTML
+      return license.dup if license.include?("<!-- DT:Rich -->")
+
+      ret = CGI.escapeHTML(license)
+
+      # two empty lines mean a new paragraph
+      ret.gsub!("\n\n", "</p><p>")
+
+      "<p>" + ret + "</p>"
     end
 
     # Run helper function, reads the display_support_status feature from the control file

--- a/library/packages/test/Makefile.am
+++ b/library/packages/test/Makefile.am
@@ -1,6 +1,7 @@
 TESTS = \
   dummy_callbacks_test.rb \
   package_callbacks_test.rb \
+  packages_ui_test.rb \
   product_test.rb \
   signature_check_callbacks_test.rb \
   slide_show_test.rb

--- a/library/packages/test/packages_ui_test.rb
+++ b/library/packages/test/packages_ui_test.rb
@@ -1,0 +1,29 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "PackagesUI"
+
+describe Yast::PackagesUI do
+  describe "#format_license" do
+    it "returns a preformatted HTML license unchanged" do
+      license = "\n<!-- DT:Rich -->\n<h3>License Confirmation</h3>"
+      expect(Yast::PackagesUI.format_license(license)).to eq(license)
+    end
+
+    it "converts a plain text into a rich text string" do
+      license = "License Confirmation"
+      expect(Yast::PackagesUI.format_license(license)).to match(/\A<p>.*<\/p>\z/)
+    end
+
+    it "escapes HTML tags in a plain text license" do
+      license = "License & Patent Confirmation"
+      expect(Yast::PackagesUI.format_license(license)).to include("&amp;")
+    end
+
+    it "converts two empty lines into paragraph separators" do
+      license = "License Confirmation\n\nTerms and Conditions"
+      expect(Yast::PackagesUI.format_license(license)).to match(/\A<p>.*<\/p><p>.*<\/p>\z/)
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 30 13:22:50 UTC 2015 - lslezak@suse.cz
+
+- Properly format the package license in the confirmation dialog
+  to make it better readable (bsc#819311)
+- 3.1.150
+
+-------------------------------------------------------------------
 Fri Sep 11 18:38:11 UTC 2015 - lslezak@suse.cz
 
 - Avoid too many snapshots created during the online migration

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.149
+Version:        3.1.150
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
...in the confirmation dialog to make it better readable.

- 3.1.150

The original layout:

![sles12-sp1-fluendo-license-proposal](https://cloud.githubusercontent.com/assets/907998/10194227/d74d8f20-6787-11e5-8702-d09111a550a5.png)

After applying this patch:

![sles12-sp1-fluendo-license-proposal-fixed](https://cloud.githubusercontent.com/assets/907998/10194256/fa7022e2-6787-11e5-8ed0-e7beeaf4ea4c.png)
