### PR TITLE
Add proc_modules.scr from yast-installation (bsc#972310)

### DIFF
--- a/library/general/src/Makefile.am
+++ b/library/general/src/Makefile.am
@@ -63,6 +63,7 @@ scrconf_DATA = \
   scrconf/anyxml.scr \
   scrconf/yast2_desktop.scr \
   scrconf/proc_mounts.scr \
+  scrconf/proc_modules.scr \
   scrconf/cfg_ypserv.scr \
   scrconf/cfg_security.scr
 

--- a/library/general/src/scrconf/proc_modules.scr
+++ b/library/general/src/scrconf/proc_modules.scr
@@ -1,0 +1,47 @@
+/**
+ * File:
+ *   proc_modules.scr
+ * Summary:
+ *   SCR Agent for reading /proc/modules
+ * Access:
+ *   read-only
+ * Authors:
+ *   Unknown <yast2-hacker@suse.de>
+ * See:
+ *   anyagent
+ *   libscr
+ * Example:
+ *   Read(.proc.modules)
+ *   ($["aic7xxx":$["size":129600, "used":"3"], 
+ *      "autofs4":$["size":9344, "used":"4"], 
+ *      "de4x5":$["size":40320, "used":"1"], 
+ *      ...
+ *   ])
+ * 
+ * $Id$
+ *
+ * Returns a <b>map</b>i. Keys are the module names, values are maps. 
+ * Keys of those maps are: "size", "used"
+ */
+.proc.modules
+
+`ag_anyagent(
+  `Description (
+  (`File("/proc/modules")),	// real file name
+  "#\n",			// Comment
+  true,				// read-only
+  (`Tuple (
+      `Name(`String("^ \t")),
+      `Whitespace (),
+      `Value (
+	`Tuple (
+	  `size (`Number()),
+	  `Whitespace(),
+	  `used (`String("^ \n")),
+	  `Optional (`String ("^\n"))
+	)
+      ),
+      `Continue ("\n")
+    ) )
+  )
+)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 23 16:26:26 UTC 2016 - cwh@suse.com
+
+- Added proc_modules.scr from yast-installation to avoid that
+  yast-sound depends on yast-installation (bsc#972310)
+- 3.1.180
+
+-------------------------------------------------------------------
 Wed Mar 16 17:10:37 UTC 2016 - knut.anderssen@suse.com
 
 - Added cfg_mail.scr from yast-mail to avoid circular dependencies

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.179
+Version:        3.1.180
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
This is to avoid yast2-sound to depend on yast2-installation.