### PR TITLE
Add FirewallD support to SuSEFirewall2 backend

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,11 @@ Style/AccessorMethodName:
 Style/ClassAndModuleCamelCase:
   Enabled: false
 
+Style/ClassVars:
+  # We really need the class variables in SuSEFirewall module
+  Exclude:
+    - "library/network/src/modules/SuSEFirewall.rb"
+
 # ensure new code is properly documented
 Style/Documentation:
   Include:
@@ -47,6 +52,12 @@ Style/FileName:
 Style/MethodName:
   Include:
     - "library/*/src/lib/**/*.rb"
+
+Style/Next:
+  # skip this check for SuSEFirewall since it forces us to refactor
+  # the code in a sub-optimal way.
+  Exclude:
+    - "library/network/src/modules/SuSEFirewall.rb"
 
 # keep it as it is part of API for old code
 Style/PredicateName:

--- a/library/network/doc/autodocs/Makefile.am
+++ b/library/network/doc/autodocs/Makefile.am
@@ -1,4 +1,9 @@
 # Makefile.am for YCP module .../doc/autodocs
 
+# Include the FirewallD API in the autodocs
+AUTODOCS_RB = $(wildcard $(srcdir)/../../src/modules/*.rb \
+			  $(srcdir)/../../src/include/*/*.rb \
+			  $(srcdir)/../../src/lib/*/*.rb)
+
 AUTODOCS_SUBDIR=network
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/network/src/Makefile.am
+++ b/library/network/src/Makefile.am
@@ -24,6 +24,10 @@ scrconf_DATA = \
 agent_SCRIPTS = \
   servers_non_y2/ag_showexports
 
-EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS)
+ylibdir = @ylibdir@/network
+ylib_DATA = \
+  lib/network/firewalld.rb
+
+EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/library/network/src/lib/network/firewalld.rb
+++ b/library/network/src/lib/network/firewalld.rb
@@ -1,0 +1,353 @@
+# encoding: utf-8
+#
+# ***************************************************************************
+#
+# Copyright (c) 2016 SUSE LLC.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 or 3 of the GNU General
+# Public License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+# ***************************************************************************
+#
+# File: lib/network/firewalld.rb
+# Summary:  FirewallD configuration API
+# Authors:  Karol Mroz <kmroz@suse.de>, Markos Chandras <mchandras@suse.de>
+#
+
+require "yast"
+
+module Firewalld
+  # exception when firewall-cmd fails
+  class FirewallCMDError < StandardError
+  end
+
+  # Execute firewalld commands using firewall-cmd
+  class FWCmd
+    include Yast::Logger
+
+    BASH_SCR_PATH = Yast::Path.new(".target.bash_output")
+    # Base firewall-cmd command
+    COMMAND = "LANG=C firewall-cmd"
+
+    attr_reader :option_str
+
+    def initialize(option_str)
+      @option_str = option_str
+    end
+
+    def command
+      "#{COMMAND} #{option_str}".strip.squeeze(" ")
+    end
+
+    # @param output [Boolean] Whether command output is desirable or not
+    # @return [String] Firewalld command output if output = true
+    # @return [Boolean] Firewalld command exit code if output = false
+    def fwd_output(output = true)
+      cmd_result = Yast::SCR.Execute(BASH_SCR_PATH, command)
+
+      # See firewall-cmd manpage for exit codes. Not all of them justify an
+      # exception. 0 and 1 can be used as true and false respectively.
+      case cmd_result["exit"]
+      when 0, 1
+        if output
+          cmd_result["stdout"]
+        else
+          log.debug "#{command} returned: #{cmd_result["stdout"]}"
+          cmd_result["exit"].zero? ? true : false
+        end
+      else
+        raise FirewallCMDError, "Calling firewall-cmd (cmd: #{command}) failed: #{cmd_result["stderr"]}"
+      end
+    end
+  end
+
+  # The firewalld API. We only use the command line interface.
+  class FirewalldAPI
+    def self.create(type = :bash)
+      case type
+      when :bash
+        FirewalldBashAPI.new
+      when :dbus
+        nil
+      else
+        raise "Unsupported Firewalld API type: #{type}"
+      end
+    end
+  end
+
+  # The firewalld bash API
+  class FirewalldBashAPI
+    include Yast::Logger
+
+  private
+
+    # Simple wrapper for commands. Returns true on success
+    def fwd_quiet_result(*args)
+      fwcmd = FWCmd.new(args.join(""))
+      fwcmd.fwd_output(false)
+    end
+
+    # Simple wrapper for commands. Returns command output
+    def fwd_result(*args)
+      fwcmd = FWCmd.new(args.join(""))
+      fwcmd.fwd_output(true)
+    end
+
+  public
+
+    ### State ###
+
+    # @return [Boolean] The firewalld service state (exit code)
+    def running?
+      fwd_quiet_result("--state")
+    end
+
+    # @return [Boolean] The firewalld reload result (exit code)
+    def reload
+      fwd_quiet_result("--reload")
+    end
+
+    # @return [Boolean] The firewalld complete-reload result (exit code)
+    def complete_reload
+      fwd_quiet_result("--complete-reload")
+    end
+
+    # @return [Boolean] The firewalld runtime-to-permanent result (exit code)
+    def make_permanent
+      fwd_quiet_result("--runtime-to-permanent")
+    end
+
+    ### Zones ####
+
+    # @return [Array<String>] List of firewall zones
+    def zones
+      fwd_result("--permanent --get-zones").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of zone's interfaces
+    def list_interfaces(zone)
+      fwd_result("--permanent --zone=#{zone} --list-interfaces").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Arrray<String>] list of zone's services
+    def list_services(zone)
+      fwd_result("--permanent --zone=#{zone} --list-services").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of zone's ports
+    def list_ports(zone)
+      fwd_result("--permanent --zone=#{zone} --list-ports").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of zone's protocols
+    def list_protocols(zone)
+      fwd_result("--permanent --zone=#{zone} --list-protocols").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of all information for given zone
+    def list_all(zone)
+      fwd_result("--permanent --zone=#{zone} --list-all").split(" ")
+    end
+
+    # @return [Array<String>] list of all information for all firewall zones
+    def list_all_zones
+      fwd_result("--permanent --list-all-zones").split("\n")
+    end
+
+    ### Interfaces ###
+
+    # @param zone [String] The firewall zone
+    # @param interface [String] The network interface
+    # @return [Boolean] True if interface is assigned to zone
+    def interface_enabled?(zone, interface)
+      fwd_quiet_result("--permanent --zone=#{zone} --query-interface=#{interface}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param interface [String] The network interface
+    # @return [Boolean] True if interface was added to zone
+    def add_interface(zone, interface)
+      fwd_quiet_result("--permanent --zone=#{zone} --add-interface=#{interface}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param interface [String] The network interface
+    # @return [Boolean] True if interface was removed from zone
+    def remove_interface(zone, interface)
+      fwd_quiet_result("--permanent --zone=#{zone} --remove-interface=#{interface}")
+    end
+
+    ### Services ###
+
+    # @return [Array<String>] List of firewall services
+    def services
+      fwd_result("--permanent --get-services").split(" ")
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] list of all information for the given service
+    def info_service(service)
+      fwd_result("--permanent --info-service #{service}").split("\n")
+    end
+
+    # @param service [String] The firewall service
+    # @return [String] Short description for service
+    def service_short(service)
+      # these may not exist on early firewalld releases
+      fwd_result("--permanent --service=#{service} --get-short").rstrip
+    end
+
+    # @param service [String] the firewall service
+    # @return [String] Description for service
+    def service_description(service)
+      fwd_result("--permanent --service=#{service} --get-description").rstrip
+    end
+
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service definition exists
+    def service_supported?(service)
+      services.include?(service)
+    end
+
+    # @param zone [String] The firewall zone
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service is enabled in zone
+    def service_enabled?(zone, service)
+      fwd_quiet_result("--permanent --zone=#{zone} --query-service=#{service}")
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] The firewall service ports
+    def service_ports(service)
+      fwd_result("--permanent --service=#{service} --get-ports").strip
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] The firewall service protocols
+    def service_protocols(service)
+      fwd_result("--permanent --service=#{service} --get-protocols").strip
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] The firewall service modules
+    def service_modules(service)
+      fwd_result("--permanent --service=#{service} --get-modules").strip
+    end
+
+    # @param zone [String] The firewall zone
+    # @param port [String] The firewall port
+    # @return [Boolean] True if port is enabled in zone
+    def port_enabled?(zone, port)
+      fwd_quiet_result("--permanent --zone=#{zone} --query-port=#{port}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param protocol [String] The zone protocol
+    # @return [Boolean] True if protocol is enabled in zone
+    def protocol_enabled?(zone, protocol)
+      fwd_quiet_result("--permanent --zone=#{zone} --query-protocol=#{protocol}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service was added to zone
+    def add_service(zone, service)
+      fwd_quiet_result("--permanent --zone=#{zone} --add-service=#{service}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param port [String] The firewall port
+    # @return [Boolean] True if port was added to zone
+    def add_port(zone, port)
+      fwd_quiet_result("--permanent --zone=#{zone} --add-port=#{port}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param protocol [String] The firewall protocol
+    # @return [Boolean] True if protocol was added to zone
+    def add_protocol(zone, protocol)
+      fwd_quiet_result("--permanent --zone=#{zone} --add-protocol=#{protocol}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service was removed from zone
+    def remove_service(zone, service)
+      fwd_quiet_result("--permanent --zone=#{zone} --remove-service=#{service}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param port [String] The firewall port
+    # @return [Boolean] True if port was removed from zone
+    def remove_port(zone, port)
+      fwd_quiet_result("--permanent --zone=#{zone} --remove-port=#{port}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param protocol [String] The firewall protocol
+    # @return [Boolean] True if protocol was removed from zone
+    def remove_protocol(zone, protocol)
+      fwd_quiet_result("--permanent --zone=#{zone} --remove-protocol=#{protocol}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Boolean] True if masquerade is enabled in zone
+    def masquerade_enabled?(zone)
+      fwd_quiet_result("--permanent --zone=#{zone} --query-masquerade")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Boolean] True if masquerade was enabled in zone
+    def add_masquerade(zone)
+      return true if masquerade_enabled?(zone)
+      fwd_quiet_result("--permanent --zone=#{zone} --add-masquerade")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Boolean] True if masquerade was removed in zone
+    def remove_masquerade(zone)
+      return true if !masquerade_enabled?(zone)
+      fwd_quiet_result("--permanent --zone=#{zone} --remove-masquerade")
+    end
+
+    ### Logging ###
+
+    # @param kind [String] Denied packets to log. Possible values are:
+    # all, unicast, broadcast, multicast and off
+    # @return [Boolean] True if desired packet type is being logged when denied
+    def log_denied_packets?(kind)
+      fwd_result("--get-log-denied").strip == kind ? true : false
+    end
+
+    # @param kind [String] Denied packets to log. Possible values are:
+    # all, unicast, broadcast, multicast and off
+    # @return [Boolean] True if desired packet type was set to being logged
+    # when denied
+    def log_denied_packets=(kind)
+      fwd_quiet_result("--set-log-denied=#{kind}")
+    end
+
+    # @return [String] packet type which is being logged when denied
+    def log_denied_packets
+      fwd_result("--get-log-denied").strip
+    end
+  end
+end

--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -1095,7 +1095,7 @@ module Yast
       end
       firewall_settings = VBox(
         Frame(
-          _("Firewall Settings"),
+          _("Firewall Settings for %{firewall}") % { firewall: SuSEFirewall.firewall_service },
           VBox(
             Left(firewall_settings),
             Left(

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -780,6 +780,9 @@ module Yast
       # By default needed packages are just checked, not installed
       @check_and_install_package = false
 
+      # internal zone identification - useful for protect-from-internal
+      @int_zone_shortname = "internal"
+
     end
 
     # Function which attempts to convert a sf2_service name to a firewalld
@@ -1116,6 +1119,16 @@ module Yast
 
       true
     end
+
+    # Function returns if firewall is protected from internal zone. For
+    # firewalld, we just return true since the internal zone is treated
+    # like any other zone.
+    #
+    # @return	[Boolean] if protected from internal
+    def GetProtectFromInternalZone
+      true
+    end
+
     # Function returns list of known interfaces in requested zone.
     # Special strings like 'any' or 'auto' and unknown interfaces are removed from list.
     #
@@ -1415,6 +1428,7 @@ module Yast
     publish function: :SuSEFirewallIsInstalled, type: "boolean ()"
     publish function: :SetInstallPackagesIfMissing, type: "void (boolean)"
     publish function: :SaveAndRestartService, type: "boolean ()"
+    publish function: :GetProtectFromInternalZone, type: "boolean ()"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -46,6 +46,8 @@ module Yast
     Yast.import "NetworkInterfaces"
     Yast.import "PackageSystem"
 
+    include Yast::Logger
+
     # Use same hash for package names and services
     @@firewall_backends = {
       sf2: "SuSEfirewall2",
@@ -568,6 +570,30 @@ module Yast
       is_zone
     end
 
+    # Returns whether all needed packages are installed (or selected for
+    # installation)
+    #
+    # @return [Boolean] whether the selected firewall backend is installed
+    def SuSEFirewallIsInstalled
+      # Always recheck the status in inst-sys, user/solver might have change
+      # the list of packages selected for installation
+      # bnc#892935: in inst_finish, the package is already installed
+      if Stage.initial
+        @needed_packages_installed = Pkg.IsSelected(@FIREWALL_PACKAGE) || PackageSystem.Installed(@FIREWALL_PACKAGE)
+        log.info "Selected for installation/installed -> #{@needed_packages_installed}"
+      elsif @needed_packages_installed.nil?
+        if Mode.normal
+          @needed_packages_installed = PackageSystem.CheckAndInstallPackages([@FIREWALL_PACKAGE])
+          log.info "CheckAndInstallPackages -> #{@needed_packages_installed}"
+        else
+          @needed_packages_installed = PackageSystem.Installed(@FIREWALL_PACKAGE)
+          log.info "Installed -> #{@needed_packages_installed}"
+        end
+      end
+
+      @needed_packages_installed
+    end
+
     # Create appropriate firewall instance based on factors such as which backends
     # are available and/or running/selected.
     #
@@ -704,6 +730,10 @@ module Yast
       # Initialize the @SETTINGS hash
       @@key_settings.each { |x| @SETTINGS[x] = nil }
       GetKnownFirewallZones().each { |zone| @SETTINGS[zone] = deep_copy(EMPTY_ZONE) }
+
+      # Are needed packages installed?
+      @needed_packages_installed = nil
+
     end
 
     # Function which attempts to convert a sf2_service name to a firewalld
@@ -1297,6 +1327,7 @@ module Yast
     publish variable: :known_firewall_zones, type: "list <string>", private: true
     publish variable: :special_all_interface_zone, type: "string"
     publish variable: :zone_names, type: "map <string, string>", private: true
+    publish variable: :needed_packages_installed, type: "boolean"
     publish function: :GetStartService, type: "boolean ()"
     publish function: :SetStartService, type: "void (boolean)"
     publish function: :GetEnableService, type: "boolean ()"
@@ -1334,6 +1365,7 @@ module Yast
     publish function: :GetZonesOfInterfacesWithAnyFeatureSupported, type: "list <string> (list <string>)"
     publish function: :SetServices, type: "boolean (list <string>, list <string>, boolean)"
     publish function: :SetServicesForZones, type: "boolean (list <string>, list <string>, boolean)"
+    publish function: :SuSEFirewallIsInstalled, type: "boolean ()"
   end
 
   # ----------------------------------------------------------------------------
@@ -2364,30 +2396,6 @@ module Yast
       end
 
       nil
-    end
-
-    # Returns whether all needed packages are installed (or selected for
-    # installation)
-    #
-    # @return [Boolean] whether SuSEfirewall2 is installed
-    def SuSEFirewallIsInstalled
-      # Always recheck the status in inst-sys, user/solver might have change
-      # the list of packages selected for installation
-      # bnc#892935: in inst_finish, the package is already installed
-      if Stage.initial
-        @needed_packages_installed = Pkg.IsSelected(@FIREWALL_PACKAGE) || PackageSystem.Installed(@FIREWALL_PACKAGE)
-        log.info "Selected for installation/installed -> #{@needed_packages_installed}"
-      elsif @needed_packages_installed.nil?
-        if Mode.normal
-          @needed_packages_installed = PackageSystem.CheckAndInstallPackages([@FIREWALL_PACKAGE])
-          log.info "CheckAndInstallPackages -> #{@needed_packages_installed}"
-        else
-          @needed_packages_installed = PackageSystem.Installed(@FIREWALL_PACKAGE)
-          log.info "Installed -> #{@needed_packages_installed}"
-        end
-      end
-
-      @needed_packages_installed
     end
 
     # Function resets flag which doesn't allow to read configuration from disk again.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -618,6 +618,21 @@ module Yast
       @needed_packages_installed
     end
 
+    # Function for saving configuration and restarting firewall.
+    # Is is the same as Write() but write is allways forced.
+    #
+    # @return	[Boolean] if successful
+    def SaveAndRestartService
+      Builtins.y2milestone("Forced save and restart")
+      SetModified()
+
+      SetStartService(true)
+
+      return false if !Write()
+
+      true
+    end
+
     # Create appropriate firewall instance based on factors such as which backends
     # are available and/or running/selected.
     #
@@ -1396,6 +1411,7 @@ module Yast
     publish function: :SetServicesForZones, type: "boolean (list <string>, list <string>, boolean)"
     publish function: :SuSEFirewallIsInstalled, type: "boolean ()"
     publish function: :SetInstallPackagesIfMissing, type: "void (boolean)"
+    publish function: :SaveAndRestartService, type: "boolean ()"
   end
 
   # ----------------------------------------------------------------------------
@@ -3573,21 +3589,6 @@ module Yast
       return false if !WriteConfiguration()
 
       return false if !ActivateConfiguration()
-
-      true
-    end
-
-    # Function for saving configuration and restarting firewall.
-    # Is is the same as Write() but write is allways forced.
-    #
-    # @return	[Boolean] if successful
-    def SaveAndRestartService
-      Builtins.y2milestone("Forced save and restart")
-      SetModified()
-
-      SetStartService(true)
-
-      return false if !Write()
 
       true
     end

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -984,7 +984,7 @@ module Yast
     @@zone_attributes = [:interfaces, :masquerade, :modified, :ports, :protocols, :services]
     # {enable,start}_firewall are "inherited" from SF2 so we can't use symbols
     # there without having to change all the SF2 callers.
-    @@key_settings = ["enable_firewall", "logging", "start_firewall"]
+    @@key_settings = ["enable_firewall", "logging", "routing", "start_firewall"]
 
     EMPTY_ZONE = {
       interfaces: [],
@@ -1877,6 +1877,24 @@ module Yast
       SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
     end
 
+    # Function sets if firewall should support routing.
+    #
+    # @param	boolean set to support route or not
+    # FirewallD does not have something similar to FW_ROUTE
+    # so this API call is not applicable to FirewallD
+    def SetSupportRoute(set_route)
+      @SETTINGS[:routing] = set_route
+    end
+
+    # Function returns if firewall supports routing.
+    #
+    # @return	[Boolean] if route is supported
+    # FirewallD does not have something similar to FW_ROUTE
+    # so this API call is not applicable to FirewallD
+    def GetSupportRoute
+      @SETTINGS[:routing]
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -2187,6 +2205,8 @@ module Yast
     publish function: :RemoveAllowedPortsOrServices, type: "void (list <string>, string, string, boolean)", private: true
     publish function: :AddAllowedPortsOrServices, type: "void (list <string>, string, string)", private: true
     publish function: :IsOtherFirewallRunning, type: "boolean ()"
+    publish function: :SetSupportRoute, type: "void (boolean)"
+    publish function: :GetSupportRoute, type: "boolean ()"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -43,6 +43,7 @@ module Yast
   # Factory for construction of appropriate firewall object based on
   # desired backend.
   class FirewallClass < Module
+    Yast.import "NetworkInterfaces"
     Yast.import "PackageSystem"
 
     # Use same hash for package names and services
@@ -284,6 +285,88 @@ module Yast
     # @example GetKnownFirewallZones() -> ["DMZ", "EXT", "INT"]
     def GetKnownFirewallZones
       deep_copy(@known_firewall_zones)
+    end
+
+    # Function returns list of maps of known interfaces.
+    #
+    # **Structure:**
+    #
+    #     [ $[ "id":"modem0", "name":"Askey 815C", "type":"dialup", "zone":"EXT" ], ... ]
+    #
+    # @return	[Array<Hash{String => String>}]
+    # @return [Array<Hash{String => String>}] of all interfaces
+    def GetAllKnownInterfaces
+      known_interfaces = []
+
+      # All dial-up interfaces
+      dialup_interfaces = NetworkInterfaces.List("dialup")
+      dialup_interfaces = [] if dialup_interfaces.nil?
+
+      # bugzilla #303858 - wrong values from NetworkInterfaces
+      dialup_interfaces = Builtins.filter(dialup_interfaces) do |one_iface|
+        if one_iface.nil? || one_iface == ""
+          Builtins.y2error("Wrong interface definition '%1'", one_iface)
+          next false
+        end
+        true
+      end
+
+      dialup_interfaces = Builtins.filter(dialup_interfaces) do |interface|
+        interface != "" && !Builtins.issubstring(interface, "lo") &&
+          !Builtins.issubstring(interface, "sit")
+      end
+
+      # All non-dial-up interfaces
+      non_dialup_interfaces = NetworkInterfaces.List("")
+      non_dialup_interfaces = [] if non_dialup_interfaces.nil?
+
+      # bugzilla #303858 - wrong values from NetworkInterfaces
+      non_dialup_interfaces = Builtins.filter(non_dialup_interfaces) do |one_iface|
+        if one_iface.nil? || one_iface == ""
+          Builtins.y2error("Wrong interface definition '%1'", one_iface)
+          next false
+        end
+        true
+      end
+
+      non_dialup_interfaces = Builtins.filter(non_dialup_interfaces) do |interface|
+        interface != "" && !Builtins.issubstring(interface, "lo") &&
+          !Builtins.issubstring(interface, "sit") &&
+          !Builtins.contains(dialup_interfaces, interface)
+      end
+
+      Builtins.foreach(dialup_interfaces) do |interface|
+        known_interfaces = Builtins.add(
+          known_interfaces,
+
+          "id"   => interface,
+          "type" => "dialup",
+          # using function to get name
+          "name" => NetworkInterfaces.GetValue(
+            interface,
+            "NAME"
+          ),
+          "zone" => GetZoneOfInterface(interface)
+
+        )
+      end
+
+      Builtins.foreach(non_dialup_interfaces) do |interface|
+        known_interfaces = Builtins.add(
+          known_interfaces,
+
+          "id"   => interface,
+          # using function to get name
+          "name" => NetworkInterfaces.GetValue(
+            interface,
+            "NAME"
+          ),
+          "zone" => GetZoneOfInterface(interface)
+
+        )
+      end
+
+      deep_copy(known_interfaces)
     end
 
     # Create appropriate firewall instance based on factors such as which backends
@@ -803,6 +886,7 @@ module Yast
     publish function: :Write, type: "boolean ()"
     publish function: :Export, type: "map <string, any> ()"
     publish function: :Import, type: "void (map <string, any>)"
+    publish function: :GetAllKnownInterfaces, type: "list <map <string, string>> ()"
   end
 
   # ----------------------------------------------------------------------------
@@ -2164,88 +2248,6 @@ module Yast
       end
 
       Builtins.toset(zones)
-    end
-
-    # Function returns list of maps of known interfaces.
-    #
-    # **Structure:**
-    #
-    #     [ $[ "id":"modem0", "name":"Askey 815C", "type":"dialup", "zone":"EXT" ], ... ]
-    #
-    # @return	[Array<Hash{String => String>}]
-    # @return [Array<Hash{String => String>}] of all interfaces
-    def GetAllKnownInterfaces
-      known_interfaces = []
-
-      # All dial-up interfaces
-      dialup_interfaces = NetworkInterfaces.List("dialup")
-      dialup_interfaces = [] if dialup_interfaces.nil?
-
-      # bugzilla #303858 - wrong values from NetworkInterfaces
-      dialup_interfaces = Builtins.filter(dialup_interfaces) do |one_iface|
-        if one_iface.nil? || one_iface == ""
-          Builtins.y2error("Wrong interface definition '%1'", one_iface)
-          next false
-        end
-        true
-      end
-
-      dialup_interfaces = Builtins.filter(dialup_interfaces) do |interface|
-        interface != "" && !Builtins.issubstring(interface, "lo") &&
-          !Builtins.issubstring(interface, "sit")
-      end
-
-      # All non-dial-up interfaces
-      non_dialup_interfaces = NetworkInterfaces.List("")
-      non_dialup_interfaces = [] if non_dialup_interfaces.nil?
-
-      # bugzilla #303858 - wrong values from NetworkInterfaces
-      non_dialup_interfaces = Builtins.filter(non_dialup_interfaces) do |one_iface|
-        if one_iface.nil? || one_iface == ""
-          Builtins.y2error("Wrong interface definition '%1'", one_iface)
-          next false
-        end
-        true
-      end
-
-      non_dialup_interfaces = Builtins.filter(non_dialup_interfaces) do |interface|
-        interface != "" && !Builtins.issubstring(interface, "lo") &&
-          !Builtins.issubstring(interface, "sit") &&
-          !Builtins.contains(dialup_interfaces, interface)
-      end
-
-      Builtins.foreach(dialup_interfaces) do |interface|
-        known_interfaces = Builtins.add(
-          known_interfaces,
-
-          "id"   => interface,
-          "type" => "dialup",
-          # using function to get name
-          "name" => NetworkInterfaces.GetValue(
-            interface,
-            "NAME"
-          ),
-          "zone" => GetZoneOfInterface(interface)
-
-        )
-      end
-
-      Builtins.foreach(non_dialup_interfaces) do |interface|
-        known_interfaces = Builtins.add(
-          known_interfaces,
-
-          "id"   => interface,
-          # using function to get name
-          "name" => NetworkInterfaces.GetValue(
-            interface,
-            "NAME"
-          ),
-          "zone" => GetZoneOfInterface(interface)
-
-        )
-      end
-
-      deep_copy(known_interfaces)
     end
 
     # Function returns list of non-dial-up interfaces.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -325,6 +325,52 @@ module Yast
       deep_copy(services_status)
     end
 
+    # Function returns map of supported services all network interfaces.
+    #
+    # @param	list <string> of services
+    # @return	[Hash <String, Hash{String => Boolean} >]
+    #
+    #
+    # **Structure:**
+    #
+    #    	Returns $[service : $[ interface : supported_status ]]
+    #
+    # @example
+    #	GetServicesInZones (["service:irc-server"]) -> $["service:irc-server":$["eth1":true]]
+    #  // No such service "something"
+    #	GetServicesInZones (["something"])) -> $["something":$["eth1":nil]]
+    #  GetServicesInZones (["samba-server"]) -> $["samba-server":$["eth1":false]]
+    def GetServicesInZones(services)
+      services = deep_copy(services)
+      # list of interfaces for each zone
+      interfaces_in_zone = {}
+
+      GetListOfKnownInterfaces().each do |i|
+        z = GetZoneOfInterface(i)
+        next if z.nil? || z.empty?
+        interfaces_in_zone[z] ||= []
+        interfaces_in_zone[z] << i
+      end
+
+      # $[ service : $[ network_interface : status ]]
+      services_status = {}
+
+      # for all services requested
+      Builtins.foreach(services) do |service|
+        Ops.set(services_status, service, {})
+        # for all zones in configuration
+        Builtins.foreach(interfaces_in_zone) do |zone, interfaces|
+          status = IsServiceSupportedInZone(service, zone)
+          # for all interfaces in zone
+          Builtins.foreach(interfaces) do |interface|
+            Ops.set(services_status, [service, interface], status)
+          end
+        end
+      end
+
+      deep_copy(services_status)
+    end
+
     # Function returns list of maps of known interfaces.
     #
     # **Structure:**
@@ -926,6 +972,34 @@ module Yast
       GetInterfacesInZone(zone)
     end
 
+    # Function returns map of supported services all network interfaces.
+    #
+    # @param	list <string> of services
+    # @return	[Hash <String, Hash{String => Boolean} >]
+    #
+    #
+    # **Structure:**
+    #
+    #    	Returns $[service : $[ interface : supported_status ]]
+    #
+    # @example
+    #	GetServicesInZones (["service:irc-server"]) -> $["service:irc-server":$["eth1":true]]
+    #  // No such service "something"
+    #	GetServicesInZones (["something"])) -> $["something":$["eth1":nil]]
+    #  GetServicesInZones (["samba-server"]) -> $["samba-server":$["eth1":false]]
+    def GetServicesInZones(services)
+      services = deep_copy(services)
+      tmp_services = deep_copy(services)
+      services = []
+      Builtins.foreach(tmp_services) do |service|
+        sf2_to_firewalld_service(service).each do |s|
+          s = service.include?("service:") ? "service:" + s : s
+          services << s
+        end
+      end
+      super(services)
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -1086,6 +1160,7 @@ module Yast
     publish function: :IsServiceSupportedInZone, type: "boolean (string, string)"
     publish function: :GetServices, type: "map <string, map <string, boolean>> (list <string>)"
     publish function: :GetListOfKnownInterfaces, type: "list <string> ()"
+    publish function: :GetServicesInZones, type: "map <string, map <string, boolean>> (list <string>)"
   end
 
   # ----------------------------------------------------------------------------
@@ -2975,57 +3050,6 @@ module Yast
       end
 
       service_is_supported
-    end
-
-    # Function returns map of supported services all network interfaces.
-    #
-    # @param	list <string> of services
-    # @return	[Hash <String, Hash{String => Boolean} >]
-    #
-    #
-    # **Structure:**
-    #
-    #    	Returns $[service : $[ interface : supported_status ]]
-    #
-    # @example
-    #	GetServicesInZones (["service:irc-server"]) -> $["service:irc-server":$["eth1":true]]
-    #  // No such service "something"
-    #	GetServicesInZones (["something"])) -> $["something":$["eth1":nil]]
-    #  GetServicesInZones (["samba-server"]) -> $["samba-server":$["eth1":false]]
-    def GetServicesInZones(services)
-      services = deep_copy(services)
-      # list of interfaces for each zone
-      interface_in_zone = {}
-
-      Builtins.foreach(GetListOfKnownInterfaces()) do |interface|
-        # zone of interface
-        zone_used = GetZoneOfInterface(interface)
-        # interface can be unassigned
-        next if zone_used.nil? || zone_used == ""
-        Ops.set(
-          interface_in_zone,
-          zone_used,
-          Builtins.add(Ops.get(interface_in_zone, zone_used, []), interface)
-        )
-      end
-
-      # $[ service : $[ network_interface : status ]]
-      services_status = {}
-
-      # for all services requested
-      Builtins.foreach(services) do |service|
-        Ops.set(services_status, service, {})
-        # for all zones in configuration
-        Builtins.foreach(interface_in_zone) do |zone, interfaces|
-          status = IsServiceSupportedInZone(service, zone)
-          # for all interfaces in zone
-          Builtins.foreach(interfaces) do |interface|
-            Ops.set(services_status, [service, interface], status)
-          end
-        end
-      end
-
-      deep_copy(services_status)
     end
 
     # Function sets status for several services in several firewall zones.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -837,6 +837,28 @@ module Yast
       false
     end
 
+    # Function returns true if service is supported (allowed) in zone. Service must be defined
+    # already be defined.
+    #
+    # @see YCP Module SuSEFirewallServices
+    # @param [String] service id
+    # @param [String] zone
+    # @return	[Boolean] if supported
+    #
+    # @example
+    #	// All ports defined by dns-server service in SuSEFirewallServices module
+    #	// are enabled in the respective zone
+    #	IsServiceSupportedInZone ("dns-server", "external") -> true
+    def IsServiceSupportedInZone(service, zone)
+      return nil if !IsKnownZone(zone)
+
+      # We may have more than one FirewallD service per SF2 service
+      sf2_to_firewalld_service(service).each do |s|
+        return false if !in_zone_attr?(zone, :services, s)
+      end
+
+      true
+    end
     # Function returns list of known interfaces in requested zone.
     # Special strings like 'any' or 'auto' and unknown interfaces are removed from list.
     #
@@ -1015,6 +1037,7 @@ module Yast
     publish function: :IsAnyNetworkInterfaceSupported, type: "boolean ()"
     publish function: :GetInterfacesInZone, type: "list <string> (string)"
     publish function: :GetInterfacesInZoneSupportingAnyFeature, type: "list <string> (string)"
+    publish function: :IsServiceSupportedInZone, type: "boolean (string, string)"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -48,6 +48,7 @@ module Yast
 
     Yast.import "NetworkInterfaces"
     Yast.import "PackageSystem"
+    Yast.import "PortRanges"
 
     include Yast::Logger
 
@@ -643,6 +644,214 @@ module Yast
     # @return [Boolean] whether protocol is supported, that is, one of TCP, UDP, IP
     def IsSupportedProtocol(protocol)
       @supported_protocols.include?(protocol)
+    end
+
+    # Function sets additional ports/services from taken list. Firstly, all additional services
+    # are removed also with their aliases. Secondly new ports/protocols are added.
+    # It uses GetAdditionalServices() function to get the current state and
+    # then it removes what has been removed and adds what has been added.
+    #
+    # @param [String] protocol
+    # @param [String] zone
+    # @param	list <string> list of ports/protocols
+    # @see #GetAdditionalServices()
+    #
+    # @example
+    #	SetAdditionalServices ("TCP", "EXT", ["53", "128"])
+    def SetAdditionalServices(protocol, zone, new_list_services)
+      new_list_services = deep_copy(new_list_services)
+      old_list_services = Builtins.toset(GetAdditionalServices(protocol, zone))
+      new_list_services = Builtins.toset(new_list_services)
+
+      if new_list_services != old_list_services
+        SetModified()
+
+        add_services = []
+        remove_services = []
+
+        # Add these services
+        Builtins.foreach(new_list_services) do |service|
+          if !Builtins.contains(old_list_services, service)
+            add_services = Builtins.add(add_services, service)
+          end
+        end
+        # Remove these services
+        Builtins.foreach(old_list_services) do |service|
+          if !Builtins.contains(new_list_services, service)
+            remove_services = Builtins.add(remove_services, service)
+          end
+        end
+
+        if Ops.greater_than(Builtins.size(remove_services), 0)
+          Builtins.y2milestone(
+            "Removing additional services %1/%2 from zone %3",
+            remove_services,
+            protocol,
+            zone
+          )
+          RemoveAllowedPortsOrServices(remove_services, protocol, zone, true)
+        end
+        if Ops.greater_than(Builtins.size(add_services), 0)
+          Builtins.y2milestone(
+            "Adding additional services %1/%2 into zone %3",
+            add_services,
+            protocol,
+            zone
+          )
+          AddAllowedPortsOrServices(add_services, protocol, zone)
+        end
+      end
+
+      nil
+    end
+
+    # Local function removes ports and their aliases (if check_for_aliases is true), for
+    # requested protocol and zone.
+    #
+    # @param	list <string> ports to be removed
+    # @param [String] protocol
+    # @param [String] zone
+    # @param	boolean check for port-aliases
+    def RemoveAllowedPortsOrServices(remove_ports, protocol, zone, check_for_aliases)
+      remove_ports = deep_copy(remove_ports)
+      if Ops.less_than(Builtins.size(remove_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      # all allowed ports
+      allowed_services = PortRanges.DividePortsAndPortRanges(
+        GetAllowedServicesForZoneProto(zone, protocol),
+        false
+      )
+
+      # removing all aliases of ports too, adding aliases into
+      if check_for_aliases
+        remove_ports_with_aliases = []
+        Builtins.foreach(remove_ports) do |remove_port|
+          # skip port ranges, they cannot have any port-alias
+          if PortRanges.IsPortRange(remove_port)
+            remove_ports_with_aliases = Builtins.add(
+              remove_ports_with_aliases,
+              remove_port
+            )
+            next
+          end
+          remove_these_ports = PortAliases.GetListOfServiceAliases(remove_port)
+          remove_these_ports = [remove_port] if remove_these_ports.nil?
+          remove_ports_with_aliases = Convert.convert(
+            Builtins.union(remove_ports_with_aliases, remove_these_ports),
+            from: "list",
+            to:   "list <string>"
+          )
+        end
+        remove_ports = deep_copy(remove_ports_with_aliases)
+      end
+      remove_ports = Builtins.toset(remove_ports)
+
+      # Remove ports only once (because of port aliases), any => integers and strings
+      already_removed = []
+
+      Builtins.foreach(remove_ports) do |remove_port|
+        # Removing from normal ports
+        Ops.set(
+          allowed_services,
+          "ports",
+          Builtins.filter(Ops.get(allowed_services, "ports", [])) do |allowed_port|
+            allowed_port != "" && allowed_port != remove_port
+          end
+        )
+        # Removing also from port ranges
+        if Ops.get(allowed_services, "port_ranges", []) != []
+          # Removing a real port from port ranges
+          if !PortRanges.IsPortRange(remove_port)
+            remove_port_nr = PortAliases.GetPortNumber(remove_port)
+            # Because of all port aliases
+            if !Builtins.contains(already_removed, remove_port_nr)
+              already_removed = Builtins.add(already_removed, remove_port_nr)
+              Ops.set(
+                allowed_services,
+                "port_ranges",
+                PortRanges.RemovePortFromPortRanges(
+                  remove_port_nr,
+                  Ops.get(allowed_services, "port_ranges", [])
+                )
+              )
+            end
+            # Removing a port range from port ranges
+          else
+            if !Builtins.contains(already_removed, remove_port)
+              # Just filtering the exact port range
+              Ops.set(
+                allowed_services,
+                "port_ranges",
+                Builtins.filter(Ops.get(allowed_services, "port_ranges", [])) do |one_port_range|
+                  one_port_range != remove_port
+                end
+              )
+              already_removed = Builtins.add(already_removed, remove_port)
+            end
+          end
+        end
+      end
+
+      allowed_services_all = Convert.convert(
+        Builtins.union(
+          Ops.get(allowed_services, "ports", []),
+          Ops.get(allowed_services, "port_ranges", [])
+        ),
+        from: "list",
+        to:   "list <string>"
+      )
+
+      allowed_services_all = PortRanges.FlattenServices(
+        allowed_services_all,
+        protocol
+      )
+
+      SetAllowedServicesForZoneProto(allowed_services_all, zone, protocol)
+
+      nil
+    end
+
+    # Local function allows ports for requested protocol and zone.
+    #
+    # @param	list <string> ports to be added
+    # @param [String] protocol
+    # @param [String] zone
+    def AddAllowedPortsOrServices(add_ports, protocol, zone)
+      add_ports = deep_copy(add_ports)
+      if Ops.less_than(Builtins.size(add_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      # all allowed ports
+      allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+
+      allowed_services = Convert.convert(
+        Builtins.union(allowed_services, add_ports),
+        from: "list",
+        to:   "list <string>"
+      )
+      # Do not do that for FirewallD
+      if self.is_a?(SuSEFirewall2Class)
+        allowed_services = PortRanges.FlattenServices(allowed_services, protocol)
+      end
+
+      SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+
+      nil
     end
 
     # Create appropriate firewall instance based on factors such as which backends
@@ -1555,6 +1764,63 @@ module Yast
       deep_copy(all_allowed_services)
     end
 
+    # Function sets list of services as allowed ports for zone and protocol
+    #
+    # @param	list <string> of allowed ports/services
+    # @param [String] zone
+    # @param [String] protocol
+    def SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+      allowed_services = deep_copy(allowed_services)
+
+      SetModified()
+
+      protocol = protocol.downcase
+
+      # allowed_services can contain both services and port definitions so the
+      # first step is to split them up
+      services, ports = sanitize_services_and_ports(allowed_services, protocol)
+
+      # First we drop existing services and ports.
+      delete_ports_with_protocol_from_zone(protocol, zone)
+      delete_services_with_protocol_from_zone(protocol, zone)
+
+      # And now add the new ports and services
+      set_ports_with_protocol_to_zone(ports, protocol, zone)
+      set_services_to_zone(services, zone)
+
+      nil
+    end
+
+    # Local function removes ports and their aliases (if check_for_aliases is true), for
+    # requested protocol and zone.
+    #
+    # @param remove_ports [Array<String>] ports to be removed
+    # @param protocol [String] Protocol
+    # @param zone [String] Zone
+    # @param _check_for_aliases [Boolean] unused
+    # @param	boolean check for port-aliases
+    def RemoveAllowedPortsOrServices(remove_ports, protocol, zone, _check_for_aliases)
+      remove_ports = deep_copy(remove_ports)
+      if Ops.less_than(Builtins.size(remove_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+      Builtins.y2debug("RemoveAdditionalServices: currently allowed services for %1_%2 -> %3",
+        zone, protocol, allowed_services)
+      # and this is what we keep
+      allowed_services -= remove_ports
+      Builtins.y2debug("RemoveAdditionalServices: new allowed services for %1_%2 -> %3",
+        zone, protocol, allowed_services)
+      SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -1678,6 +1944,123 @@ module Yast
       del_zone_modified(zone, :protocols)
     end
 
+    # Sanitize array of intermixed services and ports and return them as
+    # two separate arrays for further processing. Invalid entries will be
+    # discarded.
+    # @param allowed_services [Array<String>] list of services and ports
+    # @param protocol [String] Network Protocol
+    # @return [Array<String>][Array<String>] Array of services and Array of ports to add
+    def sanitize_services_and_ports(allowed_services, protocol)
+      services = []
+      ports = []
+      allowed_services.each do |s|
+        Builtins.y2debug("Examining %1", s)
+        # Is it a service?
+        if SuSEFirewallServices.GetSupportedServices().keys.include?(s)
+          if protocol == "tcp"
+            if !SuSEFirewallServices.GetNeededTCPPorts(s).empty?
+              Builtins.y2debug("Adding service %1", s)
+              services << s
+            end
+          elsif protocol == "udp"
+            if !SuSEFirewallServices.GetNeededUDPPorts(s).empty?
+              Builtins.y2debug("Adding service %1", s)
+              services << s
+            end
+          end
+        # Is it a port?
+        elsif s.match(/\d+((:|-)\d+)?/)
+          Builtins.y2debug("Adding port %1", s)
+          ports << s
+        # Is it something else?
+        else
+          Builtins.y2error("Ignoring unknown service: %1", s)
+        end
+      end
+
+      # Return the two arrays
+      [services, ports]
+    end
+
+    # Delete services for given protocol from zone
+    # @param zone [String] Zone
+    # @param protocol [String] Network Protocol
+    # @return nil
+    # @note This does not play well with FirewallD. Services may have TCP and UDP
+    # @note ports and we can't simply remove part of them. So what we do here is
+    # @note to remove the services which have a no other protocol dependecies
+    # @note protocol.
+    # FIXME: take IP and other protocols into consideration
+    def delete_services_with_protocol_from_zone(protocol, zone)
+      get_zone_attr(zone, :services).each do |s|
+        Builtins.y2debug(
+          "Examinining service %2_%1 for removal",
+          protocol, s)
+        if protocol == "udp" &&
+            SuSEFirewallServices.GetNeededTCPPorts(s).empty? &&
+            !SuSEFirewallServices.GetNeededUDPPorts(s).empty?
+          Builtins.y2debug("Removing service %1", s)
+          del_from_zone_attr(zone, :services, s)
+        elsif protocol == "tcp" &&
+            SuSEFirewallServices.GetNeededUDPPorts(s).empty? &&
+            !SuSEFirewallServices.GetNeededTCPPorts(s).empty?
+          del_from_zone_attr(zone, :services, s)
+          Builtins.y2debug("Removing service %1", s)
+        else
+          Builtins.y2debug("Not removing %1 because it has protocol dependencies", s)
+        end
+      end
+      nil
+    end
+
+    # Add services to zone
+    # @param services [Array<String>] list of services to add
+    # @param zone [String] Zone
+    # @return nil
+    def set_services_to_zone(services, zone)
+      return nil if services.empty?
+      # Add the new services! We do not assign since that will override
+      # services depending on other protocols!ugh!
+      services.each do |s|
+        next unless !in_zone_attr?(zone, :services, s)
+        Builtins.y2debug("Service %1 will be added to the %2 zone", s, zone)
+        add_to_zone_attr(zone, :services, s)
+        add_zone_modified(zone, :services)
+      end
+    end
+
+    # Delete ports for given protocol from zone
+    # @param protocol [String] Network Protocol
+    # @param zone [String] Zone
+    # @return nil
+    def delete_ports_with_protocol_from_zone(protocol, zone)
+      get_zone_attr(zone, :ports).each do |p|
+        port_proto = p.split("/")
+        del_from_zone_attr(zone, :ports, p) if port_proto[1] == protocol
+        add_zone_modified(zone, :ports)
+      end
+    end
+
+    # Add ports for given protocol to zone
+    # @param ports [Array<String>] list of ports to add
+    # @param zone [String] Zone
+    # @return nil
+    def set_ports_with_protocol_to_zone(ports, protocol, zone)
+      return nil if ports.empty?
+      ports.each do |p|
+        # Convert SF2 port range to FirewallD
+        p.sub!(":", "-")
+        port_proto = "#{p}/#{protocol}"
+        next unless !@SETTINGS[zone][:ports].include?(port_proto)
+        # Remove old services and set the new ones.
+        Builtins.y2debug(
+          "Port %1 will be added to the %2 zone",
+          port_proto, zone)
+        add_to_zone_attr(zone, :ports, port_proto)
+        add_zone_modified(zone, :ports)
+      end
+    end
+
   public
 
     publish variable: :firewall_service, type: "string", private: true
@@ -1744,6 +2127,9 @@ module Yast
     publish function: :IsSupportedProtocol, type: "boolean (string)", private: true
     publish function: :GetAdditionalServices, type: "list <string> (string, string)"
     publish function: :GetAllowedServicesForZoneProto, type: "list <string> (string, string)", private: true
+    publish function: :SetAdditionalServices, type: "void (string, string, list <string>)"
+    publish function: :RemoveAllowedPortsOrServices, type: "void (list <string>, string, string, boolean)", private: true
+    publish function: :AddAllowedPortsOrServices, type: "void (list <string>, string, string)", private: true
   end
 
   # ----------------------------------------------------------------------------
@@ -2426,151 +2812,6 @@ module Yast
       )
 
       true
-    end
-
-    # Local function removes ports and their aliases (if check_for_aliases is true), for
-    # requested protocol and zone.
-    #
-    # @param	list <string> ports to be removed
-    # @param [String] protocol
-    # @param [String] zone
-    # @param	boolean check for port-aliases
-    def RemoveAllowedPortsOrServices(remove_ports, protocol, zone, check_for_aliases)
-      remove_ports = deep_copy(remove_ports)
-      if Ops.less_than(Builtins.size(remove_ports), 1)
-        Builtins.y2warning(
-          "Undefined list of %1 services/ports for service",
-          protocol
-        )
-        return
-      end
-
-      SetModified()
-
-      # all allowed ports
-      allowed_services = PortRanges.DividePortsAndPortRanges(
-        GetAllowedServicesForZoneProto(zone, protocol),
-        false
-      )
-
-      # removing all aliases of ports too, adding aliases into
-      if check_for_aliases
-        remove_ports_with_aliases = []
-        Builtins.foreach(remove_ports) do |remove_port|
-          # skip port ranges, they cannot have any port-alias
-          if PortRanges.IsPortRange(remove_port)
-            remove_ports_with_aliases = Builtins.add(
-              remove_ports_with_aliases,
-              remove_port
-            )
-            next
-          end
-          remove_these_ports = PortAliases.GetListOfServiceAliases(remove_port)
-          remove_these_ports = [remove_port] if remove_these_ports.nil?
-          remove_ports_with_aliases = Convert.convert(
-            Builtins.union(remove_ports_with_aliases, remove_these_ports),
-            from: "list",
-            to:   "list <string>"
-          )
-        end
-        remove_ports = deep_copy(remove_ports_with_aliases)
-      end
-      remove_ports = Builtins.toset(remove_ports)
-
-      # Remove ports only once (because of port aliases), any => integers and strings
-      already_removed = []
-
-      Builtins.foreach(remove_ports) do |remove_port|
-        # Removing from normal ports
-        Ops.set(
-          allowed_services,
-          "ports",
-          Builtins.filter(Ops.get(allowed_services, "ports", [])) do |allowed_port|
-            allowed_port != "" && allowed_port != remove_port
-          end
-        )
-        # Removing also from port ranges
-        if Ops.get(allowed_services, "port_ranges", []) != []
-          # Removing a real port from port ranges
-          if !PortRanges.IsPortRange(remove_port)
-            remove_port_nr = PortAliases.GetPortNumber(remove_port)
-            # Because of all port aliases
-            if !Builtins.contains(already_removed, remove_port_nr)
-              already_removed = Builtins.add(already_removed, remove_port_nr)
-              Ops.set(
-                allowed_services,
-                "port_ranges",
-                PortRanges.RemovePortFromPortRanges(
-                  remove_port_nr,
-                  Ops.get(allowed_services, "port_ranges", [])
-                )
-              )
-            end
-            # Removing a port range from port ranges
-          else
-            if !Builtins.contains(already_removed, remove_port)
-              # Just filtering the exact port range
-              Ops.set(
-                allowed_services,
-                "port_ranges",
-                Builtins.filter(Ops.get(allowed_services, "port_ranges", [])) do |one_port_range|
-                  one_port_range != remove_port
-                end
-              )
-              already_removed = Builtins.add(already_removed, remove_port)
-            end
-          end
-        end
-      end
-
-      allowed_services_all = Convert.convert(
-        Builtins.union(
-          Ops.get(allowed_services, "ports", []),
-          Ops.get(allowed_services, "port_ranges", [])
-        ),
-        from: "list",
-        to:   "list <string>"
-      )
-      allowed_services_all = PortRanges.FlattenServices(
-        allowed_services_all,
-        protocol
-      )
-
-      SetAllowedServicesForZoneProto(allowed_services_all, zone, protocol)
-
-      nil
-    end
-
-    # Local function allows ports for requested protocol and zone.
-    #
-    # @param	list <string> ports to be added
-    # @param [String] protocol
-    # @param [String] zone
-    def AddAllowedPortsOrServices(add_ports, protocol, zone)
-      add_ports = deep_copy(add_ports)
-      if Ops.less_than(Builtins.size(add_ports), 1)
-        Builtins.y2warning(
-          "Undefined list of %1 services/ports for service",
-          protocol
-        )
-        return
-      end
-
-      SetModified()
-
-      # all allowed ports
-      allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
-
-      allowed_services = Convert.convert(
-        Builtins.union(allowed_services, add_ports),
-        from: "list",
-        to:   "list <string>"
-      )
-      allowed_services = PortRanges.FlattenServices(allowed_services, protocol)
-
-      SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
-
-      nil
     end
 
     # Removes service defined by package (FATE #300687) from enabled services.
@@ -3981,65 +4222,6 @@ module Yast
 
       # well, actually it returns list of services not-assigned to any well-known service
       deep_copy(all_allowed_services)
-    end
-
-    # Function sets additional ports/services from taken list. Firstly, all additional services
-    # are removed also with their aliases. Secondly new ports/protocols are added.
-    # It uses GetAdditionalServices() function to get the current state and
-    # then it removes what has been removed and adds what has been added.
-    #
-    # @param [String] protocol
-    # @param [String] zone
-    # @param	list <string> list of ports/protocols
-    # @see #GetAdditionalServices()
-    #
-    # @example
-    #	SetAdditionalServices ("TCP", "EXT", ["53", "128"])
-    def SetAdditionalServices(protocol, zone, new_list_services)
-      new_list_services = deep_copy(new_list_services)
-      old_list_services = Builtins.toset(GetAdditionalServices(protocol, zone))
-      new_list_services = Builtins.toset(new_list_services)
-
-      if new_list_services != old_list_services
-        SetModified()
-
-        add_services = []
-        remove_services = []
-
-        # Add these services
-        Builtins.foreach(new_list_services) do |service|
-          if !Builtins.contains(old_list_services, service)
-            add_services = Builtins.add(add_services, service)
-          end
-        end
-        # Remove these services
-        Builtins.foreach(old_list_services) do |service|
-          if !Builtins.contains(new_list_services, service)
-            remove_services = Builtins.add(remove_services, service)
-          end
-        end
-
-        if Ops.greater_than(Builtins.size(remove_services), 0)
-          Builtins.y2milestone(
-            "Removing additional services %1/%2 from zone %3",
-            remove_services,
-            protocol,
-            zone
-          )
-          RemoveAllowedPortsOrServices(remove_services, protocol, zone, true)
-        end
-        if Ops.greater_than(Builtins.size(add_services), 0)
-          Builtins.y2milestone(
-            "Adding additional services %1/%2 into zone %3",
-            add_services,
-            protocol,
-            zone
-          )
-          AddAllowedPortsOrServices(add_services, protocol, zone)
-        end
-      end
-
-      nil
     end
 
     # Function returns if any other firewall then SuSEfirewall2 is currently running on the

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -1305,6 +1305,36 @@ module Yast
       nil
     end
 
+    # Function returns list of special strings like 'any' or 'auto' and unknown interfaces.
+    # This function is only valid for SF2. For firewalld, we return an empty array.
+    #
+    # @param [String] zone
+    # @return	[Array<String>] special strings or unknown interfaces
+    #
+    # @example
+    #	GetSpecialInterfacesInZone("EXT") -> ["any", "unknown-1", "wrong-3"]
+    def GetSpecialInterfacesInZone(zone)
+      []
+    end
+
+    # Function removes special string from defined zone. For firewalld we
+    # return nil.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    def RemoveSpecialInterfaceFromZone(interface, zone)
+     nil
+    end
+
+    # Functions adds special string into defined zone. For firewalld we
+    # return nil.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    def AddSpecialInterfaceIntoZone(interface, zone)
+      nil
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -1481,6 +1511,9 @@ module Yast
     publish function: :GetProtectFromInternalZone, type: "boolean ()"
     publish function: :GetMasquerade, type: "boolean (string)"
     publish function: :SetMasquerade, type: "void (boolean, string)"
+    publish function: :GetSpecialInterfacesInZone, type: "list <string> (string)"
+    publish function: :RemoveSpecialInterfaceFromZone, type: "void (string, string)"
+    publish function: :AddSpecialInterfaceIntoZone, type: "void (string, string)"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -965,6 +965,21 @@ module Yast
       nil
     end
 
+    # Function returns list of zones of requested interfaces.
+    # Special string 'any' in 'EXT' zone is supported.
+    #
+    # @param [Array<String>] interfaces
+    # @return	[Array<String>] firewall zones
+    #
+    # @example
+    #	GetZonesOfInterfaces (["eth1","eth4"]) -> ["EXT"]
+    def GetZonesOfInterfacesWithAnyFeatureSupported(interfaces)
+      interfaces = deep_copy(interfaces)
+      zones = []
+      interfaces.each { |interface| zones << GetZoneOfInterface(interface) }
+      zones
+    end
+
     # Function returns whether the feature 'any' network interface is supported.
     # This is a SF2 specific construct. For firewalld, we simply return false.
     # We may decide to change this in the future.
@@ -1210,6 +1225,7 @@ module Yast
     publish function: :SetModified, type: "void ()"
     publish function: :ResetModified, type: "void ()"
     publish function: :GetModified, type: "boolean ()"
+    publish function: :GetZonesOfInterfacesWithAnyFeatureSupported, type: "list <string> (list <string>)"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -837,6 +837,27 @@ module Yast
       false
     end
 
+    # Function returns list of known interfaces in requested zone.
+    # Special strings like 'any' or 'auto' and unknown interfaces are removed from list.
+    #
+    # @param [String] zone
+    # @return	[Array<String>] of interfaces
+    # @example GetInterfacesInZone ("external") -> ["eth4", "eth5"]
+    def GetInterfacesInZone(zone)
+      return [] unless IsKnownZone(zone)
+      deep_copy(get_zone_attr(zone, :interfaces))
+    end
+
+    # Function returns list of known interfaces in requested zone.
+    # In the firewalld case, we don't support the special 'any' string.
+    # Thus, interfaces not in a zone will not be included.
+    #
+    # @param [String] zone
+    # @return	[Array<String>] of interfaces
+    def GetInterfacesInZoneSupportingAnyFeature(zone)
+      GetInterfacesInZone(zone)
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -992,6 +1013,8 @@ module Yast
     publish function: :GetZonesOfInterfaces, type: "list <string> (list <string>)"
     publish function: :GetZoneFullName, type: "string (string)"
     publish function: :IsAnyNetworkInterfaceSupported, type: "boolean ()"
+    publish function: :GetInterfacesInZone, type: "list <string> (string)"
+    publish function: :GetInterfacesInZoneSupportingAnyFeature, type: "list <string> (string)"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -1162,6 +1162,19 @@ module Yast
       true
     end
 
+    # Function adds a special interface 'xenbr+' into the FW_FORWARD_ALWAYS_INOUT_DEV variable.
+    #
+    # @see #https://bugzilla.novell.com/show_bug.cgi?id=154133
+    # @see #https://bugzilla.novell.com/show_bug.cgi?id=233934
+    # @see #https://bugzilla.novell.com/show_bug.cgi?id=375482
+    def AddXenSupport
+      Builtins.y2milestone(
+        "The whole functionality is currently handled by SuSEfirewall2 itself"
+      )
+
+      nil
+    end
+
     # Create appropriate firewall instance based on factors such as which backends
     # are available and/or running/selected.
     #
@@ -2151,6 +2164,17 @@ module Yast
       super(needed_ports, protocol, zone, false)
     end
 
+    # Sets whether ports need to be open already during boot
+    # bsc#916376. For FirewallD we simply return whatever it
+    # was passed as argument since FirewallD always does a
+    # full init on boot but we still need to be API compliant.
+    #
+    # @param [Boolean] new state
+    # @return [Boolean] current state
+    def full_init_on_boot(new_state)
+      new_state
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -2467,6 +2491,8 @@ module Yast
     publish function: :HaveService, type: "boolean (string, string, string)"
     publish function: :AddService, type: "boolean (string, string, string)"
     publish function: :RemoveService, type: "boolean (string, string, string)"
+    publish function: :AddXenSupport, type: "void ()"
+    publish function: :full_init_on_boot, type: "boolean (boolean)"
   end
 
   # ----------------------------------------------------------------------------
@@ -4711,19 +4737,6 @@ module Yast
       SetModified()
 
       Ops.set(@SETTINGS, Ops.add("FW_IGNORE_FW_BROADCAST_", zone), bcast)
-
-      nil
-    end
-
-    # Function adds a special interface 'xenbr+' into the FW_FORWARD_ALWAYS_INOUT_DEV variable.
-    #
-    # @see #https://bugzilla.novell.com/show_bug.cgi?id=154133
-    # @see #https://bugzilla.novell.com/show_bug.cgi?id=233934
-    # @see #https://bugzilla.novell.com/show_bug.cgi?id=375482
-    def AddXenSupport
-      Builtins.y2milestone(
-        "The whole functionality is currently handled by SuSEfirewall2 itself"
-      )
 
       nil
     end

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -636,6 +636,15 @@ module Yast
       true
     end
 
+    # Local function returns if protocol is supported by firewall.
+    # Protocol name must be in upper-cases.
+    #
+    # @param [String] protocol
+    # @return [Boolean] whether protocol is supported, that is, one of TCP, UDP, IP
+    def IsSupportedProtocol(protocol)
+      @supported_protocols.include?(protocol)
+    end
+
     # Create appropriate firewall instance based on factors such as which backends
     # are available and/or running/selected.
     #
@@ -791,6 +800,8 @@ module Yast
       # internal zone identification - useful for protect-from-internal
       @int_zone_shortname = "internal"
 
+      # list of protocols supported in firewall, use only upper-cases
+      @supported_protocols = ["TCP", "UDP", "IP"]
     end
 
     # Function which attempts to convert a sf2_service name to a firewalld
@@ -1668,6 +1679,8 @@ module Yast
     publish function: :SetLoggingSettings, type: "void (string, string)"
     publish function: :GetIgnoreLoggingBroadcast, type: "string (string)"
     publish function: :SetIgnoreLoggingBroadcast, type: "void (string, string)"
+    publish variable: :supported_protocols, type: "list <string>", private: true
+    publish function: :IsSupportedProtocol, type: "boolean (string)", private: true
   end
 
   # ----------------------------------------------------------------------------
@@ -2064,15 +2077,6 @@ module Yast
       end
 
       write_status
-    end
-
-    # Local function returns if protocol is supported by firewall.
-    # Protocol name must be in upper-cases.
-    #
-    # @param [String] protocol
-    # @return	[Boolean] if protocol is supported
-    def IsSupportedProtocol(protocol)
-      Builtins.contains(@supported_protocols, protocol)
     end
 
     # Local function returns configuration string used in configuration for zone.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -43,6 +43,9 @@ module Yast
   # Factory for construction of appropriate firewall object based on
   # desired backend.
   class FirewallClass < Module
+    # @return [String] the systemd service name: "firewalld" or "SuSEfirewall2"
+    attr_reader :firewall_service
+
     Yast.import "NetworkInterfaces"
     Yast.import "PackageSystem"
 
@@ -457,7 +460,7 @@ module Yast
     #
     # **Structure:**
     #
-    #     [ $[ "id":"modem0", "name":"Askey 815C", "type":"dialup", "zone":"EXT" ], ... ]
+    #     [ $[ "id":"modem1", "name":"Askey 815C", "type":"dialup", "zone":"EXT" ], ... ]
     #
     # @return	[Array<Hash{String => String>}]
     # @return [Array<Hash{String => String>}] of all interfaces

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -33,7 +33,18 @@
 require "yast"
 
 module Yast
-  class SuSEFirewallClass < Module
+  # Factory for construction of appropriate firewall object based on
+  # desired backend.
+  class FirewallClass < Module
+    def self.create
+      SuSEFirewall2Class.new
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+  # SuSEFirewall2/SF2 Class. The original, simply created from the Firewall
+  # factory class.
+  class SuSEFirewall2Class < Module
     CONFIG_FILE = "/etc/sysconfig/SuSEfirewall2"
 
     include Yast::Logger
@@ -3892,6 +3903,6 @@ module Yast
     publish function: :full_init_on_boot, type: "boolean (boolean)"
   end
 
-  SuSEFirewall = SuSEFirewallClass.new
-  SuSEFirewall.main
+  SuSEFirewall = FirewallClass.create
+  SuSEFirewall.main if SuSEFirewall.is_a?(SuSEFirewall2Class)
 end

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -867,6 +867,16 @@ module Yast
       nil
     end
 
+    def sf2_to_firewalld_zone(zone)
+      sf2_to_firewalld_map = {
+        "INT" => "trusted",
+        "EXT" => "external",
+        "DMZ" => "dmz"
+      }
+
+      sf2_to_firewalld_map[zone] || zone
+    end
+
     def Read
       # Do not read it again and again
       # to avoid overwritting live configuration.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -494,6 +494,24 @@ module Yast
       Ops.get(@zone_names, zone, _("Unknown Zone"))
     end
 
+    # Function returns if zone (shortname like "EXT") is supported by firewall.
+    # Undefined zones are, for sure, unsupported.
+    #
+    # @param [String] zone shortname
+    # @return	[Boolean] if zone is known and supported.
+    def IsKnownZone(zone)
+      is_zone = false
+
+      Builtins.foreach(GetKnownFirewallZones()) do |known_zone|
+        if known_zone == zone
+          is_zone = true
+          raise Break
+        end
+      end
+
+      is_zone
+    end
+
     # Create appropriate firewall instance based on factors such as which backends
     # are available and/or running/selected.
     #
@@ -1161,6 +1179,7 @@ module Yast
     publish function: :GetServices, type: "map <string, map <string, boolean>> (list <string>)"
     publish function: :GetListOfKnownInterfaces, type: "list <string> ()"
     publish function: :GetServicesInZones, type: "map <string, map <string, boolean>> (list <string>)"
+    publish function: :IsKnownZone, type: "boolean (string)", private: true
   end
 
   # ----------------------------------------------------------------------------
@@ -1583,24 +1602,6 @@ module Yast
     # @return	[Boolean] if protocol is supported
     def IsSupportedProtocol(protocol)
       Builtins.contains(@supported_protocols, protocol)
-    end
-
-    # Local function returns if zone (shortname like "EXT") is supported by firewall.
-    # Undefined zones are, for sure, unsupported.
-    #
-    # @param [String] zone shortname
-    # @return	[Boolean] if zone is known and supported.
-    def IsKnownZone(zone)
-      is_zone = false
-
-      Builtins.foreach(GetKnownFirewallZones()) do |known_zone|
-        if known_zone == zone
-          is_zone = true
-          raise Break
-        end
-      end
-
-      is_zone
     end
 
     # Local function returns configuration string used in configuration for zone.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -371,6 +371,35 @@ module Yast
       deep_copy(services_status)
     end
 
+    # Function sets status for several services on several network interfaces.
+    #
+    # @param	list <string> service ids
+    # @param	list <string> network interfaces
+    # @param	boolean new status of services
+    # @return	[Boolean] if successfull
+    #
+    # @example
+    #  // Disabling services
+    #	SetServices (["samba-server", "service:irc-server"], ["eth1", "modem0"], false)
+    #  // Enabling services
+    #  SetServices (["samba-server", "service:irc-server"], ["eth1", "modem0"], true)
+    # @see #SetServicesForZones()
+
+    def SetServices(services_ids, interfaces, new_status)
+      firewall_zones = GetZonesOfInterfacesWithAnyFeatureSupported(interfaces)
+      if Builtins.size(firewall_zones) == 0
+        Builtins.y2error(
+          "Interfaces '%1' are not in any group of interfaces",
+          interfaces
+        )
+        return false
+      end
+
+      SetModified()
+
+      SetServicesForZones(services_ids, firewall_zones, new_status)
+    end
+
     # Function sets internal variable, which indicates, that any
     # "firewall settings were modified", to "true".
     def SetModified
@@ -1226,6 +1255,7 @@ module Yast
     publish function: :ResetModified, type: "void ()"
     publish function: :GetModified, type: "boolean ()"
     publish function: :GetZonesOfInterfacesWithAnyFeatureSupported, type: "list <string> (list <string>)"
+    publish function: :SetServices, type: "boolean (list <string>, list <string>, boolean)"
   end
 
   # ----------------------------------------------------------------------------
@@ -3087,8 +3117,6 @@ module Yast
     # @see #GetServicesInZones()
     # @see #GetServices()
     def SetServicesForZones(services_ids, firewall_zones, new_status)
-      services_ids = deep_copy(services_ids)
-      firewall_zones = deep_copy(firewall_zones)
       # no groups == all groups
       if Builtins.size(firewall_zones) == 0
         firewall_zones = GetKnownFirewallZones()
@@ -3126,36 +3154,6 @@ module Yast
       end
 
       nil
-    end
-
-    # Function sets status for several services on several network interfaces.
-    #
-    # @param	list <string> service ids
-    # @param	list <string> network interfaces
-    # @param	boolean new status of services
-    # @return	[Boolean] if successfull
-    #
-    # @example
-    #  // Disabling services
-    #	SetServices (["samba-server", "service:irc-server"], ["eth1", "modem0"], false)
-    #  // Enabling services
-    #  SetServices (["samba-server", "service:irc-server"], ["eth1", "modem0"], true)
-    # @see #SetServicesForZones()
-    def SetServices(services_ids, interfaces, new_status)
-      services_ids = deep_copy(services_ids)
-      interfaces = deep_copy(interfaces)
-      firewall_zones = GetZonesOfInterfacesWithAnyFeatureSupported(interfaces)
-      if Builtins.size(firewall_zones) == 0
-        Builtins.y2error(
-          "Interfaces '%1' are not in any group of interfaces",
-          interfaces
-        )
-        return false
-      end
-
-      SetModified()
-
-      SetServicesForZones(services_ids, firewall_zones, new_status)
     end
 
     # Local function sets the default configuration and fills internal values.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -371,6 +371,33 @@ module Yast
       deep_copy(services_status)
     end
 
+    # Function sets internal variable, which indicates, that any
+    # "firewall settings were modified", to "true".
+    def SetModified
+      @modified = true
+
+      nil
+    end
+
+    # Do not use this function.
+    # Only for firewall installation proposal.
+    def ResetModified
+      Builtins.y2milestone("Reseting firewall-modified to 'false'")
+      @modified = false
+
+      nil
+    end
+
+    # Functions returns whether any firewall's configuration was modified.
+    #
+    # @return	[Boolean] if the configuration was modified
+    def GetModified
+      Yast.import "SuSEFirewallServices"
+      # Changed SuSEFirewall or
+      # Changed SuSEFirewallServices (needs resatrting as well)
+      @modified || SuSEFirewallServices.GetModified
+    end
+
     # Function returns list of maps of known interfaces.
     #
     # **Structure:**
@@ -1180,6 +1207,9 @@ module Yast
     publish function: :GetListOfKnownInterfaces, type: "list <string> ()"
     publish function: :GetServicesInZones, type: "map <string, map <string, boolean>> (list <string>)"
     publish function: :IsKnownZone, type: "boolean (string)", private: true
+    publish function: :SetModified, type: "void ()"
+    publish function: :ResetModified, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
   end
 
   # ----------------------------------------------------------------------------
@@ -1416,23 +1446,6 @@ module Yast
       return true if key_name.nil? && key_name == ""
 
       Builtins.contains(@one_line_per_record, key_name)
-    end
-
-    # Function sets internal variable, which indicates, that any
-    # "firewall settings were modified", to "true".
-    def SetModified
-      @modified = true
-
-      nil
-    end
-
-    # Do not use this function.
-    # Only for firewall installation proposal.
-    def ResetModified
-      Builtins.y2milestone("Reseting firewall-modified to 'false'")
-      @modified = false
-
-      nil
     end
 
     # Report the error, warning, message only once.
@@ -2251,15 +2264,6 @@ module Yast
       end
 
       @needed_packages_installed
-    end
-
-    # Functions returns whether any firewall's configuration was modified.
-    #
-    # @return	[Boolean] if the configuration was modified
-    def GetModified
-      # Changed SuSEFirewall or
-      # Changed SuSEFirewallServices (needs resatrting as well)
-      @modified || SuSEFirewallServices.GetModified
     end
 
     # Function resets flag which doesn't allow to read configuration from disk again.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -639,8 +639,9 @@ module Yast
     # Create appropriate firewall instance based on factors such as which backends
     # are available and/or running/selected.
     #
+    # @param backend_sym [Symbol] if not nil, explicitly select :sf2 or :fwd
     # @return SuSEFirewall2 or SuSEFirewalld instance.
-    def self.create
+    def self.create(backend_sym = nil)
       Yast.import "Mode"
 
       # Old testsuite
@@ -649,6 +650,13 @@ module Yast
         # will be committed later on but they will only affect the new
         # testsuite
         SuSEFirewall2Class.new
+
+      # If backend is specificed, go ahead and create an instance. Otherwise, try
+      # to detect which backend is enabled and create the appropriate instance.
+      elsif backend_sym == :sf2
+        SuSEFirewall2Class.new
+      elsif backend_sym == :fwd
+        SuSEFirewalldClass.new
       else
         begin
           # Only one running backend is permitted.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -429,6 +429,30 @@ module Yast
       @modified || SuSEFirewallServices.GetModified
     end
 
+    # By default Firewall packages are just checked whether they are installed.
+    # With this function, you can change the behavior to also offer installing
+    # the packages.
+    #
+    # @param [Boolean] new_status, 'true' if packages should be offered for installation
+    def SetInstallPackagesIfMissing(new_status)
+      if new_status.nil?
+        Builtins.y2error("Wrong value: %1", new_status)
+        return
+      end
+
+      @check_and_install_package = new_status
+
+      if @check_and_install_package
+        Builtins.y2milestone("Firewall packages will installed if missing")
+      else
+        Builtins.y2milestone(
+          "Firewall packages will not be installed even if missing"
+        )
+      end
+
+      nil
+    end
+
     # Function returns list of maps of known interfaces.
     #
     # **Structure:**
@@ -733,6 +757,10 @@ module Yast
 
       # Are needed packages installed?
       @needed_packages_installed = nil
+
+      # bnc #388773
+      # By default needed packages are just checked, not installed
+      @check_and_install_package = false
 
     end
 
@@ -1328,6 +1356,7 @@ module Yast
     publish variable: :special_all_interface_zone, type: "string"
     publish variable: :zone_names, type: "map <string, string>", private: true
     publish variable: :needed_packages_installed, type: "boolean"
+    publish variable: :check_and_install_package, type: "boolean", private: true
     publish function: :GetStartService, type: "boolean ()"
     publish function: :SetStartService, type: "void (boolean)"
     publish function: :GetEnableService, type: "boolean ()"
@@ -1366,6 +1395,7 @@ module Yast
     publish function: :SetServices, type: "boolean (list <string>, list <string>, boolean)"
     publish function: :SetServicesForZones, type: "boolean (list <string>, list <string>, boolean)"
     publish function: :SuSEFirewallIsInstalled, type: "boolean ()"
+    publish function: :SetInstallPackagesIfMissing, type: "void (boolean)"
   end
 
   # ----------------------------------------------------------------------------
@@ -2369,30 +2399,6 @@ module Yast
         else
           Builtins.y2error("Unknown key '%1'", key)
         end
-      end
-
-      nil
-    end
-
-    # By default SuSEfirewall2 packages are just checked whether they are installed.
-    # With this function, you can change the behavior to also offer installing
-    # the packages.
-    #
-    # @param [Boolean] new_status, 'true' if packages should be offered for installation
-    def SetInstallPackagesIfMissing(new_status)
-      if new_status.nil?
-        Builtins.y2error("Wrong value: %1", new_status)
-        return
-      end
-
-      @check_and_install_package = new_status
-
-      if @check_and_install_package
-        Builtins.y2milestone("SuSEfirewall2 packages will installed if missing")
-      else
-        Builtins.y2milestone(
-          "SuSEfirewall2 packages will not be installed even if missing"
-        )
       end
 
       nil

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -407,6 +407,14 @@ module Yast
       deep_copy(known_interfaces)
     end
 
+    # Function returns list of all known interfaces.
+    #
+    # @return	[Array<String>] of interfaces
+    # @example GetListOfKnownInterfaces() -> ["eth1", "eth2", "modem0", "dsl5"]
+    def GetListOfKnownInterfaces
+      GetAllKnownInterfaces().map { |i| i["id"] }
+    end
+
     # Function returns list of zones of requested interfaces
     #
     # @param [Array<String>] interfaces
@@ -1077,6 +1085,7 @@ module Yast
     publish function: :GetInterfacesInZoneSupportingAnyFeature, type: "list <string> (string)"
     publish function: :IsServiceSupportedInZone, type: "boolean (string, string)"
     publish function: :GetServices, type: "map <string, map <string, boolean>> (list <string>)"
+    publish function: :GetListOfKnownInterfaces, type: "list <string> ()"
   end
 
   # ----------------------------------------------------------------------------
@@ -2441,23 +2450,6 @@ module Yast
       end
 
       deep_copy(dial_up_interfaces)
-    end
-
-    # Function returns list of all known interfaces.
-    #
-    # @return	[Array<String>] of interfaces
-    # @example GetListOfKnownInterfaces() -> ["eth1", "eth2", "modem0", "dsl5"]
-    def GetListOfKnownInterfaces
-      interfaces = []
-
-      Builtins.foreach(GetAllKnownInterfaces()) do |interface_map|
-        interfaces = Builtins.add(
-          interfaces,
-          Ops.get_string(interface_map, "id", "")
-        )
-      end
-
-      deep_copy(interfaces)
     end
 
     # Function removes interface from defined zone.

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -31,6 +31,7 @@
 #
 # Module for handling SuSEfirewall2.
 require "yast"
+require "network/firewalld"
 
 module Yast
   # Factory for construction of appropriate firewall object based on
@@ -38,6 +39,15 @@ module Yast
   class FirewallClass < Module
     def self.create
       SuSEFirewall2Class.new
+    end
+  end
+
+  # ----------------------------------------------------------------------------
+  # SuSEFirewalld Class. Trying to provide relevent pieces of SF2 functionality via
+  # firewalld.
+  class SuSEFirewalldClass < Module
+    include Firewalld
+    def initialize
     end
   end
 

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -828,6 +828,15 @@ module Yast
       nil
     end
 
+    # Function returns whether the feature 'any' network interface is supported.
+    # This is a SF2 specific construct. For firewalld, we simply return false.
+    # We may decide to change this in the future.
+    #
+    # @return boolean false
+    def IsAnyNetworkInterfaceSupported
+      false
+    end
+
   private
 
     def set_zone_modified(zone, zone_params)
@@ -982,6 +991,7 @@ module Yast
     publish function: :IsInterfaceInZone, type: "boolean (string, string)"
     publish function: :GetZonesOfInterfaces, type: "list <string> (list <string>)"
     publish function: :GetZoneFullName, type: "string (string)"
+    publish function: :IsAnyNetworkInterfaceSupported, type: "boolean ()"
   end
 
   # ----------------------------------------------------------------------------

--- a/library/network/src/modules/SuSEFirewallServices.rb
+++ b/library/network/src/modules/SuSEFirewallServices.rb
@@ -157,6 +157,20 @@ module Yast
       @services
     end
 
+    # Sets that configuration was not modified
+    def ResetModified
+      @sfws_modified = false
+
+      nil
+    end
+
+    # Returns whether configuration was modified
+    #
+    # @return [Boolean] modified
+    def GetModified
+      @sfws_modified
+    end
+
     # Create appropriate firewall services class based on factors such as which
     # backend is selected by user or running on the system.
     #
@@ -613,20 +627,6 @@ module Yast
       nil
     end
 
-    # Sets that configuration was not modified
-    def ResetModified
-      @sfws_modified = false
-
-      nil
-    end
-
-    # Returns whether configuration was modified
-    #
-    # @return [Boolean] modified
-    def GetModified
-      @sfws_modified
-    end
-
     # Function returns needed ports allowing broadcast
     #
     # @param [String] service (including the "service:" prefix)
@@ -794,6 +794,9 @@ module Yast
       }
 
       @known_metadata = { "Name" => "name", "Description" => "description" }
+
+      # firewall needs restarting. Always false for firewalld
+      @sfws_modified = false
     end
 
     # Reads services that can be used in FirewallD
@@ -868,6 +871,13 @@ module Yast
       service
     end
 
+    # Sets that configuration was modified
+    def SetModified
+      @sfws_modified = true
+
+      nil
+    end
+
   private
 
     # A good default description for all services. We will use that to
@@ -914,6 +924,9 @@ module Yast
     publish function: :GetDescription, type: "string (string)"
     publish function: :IsKnownService, type: "boolean (string)"
     publish function: :GetNeededPortsAndProtocols, type: "map <string, list <string>> (string)"
+    publish function: :SetModified, type: "void ()"
+    publish function: :ResetModified, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
   end
 
   SuSEFirewallServices = SuSEFirewallServicesClass.create

--- a/library/network/src/modules/SuSEFirewallServices.rb
+++ b/library/network/src/modules/SuSEFirewallServices.rb
@@ -758,6 +758,22 @@ module Yast
   end
 
   class SuSEFirewalldServicesClass < SuSEFirewallServicesClass
+    SERVICES_DIR = ["/etc/firewalld/services", "/usr/lib/firewalld/services"]
+
+    IGNORED_SERVICES = ["..", "."]
+
+    def initialize
+      @services = nil
+
+      @known_services_features = {
+        "TCP"     => "tcp_ports",
+        "UDP"     => "udp_ports",
+        "IP"      => "ip_protocols",
+        "MODULES" => "modules"
+      }
+
+      @known_metadata = { "Name" => "name", "Description" => "description" }
+    end
   end
 
   SuSEFirewallServices = SuSEFirewallServicesClass.create

--- a/library/network/src/modules/SuSEFirewallServices.rb
+++ b/library/network/src/modules/SuSEFirewallServices.rb
@@ -41,6 +41,15 @@ module Yast
   end
 
   class SuSEFirewallServicesClass < Module
+    # Create appropriate firewall services class
+    #
+    # @return SuSEFirewall2ServicesClass or SuSEfirewalldServicesClass instance
+    def self.create
+      SuSEFirewall2ServicesClass.new
+    end
+  end
+
+  class SuSEFirewall2ServicesClass < SuSEFirewallServicesClass
     include Yast::Logger
 
     # this is how services defined by package are distinguished
@@ -748,6 +757,9 @@ module Yast
     publish function: :GetPossiblyConflictServices, type: "list <string> ()"
   end
 
-  SuSEFirewallServices = SuSEFirewallServicesClass.new
-  SuSEFirewallServices.main
+  class SuSEFirewalldServicesClass < SuSEFirewallServicesClass
+  end
+
+  SuSEFirewallServices = SuSEFirewallServicesClass.create
+  SuSEFirewallServices.main if SuSEFirewallServices.is_a?(SuSEFirewall2ServicesClass)
 end

--- a/library/network/test/Makefile.am
+++ b/library/network/test/Makefile.am
@@ -4,7 +4,8 @@ TESTS = \
   network_service_test.rb \
   susefirewall_proposal_test.rb \
   susefirewall_services_test.rb \
-  susefirewall_test.rb
+  susefirewall_test.rb \
+  susefirewalld_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/library/network/test/susefirewall_test.rb
+++ b/library/network/test/susefirewall_test.rb
@@ -111,7 +111,7 @@ describe Yast::SuSEFirewall do
       subject.main # Resets module configuration
 
       allow(Yast::FileUtils).to receive(:Exists)
-        .with(Yast::SuSEFirewallClass::CONFIG_FILE)
+        .with(Yast::SuSEFirewall2Class::CONFIG_FILE)
         .and_return(package_installed)
       allow(subject).to receive(:SuSEFirewallIsInstalled)
         .and_return(config_exists)

--- a/library/network/test/susefirewall_test.rb
+++ b/library/network/test/susefirewall_test.rb
@@ -9,10 +9,15 @@ Yast.import "SuSEFirewall"
 Yast.import "Stage"
 
 def reset_SuSEFirewallIsInstalled_cache
-  Yast::SuSEFirewall.needed_packages_installed = nil
+  FakeFirewall.needed_packages_installed = nil
 end
 
-describe Yast::SuSEFirewall do
+# Instantiate an SF2 object
+FakeFirewall = Yast::FirewallClass.create(:sf2)
+FakeFirewall.main
+
+describe FakeFirewall do
+
   describe "#SuSEFirewallIsInstalled" do
     before(:each) do
       reset_SuSEFirewallIsInstalled_cache
@@ -28,11 +33,11 @@ describe Yast::SuSEFirewall do
         expect(Yast::PackageSystem).to receive(:Installed).and_return(false, true).twice
 
         # Selected
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
         # Not selected and not installed
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
         # Not selected, but installed
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
       end
     end
 
@@ -44,15 +49,15 @@ describe Yast::SuSEFirewall do
         # Value is cached
         expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages).and_return(true, false).twice
 
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
 
         reset_SuSEFirewallIsInstalled_cache
 
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
       end
     end
 
@@ -64,25 +69,25 @@ describe Yast::SuSEFirewall do
         # Value is cached
         expect(Yast::PackageSystem).to receive(:Installed).and_return(false, true).twice
 
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
 
         reset_SuSEFirewallIsInstalled_cache
 
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
-        expect(Yast::SuSEFirewall.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
       end
     end
   end
 
   describe "#full_init_on_boot" do
     it "sets whether SuSEfirewall2_init should do the full init on boot and returns the current state" do
-      expect(Yast::SuSEFirewall.full_init_on_boot(true)).to eq(true)
-      expect(Yast::SuSEFirewall.GetModified()).to eq(true)
-      expect(Yast::SuSEFirewall.full_init_on_boot(false)).to eq(false)
-      expect(Yast::SuSEFirewall.GetModified()).to eq(true)
+      expect(subject.full_init_on_boot(true)).to eq(true)
+      expect(subject.GetModified()).to eq(true)
+      expect(subject.full_init_on_boot(false)).to eq(false)
+      expect(subject.GetModified()).to eq(true)
     end
   end
 

--- a/library/network/test/susefirewalld_test.rb
+++ b/library/network/test/susefirewalld_test.rb
@@ -1,0 +1,394 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "network/firewalld"
+
+Yast.import "Mode"
+Yast.import "PackageSystem"
+Yast.import "Pkg"
+Yast.import "SuSEFirewall"
+Yast.import "SuSEFirewallServices"
+Yast.import "Stage"
+
+def reset_FirewallDIsInstalled_cache
+  FakeFirewallD.needed_packages_installed = nil
+end
+
+# A few notes: FirewallD requires a running backend before it attempts to make
+# any firewall changes. But since this is a testsuite, we shouldn't mess with
+# the running system so we need to mock a lot of the API functions and trust we
+# the API does its job. However, you can set the 'need_API_mock' variable to
+# false to bypass mocking and use the real API. This will break your firewall
+# etc so make sure you understand the risks. Moreover, mocking the API has the
+# advantage of being able to run this testsuite even when SF2 is running!
+need_API_mock = true
+
+# Re-instansiate our objects
+FakeFirewallD = Yast::FirewallClass.create(:fwd)
+
+describe FakeFirewallD do
+
+  describe "#SuSEFirewallIsInstalled" do
+    before do
+      reset_FirewallDIsInstalled_cache
+    end
+
+    context "while in inst-sys" do
+      it "returns whether FirewallD is selected for installation or already installed" do
+        expect(Yast::Stage).to receive(:stage).and_return("initial").at_least(:once)
+
+        # Value is not cached
+        expect(Yast::Pkg).to receive(:IsSelected).and_return(true, false, false).exactly(3).times
+        # Fallback: if not selected, checks whether the package is installed
+        expect(Yast::PackageSystem).to receive(:Installed).and_return(false, true).twice
+
+        # Selected
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+        # Not selected and not installed
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+        # Not selected, but installed
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+      end
+    end
+
+    context "while on a running system (normal configuration)" do
+      it "returns whether FirewallD was or could have been installed" do
+        expect(Yast::Stage).to receive(:stage).and_return("normal").at_least(:once)
+        expect(Yast::Mode).to receive(:mode).and_return("normal").at_least(:once)
+
+        expect(Yast::PackageSystem).to receive(:CheckAndInstallPackages).and_return(true, false)
+        # Start fresh
+        reset_FirewallDIsInstalled_cache
+        # Install it
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+        # Start fresh
+        reset_FirewallDIsInstalled_cache
+        # Do not install it
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+      end
+    end
+
+    context "while in AutoYast config" do
+      it "returns whether FirewallD is installed" do
+        expect(Yast::Stage).to receive(:stage).and_return("normal").at_least(:once)
+        expect(Yast::Mode).to receive(:mode).and_return("autoinst_config").at_least(:once)
+
+        expect(Yast::PackageSystem).to receive(:Installed).and_return(false, true)
+
+        # Start fresh
+        reset_FirewallDIsInstalled_cache
+        # Do not istall it
+        expect(subject.SuSEFirewallIsInstalled).to eq(false)
+        # Start fresh
+        reset_FirewallDIsInstalled_cache
+        # Install it
+        expect(subject.SuSEFirewallIsInstalled).to eq(true)
+      end
+    end
+  end
+
+  describe "#FirewallD" do
+
+    before(:example) do
+      # Need a consistent view of the system interfaces.
+      allow(Yast::NetworkInterfaces).to receive(:List) { ["eth0", "eth1", "eth2", "eth3", "eth4", "lo"] }
+      if need_API_mock
+        # Do not read the system rules. This also prevents backend from starting
+        allow(subject).to receive(:Read)
+        # Do not attempt to write anything
+        allow(subject).to receive(:Write)
+        # Fake a running backend
+        allow(subject).to receive(:IsStarted) { true }
+        allow(subject).to receive(:StartServices)
+        # Add some well-known services that we will use throughout this
+        # testsuite
+        allow(subject.api).to receive(:services)
+          .and_return(["dns", "ftp", "ldap", "ntp", "ssh"])
+        allow(subject.api).to receive(:service_supported?) { false }
+        allow(subject.api).to receive(:service_supported?).with("dns") { true }
+        allow(subject.api).to receive(:service_supported?).with("ftp") { true }
+        allow(subject.api).to receive(:service_supported?).with("ldap") { true }
+        allow(subject.api).to receive(:service_supported?).with("ntp") { true }
+        allow(subject.api).to receive(:service_supported?).with("ssh") { true }
+        allow(subject.api).to receive(:service_supported?).with("telnet") { true }
+        # Remember. Yast::SuSEFirewallServices may still think that the
+        # running backend is SF2 so fake some methods.
+        # We use the ssh, ntp, ftp, ldap, telnet, dns so support them
+        allow(Yast::SuSEFirewallServices).to receive(:GetSupportedServices)
+          .and_return("dns"    => "The dns",
+                      "ftp"    => "The ftp",
+                      "ldap"   => "The ldap",
+                      "ntp"    => "The ntp",
+                      "ssh"    => "The ssh",
+                      "telnet" => "The telnet")
+        allow(Yast::SuSEFirewallServices).to receive(:service_details).with("ftp")
+          .and_return("tcp_ports" => ["21"])
+        allow(Yast::SuSEFirewallServices).to receive(:service_details).with("dns")
+          .and_return("tcp_ports" => ["53"], "udp_ports" => ["53"])
+        allow(Yast::SuSEFirewallServices).to receive(:service_details).with("ldap")
+          .and_return("tcp_ports" => ["389"])
+        allow(Yast::SuSEFirewallServices).to receive(:service_details).with("ntp")
+          .and_return("tcp_ports" => ["123"])
+        allow(Yast::SuSEFirewallServices).to receive(:service_details).with("ssh")
+          .and_return("tcp_ports" => ["22"])
+        allow(Yast::SuSEFirewallServices).to receive(:service_details).with("telnet")
+          .and_return("tcp_ports" => ["23"])
+      end
+    end
+
+    GOOD_FAKE_FIREWALLD_CONFIG = {
+      "logging"         => "off",
+      "start_firewall"  => true,
+      "enable_firewall" => true,
+      "external"        => {
+        masquerade: true,
+        interfaces: ["eth0", "eth1"],
+        services:   ["ssh"],
+        ports:      ["999/tcp", "1010/udp"]
+      },
+      "public"          => {
+        masquerade: false,
+        interfaces: ["eth2"],
+        services:   ["dns"],
+        protocols:  ["ah"]
+      }
+    }
+
+    BAD_FAKE_FIREWALLD_CONFIG = {
+      "dmz"     => {
+        invalid_setting: true
+      },
+      "foozone" => {
+        masquerade: true,
+        services:   ["foobar"],
+        interfaces: ["eth3"]
+      }
+    }
+    FULL_FAKE_FIREWALLD_CONFIG = GOOD_FAKE_FIREWALLD_CONFIG.merge(BAD_FAKE_FIREWALLD_CONFIG)
+
+    context "when verifying its basic configuration" do
+
+      it "has 'firewalld' in the FIREWALL_PACKAGE variable" do
+        expect(subject.FIREWALL_PACKAGE).to eq("firewalld")
+      end
+      it "has its API backend set" do
+        expect(subject.api).not_to be nil
+      end
+    end
+
+    context "given a known configuration" do
+      it "can import it and export it" do
+        expect(subject.Import(FULL_FAKE_FIREWALLD_CONFIG)).to be nil
+        good_config = Yast.deep_copy(GOOD_FAKE_FIREWALLD_CONFIG)
+        GOOD_FAKE_FIREWALLD_CONFIG.keys.each do |key|
+          next unless subject.GetKnownFirewallZones().include?(key)
+          good_config[key] = Yast::SuSEFirewalldClass::EMPTY_ZONE.merge(good_config[key])
+          # When importing configuration we consider all zone attributes as
+          # dirty
+          good_config[key][:modified] = [:interfaces, :masquerade, :ports, :protocols, :services]
+        end
+        expect(subject.Export).to include(good_config)
+      end
+
+      it "it does not propagate invalid settings to internal data structures" do
+        expect(subject.Export).not_to include(BAD_FAKE_FIREWALLD_CONFIG)
+      end
+
+      it "does not support the IsAnyNetworkInterfaceSupported method" do
+        expect(subject.IsAnyNetworkInterfaceSupported).to be false
+      end
+
+      it "does not support the GetProtectFromInternalZone method" do
+        expect(subject.IsAnyNetworkInterfaceSupported).to be false
+      end
+
+      it "the 'public' zone is a known one" do
+        expect(subject.IsKnownZone("public")).to be true
+        known_zones = subject.GetKnownFirewallZones
+        expect(known_zones.include?("public")).to be true
+      end
+
+      it "the '__foobarme__' zone is not a known one" do
+        expect(subject.IsKnownZone("__foobarme__")).to be false
+        known_zones = subject.GetKnownFirewallZones
+        expect(known_zones.include?("__foobarme__")).to be false
+      end
+
+      it "knows the SF2 EXT zone is the 'external' one in FirewallD" do
+        expect(subject.sf2_to_firewalld_zone("EXT")).to eq("external")
+      end
+
+      it "knows that 'dmz' means 'Demilitarized Zone'" do
+        expect(subject.GetZoneFullName("dmz")).to eq("Demilitarized Zone")
+      end
+
+      it "it does not propagate invalid settings to internal data structures" do
+        expect(subject.Export).not_to include(BAD_FAKE_FIREWALLD_CONFIG)
+      end
+
+      it "can set the masquerade to 'public' zone" do
+        expect(subject.SetMasquerade(true, "public")).to be nil
+        expect(subject.GetMasquerade("public")).to be true
+      end
+
+      it "can disable the masquerade to 'dmz' zone" do
+        expect(subject.SetMasquerade(false, "dmz")).to be nil
+        expect(subject.GetMasquerade("dmz")).to be false
+      end
+
+      it "can enable and disable masquerade on every zone" do
+        expect(subject.SetMasquerade(true)).to be nil
+        expect(subject.GetMasquerade).to be true
+        expect(subject.SetMasquerade(false)).to be nil
+        expect(subject.GetMasquerade).to be false
+      end
+
+      it "can retrieve existing services in a zone" do
+        expect(subject.GetAllowedServicesForZoneProto("external", "tcp")).to eq(["999", "ssh"])
+        expect(subject.GetAllowedServicesForZoneProto("external", "udp")).to eq(["1010"])
+      end
+
+      it "can set the 'ssh' service to an 'external' zone interface" do
+        expect(subject.SetServices(["ssh"], ["eth0"], true)).to be nil
+        # A bit complex because the return value is of the form
+        # ["ssh" => { zone1 => status, zone2 => status etc }]
+        expect(subject.GetServices(["ssh"])["ssh"]).to include("external" => true)
+        expect(subject.IsServiceSupportedInZone("ssh", "external")).to be true
+        expect(subject.GetServicesInZones(["ssh"])["ssh"]).to include("eth0" => true, "eth1" => true)
+        expect(subject.GetAllowedServicesForZoneProto("external", "tcp")).to eq(["999", "ssh"])
+      end
+
+      it "can set the 'service:ntp' to an 'external' zone interface" do
+        expect(subject.SetServices(["service:ntp"], ["eth1"], true)).to be nil
+        expect(subject.GetServices(["service:ntp"])["service:ntp"]).to include("external" => true)
+        expect(subject.IsServiceSupportedInZone("service:ntp", "external")).to be true
+        expect(subject.GetServicesInZones(["service:ntp"])["service:ntp"]).to include("eth0" => true, "eth1" => true)
+      end
+
+      it "can set multiple services to an 'external' zone interface" do
+        expect(subject.SetServices(["service:ftp", "ldap"], ["eth0", "eth1"], true)).to be nil
+        expect(subject.GetServices(["service:ftp"])["service:ftp"]).to include("external" => true)
+        expect(subject.GetServices(["ldap"])["ldap"]).to include("external" => true)
+        expect(subject.GetServicesInZones(["service:ftp"])["service:ftp"]).to \
+          eq("eth0" => true, "eth1" => true, "eth2" => false)
+      end
+
+      it "can remove the 'service:ntp' from an 'external' zone interface" do
+        expect(subject.SetServices(["service:ntp"], ["eth1"], false)).to be nil
+        expect(subject.GetServices(["service:ntp"])["service:ntp"]).to include("external" => false)
+        expect(subject.IsServiceSupportedInZone("service:ntp", "external")).to be false
+        expect(subject.GetServicesInZones(["service:ntp"])["service:ntp"]).to \
+          eq("eth0" => false, "eth1" => false, "eth2" => false)
+      end
+
+      it "can add the 'service:ntp' to the 'external' zone" do
+        expect(subject.SetServicesForZones(["service:ntp"], ["external"], true)).to be nil
+        expect(subject.GetServicesInZones(["service:ntp"])["service:ntp"]).to \
+          eq("eth0" => true, "eth1" => true, "eth2" => false)
+      end
+
+      it "can use {Add,Remove}Service methods to manage services" do
+        expect(subject.AddService("telnet", "TCP", "external")).to be true
+        expect(subject.HaveService("telnet", "TCP", "external")).to be true
+        expect(subject.RemoveService("telnet", "TCP", "external")).to be true
+        expect(subject.HaveService("telnet", "TCP", "external")).to be false
+      end
+
+      it "refuses to set service to a non-existing interface" do
+        expect(subject.SetServices(["dns"], ["ethfoobar"], true)).to be nil
+      end
+      it "refuses to set an invalid service to a zone" do
+        # mock a running backend
+        expect { subject.SetServices(["foobar"], ["eth0"], true) }.to raise_exception(
+          Yast::SuSEFirewalServiceNotFound, /Service with name/)
+      end
+
+      it "knows about all the new TCP services a zone" do
+        # This should not contain ssh, ftp and ldap since these are
+        # known services
+        expect(subject.GetAdditionalServices("tcp", "external").sort).to \
+          eq(["999"].sort)
+      end
+
+      it "knows about the IP protocols in a zone" do
+        expect(subject.GetAdditionalServices("ip", "public")).to eq(["ah"])
+      end
+
+      it "adds new ports/protocols services in a zone" do
+        expect(subject.SetAdditionalServices("tcp", "public", ["1234"])).to be nil
+        # DNS is a known service so it should not make it to the list
+        # Ditto for the rest of these examples
+        expect(subject.GetAdditionalServices("tcp", "public").sort).to \
+          eq(["1234"].sort)
+      end
+      it "can set new ports/protocols overwriting the existing ones" do
+        expect(subject.SetAdditionalServices("tcp", "public", ["5678"])).to be nil
+        expect(subject.GetAdditionalServices("tcp", "public").sort).to \
+          eq(["5678"])
+      end
+      it "can set ranges of ports" do
+        expect(subject.SetAdditionalServices("tcp", "public", ["1234-5678"])).to be nil
+        expect(subject.GetAdditionalServices("tcp", "public").sort).to \
+          eq(["1234-5678"].sort)
+      end
+      it "can set a UDP port without losing TCP port states" do
+        expect(subject.SetAdditionalServices("udp", "public", ["53"])).to be nil
+        expect(subject.GetAdditionalServices("udp", "public").sort).to \
+          eq(["53"].sort)
+        # Here we check that UDP additions do not overwrite TCP and vice
+        # versa
+        expect(subject.SetAdditionalServices("tcp", "public", ["1234-5678"])).to be nil
+        expect(subject.GetAdditionalServices("tcp", "public").sort).to \
+          eq(["1234-5678"].sort)
+      end
+
+      it "add SF2 style port ranges in a zone" do
+        expect(subject.SetAdditionalServices("tcp", "public", ["1234:5678"])).to be nil
+        expect(subject.GetAdditionalServices("tcp", "public").sort).to \
+          eq(["1234-5678"].sort)
+      end
+
+      it "adds an existing interface to zone" do
+        expect(subject.AddInterfaceIntoZone("eth4", "external")).to be nil
+        expect(subject.GetInterfacesInZone("external")). to eq(["eth0", "eth1", "eth4"])
+      end
+
+      it "adds an existing interface to zone and removes it from the other zones" do
+        expect(subject.AddInterfaceIntoZone("eth2", "dmz")).to be nil
+        expect(subject.GetInterfacesInZone("dmz")).to eq(["eth2"])
+        expect(subject.GetInterfacesInZone("public")).to eq([])
+      end
+
+      it "can remove an existing interface from zone" do
+        expect(subject.RemoveInterfaceFromZone("eth2", "dmz")).to be nil
+        expect(subject.GetInterfacesInZone("dmz")).to eq([])
+      end
+
+      it "adds a special interfaces to zone" do
+        expect(subject.AddSpecialInterfaceIntoZone("tun+", "dmz")).to be nil
+        expect(subject.GetSpecialInterfacesInZone("dmz")).to include("tun+")
+      end
+
+      it "refuses to add interfaces to a non-existing zone" do
+        expect(subject.AddInterfaceIntoZone("eth2", "nogoodzone")).to be nil
+        expect(subject.GetInterfacesInZone("nogoodzone")).to eq([])
+      end
+
+      it "can understand SF2-like logging" do
+        expect(subject.SetLoggingSettings("ACCEPT", "__DOES_NOT_MATTER__")).to be nil
+        expect(subject.GetLoggingSettings("ACCEPT")).to be false
+        expect(subject.SetLoggingSettings("DROP", "CRIT")).to be nil
+        expect(subject.GetLoggingSettings("DROP")).to eq("CRIT")
+        expect(subject.SetLoggingSettings("DROP", "NONE")).to be nil
+        expect(subject.GetLoggingSettings("DROP")).to eq("NONE")
+        expect(subject.SetLoggingSettings("DROP", "ALL")).to be nil
+        expect(subject.GetLoggingSettings("DROP")).to eq("ALL")
+      end
+
+      it "can enable broadcast logging" do
+        expect(subject.SetIgnoreLoggingBroadcast(nil, "yes")).to be nil
+        expect(subject.GetIgnoreLoggingBroadcast(nil)).to eq("yes")
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu May 19 13:16:28 UTC 2016 - mchandras@suse.de
+
+- Refactor SuSEFirewall backend code to support FirewallD. This allows
+  yast2 modules to be firewall agnostic and handle firewall services in
+  either SuSEFirewall2 or FirewallD (fate#318356, gh#yast/yast-yast2#457)
+  * Do a bit of code cleanup.
+  * Add FirewallD tests.
+- 3.1.190
+
+-------------------------------------------------------------------
 Wed May 18 09:15:04 UTC 2016 - mfilka@suse.com
 
 - bnc#972575

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.189
+Version:        3.1.190
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Hi,

This patchset extends the SuSEFirewall2 backend with FirewallD ([website](http://www.firewalld.org/), [OBS package](https://build.opensuse.org/package/show/openSUSE:Factory/firewalld)) support. The goal is for yast2 modules to be able to use either SuSEfirewall2 or FirewallD to perform their regular firewall configurations depending on which one is running on the system. Not all methods have been added to FirewallD since some of them do not appear to be used anymore. If something is missing I will fix it in a subsequent commit as bugs or limitations are being identified by the broader adoption and use of the extended API.

The only known limitation so far is in the testsuite where firewalld tests can't run in parallel with SuSEfirewall2. The reason for that is that they both manipulate the Yast::SuSEFirewall and Yast::SuSEFirewallServices objects so if these tests run in parallel strange things can happen ;) The solution so far is to disable either SuSEfirewall2 or FirewallD tests based on which backend is running as I couldn't find a way to disable parallelism on library/network/test/* files. I believe that using "doubles" or using rspec mock to fake methods is not going to actually tests the backend properly so the testsuite will end up being mostly useless. If you happen to know of the proper way to disable parallelism in a specific subdir please let me know. In the meantime I didn't want to delay the PR because of that as I want to get some broader testing of the extended code.

Thank you