### PR TITLE
Fixed clipped labels in Arabic on some widgets

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Oct 14 15:28:37 UTC 2015 - mvidner@suse.com
+
+- Fixed clipped labels in Arabic on some widgets (bsc#880701).
+- 3.1.108.9
+
+-------------------------------------------------------------------
 Fri Sep 11 18:38:11 UTC 2015 - lslezak@suse.cz
 
 - Avoid too many snapshots created during the online migration

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.108.8
+Version:        3.1.108.9
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -397,6 +397,7 @@ elif [ "$SELECTED_GUI" = "qt" -o "$SELECTED_GUI" = "gtk" ]; then
 	set_qt_home_dir
 
         # Work around clipped Arabic text, bsc#880701
+        # Upstream bug: https://bugreports.qt.io/browse/QTBUG-41450
         # Locale check: first of the variables wins; man 7 locale
         case "${LC_ALL}${LC_MESSAGES}${LANG}" in
             ar*) export QT_HARFBUZZ=old ;;

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -395,8 +395,12 @@ elif [ "$SELECTED_GUI" = "qt" -o "$SELECTED_GUI" = "gtk" ]; then
 
     if [ "$SELECTED_GUI" = "qt" ]; then
 	set_qt_home_dir
-        # work around clipped Arabic text, bsc#880701
-        export QT_HARFBUZZ=old
+
+        # Work around clipped Arabic text, bsc#880701
+        # Locale check: first of the variables wins; man 7 locale
+        case "${LC_ALL}${LC_MESSAGES}${LANG}" in
+            ar*) export QT_HARFBUZZ=old ;;
+        esac
     fi
 
     # find which control center shell we want, if there is none we

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -395,6 +395,8 @@ elif [ "$SELECTED_GUI" = "qt" -o "$SELECTED_GUI" = "gtk" ]; then
 
     if [ "$SELECTED_GUI" = "qt" ]; then
 	set_qt_home_dir
+        # work around clipped Arabic text, bsc#880701
+        export QT_HARFBUZZ=old
     fi
 
     # find which control center shell we want, if there is none we


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=880701

The actual bug seems to be between Qt and Harfbuzz. Telling Qt to use an
older Harfbuzz solves the problem.
Using that for all languages risks breaking other languages with complex
scripts (Indic?) so let's limit this to Arabic.