### PR TITLE
Fix cd/dvd URLs reassembling

### DIFF
--- a/library/types/src/modules/URL.rb
+++ b/library/types/src/modules/URL.rb
@@ -274,6 +274,10 @@ module Yast
           Ops.set(tokens, "domain", Ops.get(options, "workgroup", ""))
         end
       end
+
+      # merge host and path if the scheme does not allow a host (bsc#991935)
+      tokens = merge_host_and_path(tokens) if SCHEMES_WO_HOST.include?(tokens["scheme"].downcase)
+
       Builtins.y2debug("tokens=%1", tokens)
       deep_copy(tokens)
     end
@@ -368,7 +372,7 @@ module Yast
         userpass = Ops.add(userpass, "@")
       end
 
-      url = Builtins.sformat("%1:#{scheme_separator(tokens["scheme"])}%2", url, userpass)
+      url = Builtins.sformat("%1://%2", url, userpass)
       Builtins.y2debug("url: %1", url)
 
       if Hostname.CheckFQ(Ops.get_string(tokens, "host", "")) ||
@@ -651,19 +655,26 @@ module Yast
 
   private
 
-    # Schemes which should use a single slash.
-    # see #schema_separator
-    SINGLE_SLASH_SCHEMES = ["cd", "dvd"].freeze
+    # Schemes which should not include a host.
+    # @see #merge_host_and_path
+    SCHEMES_WO_HOST = ["cd", "dvd"].freeze
 
-    # Returns the separator to be used given a scheme
+    # Merges host and path tokens
     #
-    # Schemes like 'cd' or 'dvd' should used a single '/' character to separate
-    # the <scheme> and the <scheme-specific-part> (bsc#991935)
+    # In schemes like 'cd' or 'dvd' the host part is not allowed.
+    # It leads to conversions like: "cd:/?device=/dev/sr0" to "cd://?device=/dev/sr0"
+    # or "cd:/info" to "cd://info".
     #
-    # @param scheme [String] URI scheme
-    # @return [String] Separator to be used
-    def scheme_separator(scheme)
-      SINGLE_SLASH_SCHEMES.include?(scheme.downcase) ? "/" : "//"
+    # If no host or path are specified, the path is set to "/".
+    #
+    # @param  [Hash<String,String>] URL tokens
+    # @return [Hash<String,String>] URL tokens with host and path merged
+    def merge_host_and_path(tokens)
+      parts = [tokens["host"], tokens["path"]].reject(&:empty?)
+      tokens.merge(
+        "path" => File.join("/", *parts),
+        "host" => ""
+      )
     end
   end
 

--- a/library/types/src/modules/URL.rb
+++ b/library/types/src/modules/URL.rb
@@ -368,7 +368,7 @@ module Yast
         userpass = Ops.add(userpass, "@")
       end
 
-      url = Builtins.sformat("%1://%2", url, userpass)
+      url = Builtins.sformat("%1:#{scheme_separator(tokens["scheme"])}%2", url, userpass)
       Builtins.y2debug("url: %1", url)
 
       if Hostname.CheckFQ(Ops.get_string(tokens, "host", "")) ||
@@ -648,6 +648,23 @@ module Yast
     publish function: :FormatURL, type: "string (map, integer)"
     publish function: :HidePassword, type: "string (string)"
     publish function: :HidePasswordToken, type: "map (map)"
+
+  private
+
+    # Schemes which should use a single slash.
+    # see #schema_separator
+    SINGLE_SLASH_SCHEMES = ["cd", "dvd"].freeze
+
+    # Returns the separator to be used given a scheme
+    #
+    # Schemes like 'cd' or 'dvd' should used a single '/' character to separate
+    # the <scheme> and the <scheme-specific-part> (bsc#991935)
+    #
+    # @param scheme [String] URI scheme
+    # @return [String] Separator to be used
+    def scheme_separator(scheme)
+      SINGLE_SLASH_SCHEMES.include?(scheme.downcase) ? "/" : "//"
+    end
   end
 
   URL = URLClass.new

--- a/library/types/test/Makefile.am
+++ b/library/types/test/Makefile.am
@@ -2,6 +2,7 @@ TESTS = \
   ip_test.rb \
   ipv4_netmask_test.rb \
   hostname_test.rb \
+  url_test.rb \
   string_test.rb
 
 TEST_EXTENSIONS = .rb

--- a/library/types/test/url_test.rb
+++ b/library/types/test/url_test.rb
@@ -138,10 +138,8 @@ describe Yast::URL do
     }.freeze
 
     URLS.each do |url, rebuilt|
-      context "given #{url}" do
-        it "returns #{rebuilt}" do
-          expect(subject.Build(subject.Parse(url))).to eq(rebuilt)
-        end
+      it "returns '#{rebuilt}' for '#{url}'" do
+        expect(subject.Build(subject.Parse(url))).to eq(rebuilt)
       end
     end
   end

--- a/library/types/test/url_test.rb
+++ b/library/types/test/url_test.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "URL"
+
+describe Yast::URL do
+  subject { Yast::URL }
+
+  let(:url) { "https://myuser:mypassword@suse.de:1234/some-path?preview=true#contents" }
+  let(:tokens) do
+    {
+      "scheme"   => "https",
+      "host"     => "suse.de",
+      "path"     => "/some-path",
+      "fragment" => "contents",
+      "user"     => "myuser",
+      "pass"     => "mypassword",
+      "port"     => "1234",
+      "query"    => "preview=true"
+    }
+  end
+
+  describe ".Parse" do
+    it "returns a hash containing the token extracted from the URL" do
+      expect(subject.Parse(url)).to eq(tokens)
+    end
+  end
+
+  describe ".Build" do
+    it "returns the URL for the given tokens" do
+      expect(subject.Build(tokens)).to eq(url)
+    end
+
+    context "given a cd/dvd URL" do
+      let(:tokens) do
+        {
+          "scheme" => "cd",
+          "query"  => "device=/dev/sr0"
+        }
+      end
+
+      it "returns a URL containing which a single slash to separate the schema from the rest" do
+        expect(subject.Build(tokens)).to eq("cd:/?device=/dev/sr0")
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Aug  8 10:54:35 UTC 2016 - igonzalezsosa@suse.com
+
+- Fixed handling of cd:/ and dvd:/ URLs (bsc#991935)
+- 3.1.202
+
+-------------------------------------------------------------------
 Thu Aug  4 09:04:50 UTC 2016 - mvidner@suse.cz
 
 - Declare textdomain to fix untranslated texts (bsc#992084).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.201
+Version:        3.1.202
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Before this patch:

```ruby
url = "cd:/?device=/dev/sr0"
Yast::URL.Build(Yast::URL.Parse(url)) # => "cd://?device=/dev/sr0"
```

After this patch it returns `cd:/?device=/dev/sr0`.