### PR TITLE
Link to docs for Cheetah.run

### DIFF
--- a/library/system/src/lib/yast2/execute.rb
+++ b/library/system/src/lib/yast2/execute.rb
@@ -36,7 +36,7 @@ module Yast
     textdomain "base"
 
     # Runs arguments with respect of changed root in installation.
-    # @see Cheetah.run for parameters
+    # @see http://www.rubydoc.info/github/openSUSE/cheetah/Cheetah.run parameter docs
     # @raise Cheetah::ExecutionFailed
     def self.on_target(*args)
       root = "/"
@@ -52,7 +52,7 @@ module Yast
     end
 
     # Runs arguments without changed root.
-    # @see Cheetah.run for parameters
+    # @see http://www.rubydoc.info/github/openSUSE/cheetah/Cheetah.run parameter docs
     # @raise Cheetah::ExecutionFailed
     def self.locally(*args)
       popup_error { Cheetah.run(*args) }


### PR DESCRIPTION
Use a full URL so that YARD can make a link in the rendered docs.
It is especially important because Cheetah.run takes a great variety of
arguments.