### PR TITLE
Moved cfg_mail.scr from yast2-mail (FATE#319711)

### DIFF
--- a/library/mail/src/scrconf/cfg_mail.scr
+++ b/library/mail/src/scrconf/cfg_mail.scr
@@ -1,0 +1,30 @@
+/**
+ * File:
+ *   cfg_mail.scr
+ * Summary:
+ *   SCR Agent for reading/writing /etc/sysconfig/mail
+ *   using the ini-agent
+ * Access:
+ *   read/write
+ * Authors:
+ *   Martin Vidner <mvidner@suse.cz>
+ * See:
+ *   yast2-agent-ini/ini.html
+ *   libscr
+ * Example:
+ *   Read(.sysconfig.mail.FROM_HEADER)
+ *   ("mycompany.com")
+ **
+ *   Write(.sysconfig.mail.FROM_HEADER, "MyCompany.com")
+ *   (true)
+ *
+ * $Id$
+ *
+ * Read/Sets the values defined in <tt>/etc/sysconfig/mail</tt>
+ * in an easy manner.
+ */
+.sysconfig.mail
+
+`ag_ini(
+  `SysConfigFile("/etc/sysconfig/mail")
+)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 16 17:10:37 UTC 2016 - knut.anderssen@suse.com
+
+- Added cfg_mail.scr from yast-mail to avoid circular dependencies
+  with yast2-security, yast2-users and yast2-mail (FATE#319711)
+- 3.1.179
+
+-------------------------------------------------------------------
 Thu Mar 10 10:15:13 UTC 2016 - dvaleev@suse.com
 
 - Introduce PowerNV platform (boo#970582)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.178
+Version:        3.1.179
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 
@@ -110,6 +110,9 @@ Conflicts:      yast2-sshd < 2.16.1
 
 # moved ag_content agent 
 Conflicts:      yast2-instserver <= 2.16.3
+
+# moved cfg_mail.scr
+Conflicts:      yast2-mail < 3.1.7
 
 # InstError
 Conflicts:      yast2-installation < 2.18.5


### PR DESCRIPTION
- Added cfg_mail.scr due to circular dependencies as showed [here](https://build.opensuse.org/request/show/372909)