### PR TITLE
Do not crash if subscription-tools.rpm is missing.

### DIFF
--- a/library/control/src/modules/ProductProfile.rb
+++ b/library/control/src/modules/ProductProfile.rb
@@ -160,7 +160,7 @@ module Yast
         # YaPI::SubscriptionTools are only available for SLES
         Yast.import "YaPI::SubscriptionTools"
       rescue NameError
-        y2milestone("subscription-tools package not present: no compliance checking")
+        Builtins.y2milestone("subscription-tools package not present: no compliance checking")
         return true
       end
 


### PR DESCRIPTION
BTW the package lives in
https://build.opensuse.org/package/show/SUSE:SLE-12:GA/subscription-tools

This is the first real bug I've found with ruby-lint, after thousands of
false positives!!

I was looking why it was not seeing the Pkg namespace as it should, and
noticed a real problem in the last line:

$ ruby-lint -p text library/control/src/modules/ProductProfile.rb
ProductProfile.rb: error: line 52, column 18: undefined constant Pkg
ProductProfile.rb: error: line 64, column 17: undefined constant Pkg
ProductProfile.rb: error: line 81, column 33: undefined method tmpdir on an instance of DirectoryClass
ProductProfile.rb: error: line 86, column 24: undefined constant Pkg
ProductProfile.rb: error: line 95, column 19: undefined constant Pkg
ProductProfile.rb: error: line 138, column 21: undefined constant YaPI
ProductProfile.rb: error: line 138, column 21: undefined constant YaPI::SubscriptionTools
ProductProfile.rb: error: line 163, column 9: undefined method y2milestone