### PR TITLE
Packages: remove warning Icon from package callbacks.

### DIFF
--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -2989,9 +2989,6 @@ module Yast
         HSpacing(50), # enforce width
         VSpacing(0.1),
         HBox(
-          # maybe more icon types could be used
-          # "info, "warning", "error"
-          Icon.Image("warning", "margin_right" => 2),
           Left(Label(message))
         ),
         VSpacing(0.1),

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -2988,9 +2988,7 @@ module Yast
       VBox(
         HSpacing(50), # enforce width
         VSpacing(0.1),
-        HBox(
-          Left(Label(message))
-        ),
+        Left(Label(message)),
         VSpacing(0.1),
         HBox(
           HSpacing(0.6),

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Aug 26 10:37:45 UTC 2016 - kanderssen@suse.com
+
+- Packages: remove warning icon from package callbacks.
+  (bnc#988949)
+- 3.1.205
+
+-------------------------------------------------------------------
 Thu Aug 25 14:17:13 CEST 2016 - schubi@suse.de
 
 - Set AutoYaST default timeout entries for reporting errors

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.204
+Version:        3.1.205
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
How it looks before:

![screenshot_sle12_update_2016-08-26_12 45 25](https://cloud.githubusercontent.com/assets/7056681/18004309/fa2982d0-6b8a-11e6-9744-dad04ae37722.png)

How looks now:

![screenshot_sle12_update_2016-08-26_12 43 26](https://cloud.githubusercontent.com/assets/7056681/18004299/e500695a-6b8a-11e6-872a-692b915d5851.png)

