### PR TITLE
Fixed displaying the file conflicts callbacks (bsc#983464)

### DIFF
--- a/library/packages/src/lib/packages/file_conflict_callbacks.rb
+++ b/library/packages/src/lib/packages/file_conflict_callbacks.rb
@@ -37,6 +37,7 @@ module Packages
         Yast.import "Report"
         Yast.import "Label"
         Yast.import "PackageCallbacks"
+        Yast.import "Wizard"
 
         textdomain "base"
 
@@ -83,6 +84,7 @@ module Packages
           Yast::UI.ChangeWidget(Id(PKG_INSTALL_WIDGET), :Value, 0)
           Yast::UI.ChangeWidget(Id(PKG_INSTALL_WIDGET), :Label, label)
         else
+          Yast::Wizard.CreateDialog
           # TRANSLATORS: help text for the file conflict detection progress
           help = _("<p>Detecting the file conflicts is in progress.</p>")
           # Use the same label for the window title and the progressbar label
@@ -148,10 +150,11 @@ module Packages
       # Handle the file conflict detection finish callback.
       def finish
         log.info "File conflict check finished"
-        return if Yast::Mode.commandline
+        return if Yast::Mode.commandline || pkg_installation?
 
         # finish the opened progress dialog
-        Yast::Progress.Finish unless pkg_installation?
+        Yast::Progress.Finish
+        Yast::Wizard.CloseDialog
       end
 
       # Construct the file conflicts dialog.

--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -80,6 +80,7 @@ describe Packages::FileConflictCallbacks do
 
       it "opens a new progress if installation progress was not displayed" do
         expect(Yast::UI).to receive(:WidgetExists).and_return(false)
+        expect(Yast::Wizard).to receive(:CreateDialog)
         expect(Yast::Progress).to receive(:Simple)
 
         start_cb.call
@@ -287,7 +288,8 @@ describe Packages::FileConflictCallbacks do
       end
 
       it "closes progress if installation progress was not displayed" do
-        expect(Yast::UI).to receive(:WidgetExists).and_return(false)
+        allow(Yast::UI).to receive(:WidgetExists).and_return(false)
+        expect(Yast::Wizard).to receive(:CloseDialog)
         expect(Yast::Progress).to receive(:Finish)
 
         finish_cb.call

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  8 12:13:16 UTC 2016 - lslezak@suse.cz
+
+- Fixed displaying the file conflicts callbacks when the Progress
+  dialog is not displayed (bsc#983464)
+- 3.1.193
+
+-------------------------------------------------------------------
 Thu Jun  2 10:29:34 UTC 2016 - igonzalezsosa@suse.com
 
 - Drop yast2-devel-doc package (fate#320356)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.192
+Version:        3.1.193
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
...when the Progress dialog is not displayed.

Open a new Wizard window and close it at the end, this ensures the original dialog content is restored after finishing the callbacks.

- 3.1.193