### PR TITLE
Fixed clipped dialog label (bsc#948381)

### DIFF
--- a/library/wizard/src/modules/Progress.rb
+++ b/library/wizard/src/modules/Progress.rb
@@ -458,6 +458,7 @@ module Yast
 
       if !UI.WizardCommand(term(:SetDialogHeading, window_title))
         UI.ChangeWidget(Id(:title), :Value, window_title)
+        UI.RecalcLayout
       end
       Wizard.SetHelpText(help_text) if "" != help_text && nil != help_text
       Wizard.DisableBackButton

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  4 20:19:10 UTC 2015 - lslezak@suse.cz
+
+- Fixed clipped dialog label (bsc#948381)
+- 3.1.156
+
+-------------------------------------------------------------------
 Fri Oct 23 11:52:35 UTC 2015 - mvidner@suse.com
 
 - Fixed clipped labels in Arabic on some widgets (bsc#880701).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.155
+Version:        3.1.156
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- 3.1.156

### Debugged and tested with a small script

    require "yast"
    Yast.import "Wizard"
    Yast.import "Progress"

    Yast::Wizard.CreateDialog
    Yast::Progress.New("Initializing Boot Loader Configuration", " ", 1, [], [], "")
    Yast::UI.UserInput
    Yast::Wizard.CloseDialog

### Note

The tricky part is that you have to test it in a low-res screen (less than 800x600) to force usage of the simple Wizard implementation in the `Wizard` module. In the full Wizard UI the problem does not happen.

### The original output

![dialog_label_broken](https://cloud.githubusercontent.com/assets/907998/10952022/e0458c20-8340-11e5-8456-0b37afd199d2.png)


### With the fix applied

![dialog_label_fixed](https://cloud.githubusercontent.com/assets/907998/10952035/f5779f02-8340-11e5-91ff-e62750d9c46b.png)
