### PR TITLE
SuSEFirewall module reads system configuration during autoinstallation

### DIFF
--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -2510,14 +2510,7 @@ module Yast
 
       Progress.NextStage if have_progress
 
-      # get default configuration for autoinstallation
-      # if (Mode::installation() || Mode::autoinst()) {
-      if Mode.autoinst
-        ReadDefaultConfiguration()
-        # read current configuration for another cases
-      else
-        ReadCurrentConfiguration()
-      end
+      ReadCurrentConfiguration()
 
       Progress.NextStage if have_progress
 

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -1462,6 +1462,12 @@ module Yast
       nil
     end
 
+    # Function to import and merge SuSEFirewall configuration
+    def read_and_import(settings)
+      Read()
+      Import(@SETTINGS.merge(settings))
+    end
+
     # Function returns if the interface is in zone.
     #
     # @param [String] interface
@@ -3825,6 +3831,7 @@ module Yast
     publish function: :IsStarted, type: "boolean ()"
     publish function: :Export, type: "map <string, any> ()"
     publish function: :Import, type: "void (map <string, any>)"
+    publish function: :read_and_import, type: "void (map <string, any>)"
     publish function: :IsInterfaceInZone, type: "boolean (string, string)"
     publish function: :GetZoneOfInterface, type: "string (string)"
     publish function: :GetZonesOfInterfaces, type: "list <string> (list <string>)"

--- a/library/network/test/susefirewall_test.rb
+++ b/library/network/test/susefirewall_test.rb
@@ -107,12 +107,9 @@ describe Yast::SuSEFirewall do
   end
 
   describe "#Read" do
-    before { subject.main }
-
-    let(:package_installed) { true }
-    let(:config_exists) { true }
-
     before do
+      subject.main # Resets module configuration
+
       allow(Yast::FileUtils).to receive(:Exists)
         .with(Yast::SuSEFirewallClass::CONFIG_FILE)
         .and_return(package_installed)
@@ -120,11 +117,23 @@ describe Yast::SuSEFirewall do
         .and_return(config_exists)
     end
 
+    let(:package_installed) { true }
+    let(:config_exists) { true }
+
+    context "when package and config file are available" do
+      it "reads current configuration" do
+        expect(subject).to receive(:ConvertToServicesDefinedByPackages)
+        expect(Yast::NetworkInterfaces).to receive(:Read)
+        expect(subject).to receive(:ReadCurrentConfiguration)
+        expect(subject.Read).to eq(true)
+      end
+    end
+
     context "when configuration does not exist" do
       let(:config_exists) { false }
 
       it "empties firewall config and returns false" do
-        expect(subject.Read).to eql(false)
+        expect(subject.Read).to eq(false)
         expect(subject.GetStartService).to eq(false)
         expect(subject.GetEnableService).to eq(false)
       end
@@ -134,52 +143,11 @@ describe Yast::SuSEFirewall do
       let(:package_installed) { false }
 
       it "empties firewall config and returns false" do
-        expect(subject.Read).to eql(false)
+        expect(subject.Read).to eq(false)
         expect(subject.GetStartService).to eq(false)
         expect(subject.GetEnableService).to eq(false)
       end
     end
 
-    context "when packages and config file are available" do
-      before do
-        allow(subject).to receive(:ConvertToServicesDefinedByPackages)
-        allow(Yast::NetworkInterfaces).to receive(:Read)
-      end
-
-      around do |example|
-        old_mode = Yast::Mode.mode
-        Yast::Mode.SetMode(mode)
-        example.run
-        Yast::Mode.SetMode(old_mode)
-      end
-
-      context "during autoinstallation mode" do
-        let(:mode) { "autoinstallation" }
-
-        it "reads the default configuration" do
-          expect(subject).to receive(:ReadDefaultConfiguration)
-          expect(subject.Read).to eql(true)
-        end
-      end
-
-      context "during normal mode" do
-        let(:mode) { "normal" }
-
-        it "reads the default configuration" do
-          expect(subject).to receive(:ReadCurrentConfiguration)
-          expect(subject.Read).to eql(true)
-        end
-      end
-
-      context "during installation mode" do
-        let(:mode) { "installation" }
-
-        it "reads the default configuration" do
-          expect(subject).to receive(:ReadCurrentConfiguration)
-          expect(subject.Read).to eql(true)
-        end
-      end
-
-    end
   end
 end

--- a/library/network/test/susefirewall_test.rb
+++ b/library/network/test/susefirewall_test.rb
@@ -150,4 +150,58 @@ describe Yast::SuSEFirewall do
     end
 
   end
+
+  describe "#Import" do
+    before { subject.main }
+
+    it "imports given settings" do
+      subject.Import("start_firewall" => true, "enable_firewall" => false)
+      expect(subject.GetStartService).to eq(true)
+      expect(subject.GetEnableService).to eq(false)
+    end
+
+    context "given a configuration" do
+      before do
+        subject.Import("start_firewall" => true, "enable_firewall" => false)
+      end
+
+      context "when a setting is not given" do
+        it "removes that setting from the configuration" do
+          subject.Import("enable_firewall" => true)
+          expect(subject.GetStartService).to eq(false)
+          expect(subject.GetEnableService).to eq(true)
+        end
+      end
+
+      context "when nil is passed" do
+        it "removes all settings" do
+          subject.Import(nil)
+          expect(subject.GetStartService).to eq(false)
+          expect(subject.GetEnableService).to eq(false)
+        end
+      end
+
+      context "when an empty hash is passed" do
+        it "removes all settings" do
+          subject.Import({})
+          expect(subject.GetStartService).to eq(false)
+          expect(subject.GetEnableService).to eq(false)
+        end
+      end
+    end
+  end
+
+  describe "#read_and_import" do
+    before do
+      subject.main
+      subject.Import("start_firewall" => true)
+    end
+
+    it "reads and merge given values into the current settings" do
+      expect(subject).to receive(:Read)
+      subject.read_and_import("enable_firewall" => true)
+      expect(subject.GetStartService).to eq(true)
+      expect(subject.GetEnableService).to eq(true)
+    end
+  end
 end

--- a/library/network/test/susefirewall_test.rb
+++ b/library/network/test/susefirewall_test.rb
@@ -148,7 +148,6 @@ describe Yast::SuSEFirewall do
         expect(subject.GetEnableService).to eq(false)
       end
     end
-
   end
 
   describe "#Import" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Feb  4 12:35:38 UTC 2016 - kanderssen@suse.com
+
+- SuSEFirewall module reads system configuration during
+  autoinstallation. It behaves in the same way than
+  regular installation or normal operation (bsc#963585)
+- Add a read_and_import method to SuSEFirewall module.
+- 3.1.108.12
+
+-------------------------------------------------------------------
 Tue Nov 17 12:11:54 UTC 2015 - igonzalezsosa@suse.com
 
 - Add a default value for firewall setting FW_BOOT_INIT_FULL

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.108.11
+Version:        3.1.108.12
 Release:        0
 URL:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
* Changes SuSEFirewall to read system's configuration during installation, instead of using `ReadDefaultConfiguration()`. It's should fix [bsc#963585](https://bugzilla.suse.com/show_bug.cgi?id=963585).
* Add a new method `read_and_import` which read the firewall configuration and merges a configuration hash (usually from an AutoYaST profile). In contrast to the regular `Import`, it performs a merge.