### PR TITLE
Popup.Error will escape tags when using richtext

### DIFF
--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -48,6 +48,7 @@ module Yast
       Yast.import "Label"
       Yast.import "Mode"
       Yast.import "Directory"
+      Yast.import "String"
 
       @feedback_open = false
 

--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -48,7 +48,6 @@ module Yast
       Yast.import "Label"
       Yast.import "Mode"
       Yast.import "Directory"
-      Yast.import "String"
 
       @feedback_open = false
 
@@ -891,7 +890,7 @@ module Yast
               VSpacing(0.5),
               RichText(
                 Builtins.mergestring(
-                  Builtins.splitstring(String.EscapeTags(details), "\n"),
+                  Builtins.splitstring(ERB::Util.html_escape(details), "\n"),
                   "<br>"
                 )
               ),

--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -36,6 +36,7 @@
 # <br>
 # See also <a href="../wizard/README.popups">README.popups</a>
 require "yast"
+require "erb"
 
 module Yast
   class PopupClass < Module
@@ -47,7 +48,6 @@ module Yast
       Yast.import "Label"
       Yast.import "Mode"
       Yast.import "Directory"
-      Yast.import "String"
 
       @feedback_open = false
 
@@ -1325,7 +1325,7 @@ module Yast
           Ops.greater_than(Builtins.size(lines), @too_many_lines)
         anyMessageInternalRich(
           Label.ErrorMsg,
-          String.EscapeTags(message),
+          ERB::Util.html_escape(message),
           @default_width,
           @default_height
         )

--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -1325,7 +1325,7 @@ module Yast
           Ops.greater_than(Builtins.size(lines), @too_many_lines)
         anyMessageInternalRich(
           Label.ErrorMsg,
-          message,
+          String.EscapeTags(message),
           @default_width,
           @default_height
         )

--- a/library/general/test/popup_test.rb
+++ b/library/general/test/popup_test.rb
@@ -1,6 +1,7 @@
 #! /usr/bin/env rspec
 
 require_relative "test_helper"
+require "erb"
 
 Yast.import "Popup"
 Yast.import "String"
@@ -89,11 +90,11 @@ describe Yast::Popup do
 
       it "escapes the tags if message is too long" do
         message = line * limit
-        expect(subject).to receive(:RichText).with(Yast::String.EscapeTags(message))
+        expect(subject).to receive(:RichText).with(ERB::Util.html_escape(message))
         subject.Error(message)
       end
 
-      it "does not escape the tags if message is not too long" do
+      it "keeps the original text if the message is short" do
         expect(subject).to receive(:RichText).with(line)
         subject.Error(line)
       end

--- a/library/general/test/popup_test.rb
+++ b/library/general/test/popup_test.rb
@@ -67,7 +67,7 @@ describe Yast::Popup do
     let(:line) { "<h1>Title</h1>\n" }
     let(:limit) { subject.too_many_lines }
 
-    # Backup and restore the original switch_to_rich flag
+    # Backup and restore the original switch_to_richtext flag
     around do |example|
       old_switch_to_richtext = subject.switch_to_richtext
       subject.switch_to_richtext = switch_to_richtext

--- a/library/general/test/popup_test.rb
+++ b/library/general/test/popup_test.rb
@@ -4,7 +4,6 @@ require_relative "test_helper"
 require "erb"
 
 Yast.import "Popup"
-Yast.import "String"
 
 describe Yast::Popup do
   let(:ui) { double("Yast::UI") }
@@ -68,6 +67,7 @@ describe Yast::Popup do
     let(:line) { "<h1>Title</h1>\n" }
     let(:limit) { subject.too_many_lines }
 
+    # Backup and restore the original switch_to_rich flag
     around do |example|
       old_switch_to_richtext = subject.switch_to_richtext
       subject.switch_to_richtext = switch_to_richtext

--- a/library/general/test/popup_test.rb
+++ b/library/general/test/popup_test.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 
 Yast.import "Popup"
+Yast.import "String"
 
 describe Yast::Popup do
   let(:ui) { double("Yast::UI") }
@@ -62,9 +63,40 @@ describe Yast::Popup do
   describe ".Error" do
     before { allow(ui).to receive(:OpenDialog) }
 
-    it "shows a popup without escaping tags" do
-      expect(subject).to receive(:RichText).with("<h1>Title</h1>")
-      subject.Error("<h1>Title</h1>")
+    let(:switch_to_richtext) { true }
+    let(:line) { "<h1>Title</h1>\n" }
+    let(:limit) { subject.too_many_lines }
+
+    around do |example|
+      old_switch_to_richtext = subject.switch_to_richtext
+      subject.switch_to_richtext = switch_to_richtext
+      example.run
+      subject.switch_to_richtext = old_switch_to_richtext
+    end
+
+    context "when switching to richtext is not allowed" do
+      let(:switch_to_richtext) { false }
+
+      it "shows a popup without escaping tags" do
+        message = line * limit
+        expect(subject).to receive(:RichText).with(message)
+        subject.Error(message)
+      end
+    end
+
+    context "when switch to richtext is allowed" do
+      let(:switch_to_richtext) { true }
+
+      it "escapes the tags if message is too long" do
+        message = line * limit
+        expect(subject).to receive(:RichText).with(Yast::String.EscapeTags(message))
+        subject.Error(message)
+      end
+
+      it "does not escape the tags if message is not too long" do
+        expect(subject).to receive(:RichText).with(line)
+        subject.Error(line)
+      end
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug  9 11:31:45 UTC 2016 - igonzalezsosa@suse.com
+
+- Popup.Error will escape the text when message is too long and
+  richtext is used (bsc#992506)
+- 3.1.203
+
+-------------------------------------------------------------------
 Mon Aug  8 10:54:35 UTC 2016 - igonzalezsosa@suse.com
 
 - Fixed handling of cd:/ and dvd:/ URLs (bsc#991935)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.202
+Version:        3.1.203
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
This patch fixes [bsc#992506](https://bugzilla.suse.com/show_bug.cgi?id=992506). When trying to contact a non-valid SCC/SMT server, YaST didn't escaped the error message.

![not-escaped-error](https://cloud.githubusercontent.com/assets/15836/17515616/545c2ec2-5e31-11e6-854b-4957ff08c608.png)

After this fix, this situation should be handled properly:

![escaped-error](https://cloud.githubusercontent.com/assets/15836/17515618/56c3774c-5e31-11e6-8b65-f9987d6b210a.png)

The bug was introduced in this older [PR](https://github.com/yast/yast-yast2/pull/442). The reason is that we have two different use cases here:

* I want to show an error and we should escape the content (potentially unsafe).
* I want to show a long message and I don't want the content to be escaped (supposed to be safe).

So now we're escaping in case of showing an error. AutoYaST timed dialogs won't be affected as the implementation is different and does not try to switch to richtext in long error messages.