### PR TITLE
SrvStatusComponent -> ServiceStatus

### DIFF
--- a/library/cwm/src/modules/CWM.rb
+++ b/library/cwm/src/modules/CWM.rb
@@ -985,6 +985,21 @@ module Yast
       nil
     end
 
+    # Saves changes of all the widgets in the current dialog
+    #
+    # @param [Hash] event map event that triggered the saving
+    def save_current_widgets(event)
+      saveWidgets(@current_dialog_widgets, event)
+    end
+
+    # Validates all the widgets in the current dialog
+    #
+    # @param [Hash] event map event that caused validation
+    # @return [Boolean] true if everything is OK, false  if something is wrong
+    def validate_current_widgets(event)
+      validateWidgets(@current_dialog_widgets, event)
+    end
+
     publish function: :StringsOfTerm, type: "list <string> (term)"
     publish function: :ValidateBasicType, type: "boolean (any, string)"
     publish function: :ValidateValueType, type: "boolean (string, any, string)"

--- a/library/general/src/Makefile.am
+++ b/library/general/src/Makefile.am
@@ -89,7 +89,7 @@ ylib2dir = "${yast2dir}/lib/ui"
 ylib2_DATA = \
   lib/ui/dialog.rb \
   lib/ui/event_dispatcher.rb \
-  lib/ui/srv_status_component.rb
+  lib/ui/service_status.rb
 
 EXTRA_DIST = $(module_DATA) $(client_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ydata_DATA) $(fillup_DATA) $(ylib_DATA) $(ylib2_DATA)
 

--- a/library/general/src/lib/ui/service_status.rb
+++ b/library/general/src/lib/ui/service_status.rb
@@ -17,46 +17,37 @@
 #  you may find current contact information at www.suse.com
 
 require "yast"
-Yast.import "Service"
 Yast.import "UI"
 
 module UI
-  # Component encapsulating the widgets for managing the status of services (both
-  # currently and on system boot) and the behavior associated to those widgets
+  # Widgets for managing the status of services (both currently and on system
+  # boot) and the behavior associated to those widgets
   #
-  # TODO: The API is experimental and subject to change. This component is only
-  # used by yast2-dns-server and should not be used by any other module until
-  # an upcoming refactoring, planned for SLE12-SP2. To see some of the planned
-  # improvements, check https://github.com/yast/yast-yast2/pull/401
-  #
-  # As long as #handle_input is invoked in the event loop, the component will
-  # handle interactive starting and stopping of the service on user demand. In
-  # addition #reload can be used after saving the settings.
-  #
-  # To manage the status on boot, the component can be queried for the user
-  # selection using #enabled?. In addition enabled_callback (in constructor)
-  # can be used to observe the status of the corresponding field in the UI.
-  class SrvStatusComponent
+  # As long as #handle_input is invoked in the event loop, the widget will
+  # handle interactive starting and stopping of the service on user demand.
+  class ServiceStatus
     include Yast::UIShortcuts
     include Yast::I18n
     include Yast::Logger
 
-    # @param service_name [String] name of the service as expected by
-    #   Yast::Service
-    # @param reload [Boolean] initial value for the "reload" checkbox.
-    #   Keep in mind it will always be displayed as unchecked if the service is
-    #   not running, despite the real value.
-    # @param enabled_callback [Proc] callback executed when the "enabled on
-    #   boot" checkbox is changed. The only parameter of the callback is the new
-    #   state of the checkbox (boolean).
-    def initialize(service_name, reload: true, enabled_callback: nil)
-      @service_name = service_name
+    # @param service [Object] An object providing the following methods:
+    #   #name, #start, #stop, #enabled?, #running?
+    #   For systemd compliant services, just do
+    #   Yast::SystemdService.find("name_of_the_service")
+    # @param reload [Boolean] Initial value for the "reload" checkbox.
+    #   Keep in mind it will always be displayed as unchecked if the service
+    #   is not running, despite the real value.
+    # @param reload_label [Symbol] Type of label for the "reload" checkbox.
+    #   :restart means that the service will be restarted, not just reloaded.
+    def initialize(service, reload: true, reload_label: :reload)
+      @service = service
       @reload = reload
-      @enabled_callback = enabled_callback
 
-      @enabled = service_enabled?
-      @id_prefix = "_srv_status_#{@service_name}"
+      @enabled = @service.enabled?
+      @id_prefix = "_srv_status_#{@service.name}"
       textdomain "base"
+      @reload_label = (reload_label == :restart) ?
+        _("Restart After Saving Settings") : _("Reload After Saving Settings")
     end
 
     # @return [YaST::Term]
@@ -74,37 +65,37 @@ module UI
 
     # Handles the input triggered by the widgets, this method must be called in
     # the event loop of the dialog using the component.
+    #
+    # @return [Symbol] Label for the managed event
     def handle_input(input)
       case input
       when "#{id_prefix}_stop"
-        stop_service
-        refresh_widget
+        @service.stop
+        refresh
+        :stopped
       when "#{id_prefix}_start"
-        start_service
-        refresh_widget
+        @service.start
+        refresh
+        :started
       when "#{id_prefix}_reload"
         @reload = Yast::UI.QueryWidget(Id(input), :Value)
+        :reload_changed
       when "#{id_prefix}_enabled"
         @enabled = Yast::UI.QueryWidget(Id(input), :Value)
-        @enabled_callback.call(@enabled) if @enabled_callback
+        :enabled_changed
       else
-        log.info "Input not handled by SrvStatusComponent: #{input}"
+        log.info "Input not handled by ServiceStatus: #{input}"
+        :ignored
       end
     end
 
     # Updates the widget to reflect the current status of the service and the
     # settings
-    def refresh_widget
-      Yast::UI.ChangeWidget(Id("#{id_prefix}_reload"), :Enabled, service_running?)
-      Yast::UI.ChangeWidget(Id("#{id_prefix}_reload"), :Value, service_running? && @reload)
+    def refresh
+      Yast::UI.ChangeWidget(Id("#{id_prefix}_reload"), :Enabled, @service.running?)
+      Yast::UI.ChangeWidget(Id("#{id_prefix}_reload"), :Value, @service.running? && @reload)
       Yast::UI.ChangeWidget(Id("#{id_prefix}_enabled"), :Value, @enabled)
       Yast::UI.ReplaceWidget(Id("#{id_prefix}_status"), status_widget)
-    end
-
-    # Reloads the service only if the user requested so. It should be called
-    # after saving the settings.
-    def reload
-      reload_service if service_running? && @reload
     end
 
     # rubocop:disable Style/TrivialAccessors
@@ -116,6 +107,13 @@ module UI
       @enabled
     end
 
+    # Checks if the user requested the service to be reloaded when saving
+    #
+    # @return [Boolean]
+    def reload?
+      @reload
+    end
+
     # rubocop:enable Style/TrivialAccessors
 
     # Content for the help
@@ -125,63 +123,22 @@ module UI
         "Displays the current status of the service. The status will remain "\
         "the same after saving the settings, independently of the value of "\
         "'start service during boot'.</p>\n"\
-        "<p><b><big>Reload After Saving Settings</big></b><br>\n"\
+        "<p><b><big>%{reload_label}</big></b><br>\n"\
         "Only applicable if the service is currently running. "\
         "Ensures the running service reloads the new configuration after "\
-        "saving it (via 'ok' or 'save' buttons).</p>\n"\
+        "saving it (either finishing the dialog or pressing the apply "\
+        "button).</p>\n"\
         "<p><b><big>Start During System Boot</big></b><br>\n"\
         "Check this field to enable the service at system boot. "\
         "Un-check it to disable the service. "\
         "This does not affect the current status of the service in the already "\
         "running system.</p>\n"
-      )
+      ) % {reload_label: @reload_label}
     end
 
   protected
 
     attr_reader :id_prefix
-
-    # Checks if the service is currently running
-    #
-    # Must be redefined for services not following standard procedures
-    #
-    # @return [Boolean]
-    def service_running?
-      Yast::Service.active?(@service_name)
-    end
-
-    # Checks if the service is currently enabled on boot
-    #
-    # Must be redefined for services not following standard procedures
-    #
-    # @return [Boolean]
-    def service_enabled?
-      Yast::Service.enabled?(@service_name)
-    end
-
-    # Starts the service inmediatly
-    #
-    # Must be redefined for services not following standard procedures
-    def start_service
-      log.info "Default implementation of SrvStatusComponent#start_service for #{@service_name}"
-      Yast::Service.Start(@service_name)
-    end
-
-    # Stops the service inmediatly
-    #
-    # Must be redefined for services not following standard procedures
-    def stop_service
-      log.info "Default implementation of SrvStatusComponent#stop_service for #{@service_name}"
-      Yast::Service.Stop(@service_name)
-    end
-
-    # Reloads the configuration of a running service
-    #
-    # Must be redefined for services not following standard procedures
-    def reload_service
-      log.info "Default implementation of SrvStatusComponent#reload_service for #{@service_name}"
-      Yast::Service.Reload(@service_name)
-    end
 
     # Widget displaying the status and associated buttons
     def status_widget
@@ -209,19 +166,19 @@ module UI
     # Widget to configure reloading of the running service
     def reload_widget
       opts = [:notify]
-      opts << :disabled unless service_running?
+      opts << :disabled unless @service.running?
       Left(
         CheckBox(
           Id("#{id_prefix}_reload"),
           Opt(*opts),
-          _("Reload After Saving Settings"),
-          service_running? && @reload
+          @reload_label,
+          @service.running? && @reload
         )
       )
     end
 
     def label_and_action_widgets
-      if service_running?
+      if @service.running?
         [
           # TRANSLATORS: status of a service
           Label(_("running")),

--- a/library/general/src/lib/ui/service_status.rb
+++ b/library/general/src/lib/ui/service_status.rb
@@ -46,8 +46,11 @@ module UI
       @enabled = @service.enabled?
       @id_prefix = "_srv_status_#{@service.name}"
       textdomain "base"
-      @reload_label = (reload_label == :restart) ?
-        _("Restart After Saving Settings") : _("Reload After Saving Settings")
+      if reload_label == :restart
+        @reload_label = _("Restart After Saving Settings")
+      else
+        @reload_label = _("Reload After Saving Settings")
+      end
     end
 
     # @return [YaST::Term]
@@ -133,7 +136,7 @@ module UI
         "Un-check it to disable the service. "\
         "This does not affect the current status of the service in the already "\
         "running system.</p>\n"
-      ) % {reload_label: @reload_label}
+      ) % { reload_label: @reload_label }
     end
 
   protected

--- a/library/general/test/Makefile.am
+++ b/library/general/test/Makefile.am
@@ -10,7 +10,7 @@ TESTS = \
   os_release_test.rb \
   popup_test.rb \
   proposal_client_test.rb \
-  srv_status_component_test.rb \
+  service_status_test.rb \
   agents_test/proc_meminfo_agent_test.rb
 
 TEST_EXTENSIONS = .rb

--- a/library/general/test/service_status_test.rb
+++ b/library/general/test/service_status_test.rb
@@ -1,7 +1,7 @@
 #! /usr/bin/env rspec
 
 require_relative "test_helper"
-require "ui/srv_status_component"
+require "ui/service_status"
 
 # Some helpers to test the UI
 
@@ -34,24 +34,42 @@ def id_for(term)
   id.params.first
 end
 
-# Class using SrvStatusComponent
+class DummyService
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def enabled?
+    @name == "active"
+  end
+
+  def running?
+    @name == "active"
+  end
+
+  def start; end
+  def stop; end
+end
+
+# Class using ServiceStatus
 class DummyDialog
   include Yast::UIShortcuts
 
   attr_reader :enabled1, :enabled2, :srv1_component, :srv2_component
 
-  def initialize
-    @srv1_component = ::UI::SrvStatusComponent.new(
-      "service1",
-      enabled_callback: ->(e) { @enabled1 = e }
-    )
-    @srv2_component = ::UI::SrvStatusComponent.new("service2")
+  def initialize(service1, service2)
+    @srv1_component = ::UI::ServiceStatus.new(service1)
+    @srv2_component = ::UI::ServiceStatus.new(service2)
     @enabled1 = @srv1_component.enabled?
     @enabled2 = @srv2_component.enabled?
   end
 
   def handle_input(input)
-    @srv1_component.handle_input(input)
+    if @srv1_component.handle_input(input) == :enabled_changed
+      @enabled1 = @srv1_component.enabled?
+    end
     @srv2_component.handle_input(input)
   end
 
@@ -69,25 +87,20 @@ module Yast
   extend Yast::I18n
   Yast.textdomain "base"
 
-  import "Service"
   import "UI"
 
-  describe ::UI::SrvStatusComponent do
-    before do
-      allow(Yast::Service).to receive(:enabled?).with("service1").and_return true
-      allow(Yast::Service).to receive(:enabled?).with("service2").and_return false
-      allow(Yast::Service).to receive(:active?).with("service1").and_return true
-      allow(Yast::Service).to receive(:active?).with("service2").and_return false
-    end
+  describe ::UI::ServiceStatus do
+    let(:active) { DummyService.new("active") }
+    let(:inactive) { DummyService.new("inactive") }
 
-    let(:dialog) { DummyDialog.new }
+    let(:dialog) { DummyDialog.new(active, inactive) }
     let(:widgets) { dialog.content }
-    let(:stop_service1) { widget_by_id_and_text(widgets, "service1", "Stop now") }
-    let(:start_service2) { widget_by_id_and_text(widgets, "service2", "Start now") }
-    let(:reload_service1) { widget_by_id_and_text(widgets, "service1", "Reload After Saving Settings") }
-    let(:reload_service2) { widget_by_id_and_text(widgets, "service2", "Reload After Saving Settings") }
-    let(:enabled_service1) { widget_by_id_and_text(widgets, "service1", "Start During System Boot") }
-    let(:enabled_service2) { widget_by_id_and_text(widgets, "service2", "Start During System Boot") }
+    let(:stop_active) { widget_by_id_and_text(widgets, "active", "Stop now") }
+    let(:start_inactive) { widget_by_id_and_text(widgets, "inactive", "Start now") }
+    let(:reload_active) { widget_by_id_and_text(widgets, "active", "Reload After Saving Settings") }
+    let(:reload_inactive) { widget_by_id_and_text(widgets, "inactive", "Reload After Saving Settings") }
+    let(:enabled_active) { widget_by_id_and_text(widgets, "active", "Start During System Boot") }
+    let(:enabled_inactive) { widget_by_id_and_text(widgets, "inactive", "Start During System Boot") }
 
     describe "#initialize" do
       it "reads the initial enabled state from the system" do
@@ -98,38 +111,38 @@ module Yast
 
     describe "#widget" do
       it "includes all the UI elements" do
-        expect(stop_service1).not_to be_nil
-        expect(start_service2).not_to be_nil
-        expect(reload_service1).not_to be_nil
-        expect(reload_service2).not_to be_nil
-        expect(enabled_service1).not_to be_nil
-        expect(enabled_service2).not_to be_nil
+        expect(stop_active).not_to be_nil
+        expect(start_inactive).not_to be_nil
+        expect(reload_active).not_to be_nil
+        expect(reload_inactive).not_to be_nil
+        expect(enabled_active).not_to be_nil
+        expect(enabled_inactive).not_to be_nil
       end
 
       it "disables and unchecks the reload button for stopped services" do
-        expect(options_for(reload_service2).any? { |p| p == :disabled })
-        expect(reload_service2.params.last).to eq false
+        expect(options_for(reload_inactive).any? { |p| p == :disabled })
+        expect(reload_inactive.params.last).to eq false
       end
 
       it "enables the reload button for stopped services" do
-        expect(options_for(reload_service1).none? { |p| p == :disabled })
+        expect(options_for(reload_active).none? { |p| p == :disabled })
       end
     end
 
     describe "#handle_input" do
       it "stops the service on user request" do
-        expect(Yast::Service).to receive(:Stop).with("service1")
-        dialog.handle_input(id_for(stop_service1))
+        expect(active).to receive(:stop)
+        dialog.handle_input(id_for(stop_active))
       end
 
       it "starts the service on user request" do
-        expect(Yast::Service).to receive(:Start).with("service2")
-        dialog.handle_input(id_for(start_service2))
+        expect(inactive).to receive(:start)
+        dialog.handle_input(id_for(start_inactive))
       end
 
       it "triggers 'enabled_callback' if available" do
         allow(Yast::UI).to receive(:QueryWidget).and_return "new_value"
-        dialog.handle_input(id_for(enabled_service1))
+        dialog.handle_input(id_for(enabled_active))
 
         expect(dialog.enabled1).to eq "new_value"
       end
@@ -138,7 +151,7 @@ module Yast
         expect(dialog.srv1_component.enabled?).to eq true
 
         allow(Yast::UI).to receive(:QueryWidget).and_return false
-        dialog.handle_input(id_for(enabled_service1))
+        dialog.handle_input(id_for(enabled_active))
 
         expect(dialog.srv1_component.enabled?).to eq false
       end

--- a/library/general/test/service_status_test.rb
+++ b/library/general/test/service_status_test.rb
@@ -50,6 +50,7 @@ class DummyService
   end
 
   def start; end
+
   def stop; end
 end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Nov 26 08:47:31 UTC 2015 - ancor@suse.com
+
+- New methods CWM.save_current_widgets and
+  CWM.validate_current_widgets
+- Replaced UI::SrvStatusComponent with UI::ServiceStatus
+- 3.1.160
+
+-------------------------------------------------------------------
 Tue Nov 24 14:05:14 CET 2015 - snwint@suse.de
 
 - rewrite save_y2logs (and log linuxrc.log and wickedd.log)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.159
+Version:        3.1.160
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
Replace `UI::SrvStatusComponent` with `UI:ServiceStatus`. The new class has a much better API, as explained below.

Instead of the service_xx methods, it knows expect an object that complains to the SystemdService API. For non-standard services the user is expected to implement their own class.

Instead of using callbacks, handle_input now returns a meaningful symbol.

See https://github.com/yast/yast-dns-server/pull/52 for code changes in yast-dns-server

This PR also introduces `CWM.save_current_widgets` and `CWM.validate_current_widgets`, needed to implement an "apply" button.