### PR TITLE
Fix "when" key in FinishClient#info

### DIFF
--- a/library/general/src/lib/installation/finish_client.rb
+++ b/library/general/src/lib/installation/finish_client.rb
@@ -90,7 +90,7 @@ module Installation
     # Adapt the metadata for inst_finish API
     def info
       {
-        "when " => modes,
+        "when"  => modes,
         "steps" => steps,
         "title" => title
       }

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Mon May  9 10:24:27 UTC 2016 - igonzalezsosa@suse.com
+
+- Fix "when" key in FinishClient#info
+
+-------------------------------------------------------------------
 Fri Apr 22 14:37:28 UTC 2016 - knut.anderssen@suse.com
 
 - Added restarting state to Installation to for example recover


### PR DESCRIPTION
Fixes "when" key in FinishClient#info.

I'm not releasing a new version (I'll do that as part of the #465 PR).