### PR TITLE
Restart file cleanup

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 18 16:33:56 UTC 2016 - lslezak@suse.cz
+
+- Remove the restart file when starting YaST to avoid possible
+  infinite loop (bsc#842910)
+- 3.2.5
+
+-------------------------------------------------------------------
 Wed Nov 16 15:18:39 CET 2016 - schubi@suse.de
 
 - Added needed include in Kernel.rb. Found while testing

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.4
+Version:        3.2.5
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -422,6 +422,11 @@ else
 	*) REDO_FILE=/var/lib/YaST2/restart_yast ;;
     esac
     snapshot_pre $module
+
+    # remove the redo file if it already exists before starting the module,
+    # avoid possible infinite loop (bsc#842910)
+    rm -f "$REDO_FILE"
+
     #  break out on errors, #343258
     while [ $exit_code = 0 ]; do
 	$ybindir/y2base $module "$@" "$SELECTED_GUI" $Y2_GEOMETRY $Y2UI_ARGS

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -349,7 +349,7 @@ if [ "$SELECTED_GUI" = "ncurses" ]; then
 	        TTY=console
 		;;
 	esac
-	
+
 	# The part below has changed: we don't use 'testutf8' any longer, i.e.
 	# don't start YaST in UTF-8 locale by default and don't fix the settings
 	# in rxvt*|vt*|xterm*|linux|screen* (trust the locale).
@@ -367,9 +367,9 @@ if [ "$SELECTED_GUI" = "ncurses" ]; then
 			export LANG=en_US
 			export LC_CTYPE=en_US
 			export LC_ALL=en_US # just to make sure.
-		    fi	
+		    fi
 		    ;;
-	     esac	
+	     esac
 	fi
 
 	# set color theme, if defined


### PR DESCRIPTION
Remove the restart file (usually `/var/lib/YaST2/restart_yast`) if it already exists before starting the module to  avoid possible infinite loop. Fixes [bug #842910](https://bugzilla.suse.com/show_bug.cgi?id=842910).

The file might be accidentally left in the system when YaST crashes or system shuts down unexpectedly before YaST removes that restart file.

How to reproduce the issue:

```
touch /var/lib/YaST2/restart_yast
yast2 lan
# now you cannot escape from the module, it will keep starting again and again
```