### PR TITLE
Locate returns interface names instead of types (bsc#998717)

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1618,8 +1618,10 @@ module Yast
     def Locate(key, val)
       ret = []
 
-      @Devices.each do |device, devsmap|
-        ret << device if devsmap.any? { |_t, d| d[key] == val }
+      @Devices.values.each do |devsmap|
+        devsmap.each do |device, conf|
+          ret << device if conf[key] == val
+        end
       end
 
       ret
@@ -1633,8 +1635,10 @@ module Yast
     def LocateNOT(key, val)
       ret = []
 
-      @Devices.each do |device, devsmap|
-        ret << device if devsmap.any? { |_t, d| d[key] != val }
+      @Devices.values.each do |devsmap|
+        devsmap.each do |device, conf|
+          ret << device if conf[key] != val
+        end
       end
 
       ret

--- a/library/network/test/network_interfaces_test.rb
+++ b/library/network/test/network_interfaces_test.rb
@@ -198,9 +198,9 @@ describe Yast::NetworkInterfaces do
       subject.CleanCacheRead
     end
 
-    it "returns an array of devices types which have got given key,value" do
-      expect(subject.Locate("BOOTPROTO", "static")).to eql(["bond", "em", "eth"])
-      expect(subject.Locate("BONDING_MASTER", "YES")).to eql(["bond"])
+    it "returns an array of devices which have got given key,value" do
+      expect(subject.Locate("BOOTPROTO", "static")).to eql(["bond0", "em1", "eth0","eth1"])
+      expect(subject.Locate("BONDING_MASTER", "YES")).to eql(["bond0"])
     end
 
     it "returns an empty array if not device match given criteria" do
@@ -219,8 +219,8 @@ describe Yast::NetworkInterfaces do
       subject.CleanCacheRead
     end
 
-    it "returns an array of devices types which have got a different key,value than given ones" do
-      expect(subject.LocateNOT("BOOTPROTO", "static")).to eql(["arc", "br", "ppp", "vlan"])
+    it "returns an array of devices which have got a different key,value than given ones" do
+      expect(subject.LocateNOT("BOOTPROTO", "static")).to eql(["arc5", "br1", "ppp0", "vlan3"])
     end
   end
 

--- a/library/network/test/network_interfaces_test.rb
+++ b/library/network/test/network_interfaces_test.rb
@@ -199,7 +199,7 @@ describe Yast::NetworkInterfaces do
     end
 
     it "returns an array of devices which have got given key,value" do
-      expect(subject.Locate("BOOTPROTO", "static")).to eql(["bond0", "em1", "eth0","eth1"])
+      expect(subject.Locate("BOOTPROTO", "static")).to eql(["bond0", "em1", "eth0", "eth1"])
       expect(subject.Locate("BONDING_MASTER", "YES")).to eql(["bond0"])
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,8 +1,10 @@
 -------------------------------------------------------------------
 Fri Sep 16 17:53:15 UTC 2016 - kanderssen@suse.com
 
-- Network: Locate returns interface names instead of type.
-  (bsc#998717)
+- Network: Fix bug introduced during NetworkInterfaces.Read cleanup
+  The method Networkinterfaces.Locate now returns the interface
+  name of the interfaces that match the given condition instead of
+  the type. (bsc#998717)
 - 3.1.206
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 16 17:53:15 UTC 2016 - kanderssen@suse.com
+
+- Network: Locate returns interface names instead of type.
+  (bsc#998717)
+- 3.1.206
+
+-------------------------------------------------------------------
 Fri Aug 26 10:37:45 UTC 2016 - kanderssen@suse.com
 
 - Packages: remove warning icon from package callbacks.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.205
+Version:        3.1.206
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
During the cleanup of NetworkInterfaces the behaviour of Locate method was changed by error as you can see here: 

https://github.com/yast/yast-yast2/pull/433/files#diff-9e2299f8f1f2334535a5e511b4383b4aR181

This just give the original behavior, fixing also current method tests.



