### PR TITLE
Make the "Abort" button default in the file conflict popup

### DIFF
--- a/library/packages/src/lib/packages/file_conflict_callbacks.rb
+++ b/library/packages/src/lib/packages/file_conflict_callbacks.rb
@@ -137,7 +137,6 @@ module Packages
         Yast::UI.OpenDialog(dialog(conflicts))
 
         begin
-          Yast::UI.SetFocus(Id(:continue))
           ret = Yast::UI.UserInput
           log.info "User Input: #{ret}"
           ret == :continue
@@ -161,8 +160,8 @@ module Packages
       # @return [Term] UI term
       def dialog(conflicts)
         button_box = ButtonBox(
-          PushButton(Id(:continue), Opt(:default, :okButton), Yast::Label.ContinueButton),
-          PushButton(Id(:abort), Opt(:cancelButton), Yast::Label.AbortButton)
+          PushButton(Id(:continue), Opt(:okButton), Yast::Label.ContinueButton),
+          PushButton(Id(:abort), Opt(:default, :cancelButton), Yast::Label.AbortButton)
         )
 
         # TRANSLATORS: A popup label, use max. 70 chars per line, use more lines if needed

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 11 07:55:44 UTC 2016 - lslezak@suse.cz
+
+- Make the "Abort" button default in the file conflict popup
+  (safe default compatible with zypper) (bsc#923590)
+- 3.1.184
+
+-------------------------------------------------------------------
 Mon Apr  4 14:36:18 CEST 2016 - schubi@suse.de
 
 - Added system_time to ylib_DATA.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.183
+Version:        3.1.184
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
Discussed with Ken, the reasons for the change are:

- Safe default
- Compatible with zypper

### Screenshot

![file_conflicts_default_abort](https://cloud.githubusercontent.com/assets/907998/14420735/faa2bb1a-ffcd-11e5-8c59-5b85aa3ed46a.png)
