### PR TITLE
Removed build dependency on yast2-perl-bindings (bsc#999203)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 16 07:23:10 UTC 2016 - mvidner@suse.com
+
+- Removed build dependency on yast2-perl-bindings (bsc#999203)
+
+-------------------------------------------------------------------
 Fri Aug 26 10:37:45 UTC 2016 - kanderssen@suse.com
 
 - Packages: remove warning icon from package callbacks.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -42,7 +42,6 @@ BuildRequires:  update-desktop-files
 # Needed already in build time
 BuildRequires:  yast2-core >= 2.18.12
 BuildRequires:  yast2-devtools >= 3.1.10
-BuildRequires:  yast2-perl-bindings
 BuildRequires:  yast2-pkg-bindings >= 2.20.3
 # To have Yast::CoreExt::AnsiString
 BuildRequires:  yast2-ruby-bindings >= 3.1.36


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=999203

The remaining 4 pm files in this package do not participate in build
time tests.