### PR TITLE
Use a high resolution window icon (64x64) (bsc#985432)

### DIFF
--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -65,7 +65,7 @@ module Yast
       @relnotes_button_id = ""
 
       @icon_dir = File.join(Directory.themedir, "current", "icons",
-        "22x22", "apps")
+        "64x64", "apps")
       @icon_name = "yast"
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun 22 08:39:50 UTC 2016 - lslezak@suse.cz
+
+- Use a high resolution window icon (64x64) instead of the low
+  resolution (22x22) one (bsc#985432)
+- 3.1.194
+
+-------------------------------------------------------------------
 Wed Jun  8 12:13:16 UTC 2016 - lslezak@suse.cz
 
 - Fixed displaying the file conflicts callbacks when the Progress

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.193
+Version:        3.1.194
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
...instead of the low resolution (22x22) one.

The standalone icon does not look that bad, but when comparing it with the other applications it looks awful, see this screenshot from [bug 985432](https://bugzilla.suse.com/show_bug.cgi?id=985432):

![](https://bugzilla.suse.com/attachment.cgi?id=681204)

## Screenshots

I have tested the fix using the Plasma 5 window switcher, the look obviously depends on the configured style.

### The Original Look

This is the original 22x22 icon, it looks a bit fuzzy without much details:

![yast_lowres_icon](https://cloud.githubusercontent.com/assets/907998/16260189/8fd03552-3866-11e6-8fd6-2aa48b8d70b0.png)


### The New Look

The new 64x64 icon is more sharp with more details:

![yast_hires_icon](https://cloud.githubusercontent.com/assets/907998/16260201/98b7a344-3866-11e6-8604-a91b3265b262.png)
