### PR TITLE
Define Arch.arm

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -65,7 +65,7 @@ module Yast
     # ************************************************************
     # system architecture
 
-    # Returns full architecture type (one of i386, sparc, sparc64, ppc, ppc64, alpha, s390_32, s390_64, ia64, x86_64, aarch64)
+    # Returns full architecture type (one of i386, sparc, sparc64, ppc, ppc64, alpha, s390_32, s390_64, ia64, x86_64, arm, aarch64)
     #
     # @return [String] architecture
     def architecture
@@ -160,12 +160,17 @@ module Yast
       architecture == "x86_64"
     end
 
+    # true for all 32-bit ARM architectures
+    def arm
+      architecture == "arm"
+    end
+
     # true for all aarch64 (ARM64) architectures
     def aarch64
       architecture == "aarch64"
     end
 
-    # Returns general architecture type (one of sparc, ppc, s390, i386, alpha, ia64, x86_64, aarch64)
+    # Returns general architecture type (one of sparc, ppc, s390, i386, alpha, ia64, x86_64, arm, aarch64)
     #
     # @return [String] arch_short
     def arch_short
@@ -512,6 +517,7 @@ module Yast
     publish function: :s390, type: "boolean ()"
     publish function: :ia64, type: "boolean ()"
     publish function: :x86_64, type: "boolean ()"
+    publish function: :arm, type: "boolean ()"
     publish function: :aarch64, type: "boolean ()"
     publish function: :arch_short, type: "string ()"
     publish function: :board_mac, type: "boolean ()"


### PR DESCRIPTION
So far only Arch.aarch64 existed but no 32-bit equivalent.

Will be needed for further yast-bootloader changes.

Signed-off-by: Andreas Färber <afaerber@suse.de>