### PR TITLE
Fix for the new yast2-core

### DIFF
--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -110,8 +110,7 @@ class DummyPkg
 
   MOCK_METHODS.each do |method|
     # mock empty methods with a single argument
-    send(:define_method, method) do |func|
-    end
+    define_method(method) { |arg| }
   end
 end
 

--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -24,6 +24,95 @@ class DummyPkg
   def CallbackFileConflictFinish(func)
     @fc_finish = func
   end
+
+  # run this command in "irb -ryast" to obtain the method names:
+  # Yast.import "Pkg"; Yast::Pkg.methods.select {|m| m.to_s.start_with?("Callback")}
+  # (Remove the methods which are defined above.)
+  MOCK_METHODS = [
+    :CallbackAcceptFileWithoutChecksum,
+    :CallbackAcceptUnknownDigest,
+    :CallbackAcceptUnknownGpgKey,
+    :CallbackAcceptUnsignedFile,
+    :CallbackAcceptVerificationFailed,
+    :CallbackAcceptWrongDigest,
+    :CallbackAuthentication,
+    :CallbackDestDownload,
+    :CallbackDoneDownload,
+    :CallbackDonePackage,
+    :CallbackDoneProvide,
+    :CallbackDoneRefresh,
+    :CallbackDoneScanDb,
+    :CallbackErrorScanDb,
+    :CallbackFinishDeltaApply,
+    :CallbackFinishDeltaDownload,
+    :CallbackImportGpgKey,
+    :CallbackInitDownload,
+    :CallbackMediaChange,
+    :CallbackMessage,
+    :CallbackNotifyConvertDb,
+    :CallbackNotifyRebuildDb,
+    :CallbackPkgGpgCheck,
+    :CallbackProblemDeltaApply,
+    :CallbackProblemDeltaDownload,
+    :CallbackProcessDone,
+    :CallbackProcessNextStage,
+    :CallbackProcessProgress,
+    :CallbackProcessStart,
+    :CallbackProgressConvertDb,
+    :CallbackProgressDeltaApply,
+    :CallbackProgressDeltaDownload,
+    :CallbackProgressDownload,
+    :CallbackProgressPackage,
+    :CallbackProgressProvide,
+    :CallbackProgressRebuildDb,
+    :CallbackProgressReportEnd,
+    :CallbackProgressReportProgress,
+    :CallbackProgressReportStart,
+    :CallbackProgressScanDb,
+    :CallbackResolvableReport,
+    :CallbackScriptFinish,
+    :CallbackScriptProblem,
+    :CallbackScriptProgress,
+    :CallbackScriptStart,
+    :CallbackSourceChange,
+    :CallbackSourceCreateDestroy,
+    :CallbackSourceCreateEnd,
+    :CallbackSourceCreateError,
+    :CallbackSourceCreateInit,
+    :CallbackSourceCreateProgress,
+    :CallbackSourceCreateStart,
+    :CallbackSourceProbeEnd,
+    :CallbackSourceProbeError,
+    :CallbackSourceProbeFailed,
+    :CallbackSourceProbeProgress,
+    :CallbackSourceProbeStart,
+    :CallbackSourceProbeSucceeded,
+    :CallbackSourceReportDestroy,
+    :CallbackSourceReportEnd,
+    :CallbackSourceReportError,
+    :CallbackSourceReportInit,
+    :CallbackSourceReportProgress,
+    :CallbackSourceReportStart,
+    :CallbackStartConvertDb,
+    :CallbackStartDeltaApply,
+    :CallbackStartDeltaDownload,
+    :CallbackStartDownload,
+    :CallbackStartPackage,
+    :CallbackStartProvide,
+    :CallbackStartRebuildDb,
+    :CallbackStartRefresh,
+    :CallbackStartScanDb,
+    :CallbackStopConvertDb,
+    :CallbackStopRebuildDb,
+    :CallbackTrustedKeyAdded,
+    :CallbackTrustedKeyRemoved
+  ].freeze
+
+  MOCK_METHODS.each do |method|
+    # mock empty methods with a single argument
+    send(:define_method, method) do |func|
+    end
+  end
 end
 
 describe Packages::FileConflictCallbacks do
@@ -42,10 +131,10 @@ describe Packages::FileConflictCallbacks do
 
   describe ".register" do
     it "calls the Pkg methods for registering the file conflicts handlers" do
-      expect(dummy_pkg).to receive(:CallbackFileConflictStart)
-      expect(dummy_pkg).to receive(:CallbackFileConflictProgress)
-      expect(dummy_pkg).to receive(:CallbackFileConflictReport)
-      expect(dummy_pkg).to receive(:CallbackFileConflictFinish)
+      expect(dummy_pkg).to receive(:CallbackFileConflictStart).at_least(:once)
+      expect(dummy_pkg).to receive(:CallbackFileConflictProgress).at_least(:once)
+      expect(dummy_pkg).to receive(:CallbackFileConflictReport).at_least(:once)
+      expect(dummy_pkg).to receive(:CallbackFileConflictFinish).at_least(:once)
 
       Packages::FileConflictCallbacks.register
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan  5 08:06:25 UTC 2017 - lslezak@suse.cz
+
+- Fixed tests to pass with the latest yast2-core package
+  (related to the bsc#932331 fix)
+- 3.2.10
+
+-------------------------------------------------------------------
 Tue Dec 20 16:28:45 UTC 2016 - igonzalezsosa@suse.com
 
 - Add a method to read the ID property from the /etc/os-release

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.9
+Version:        3.2.10
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- Fixes a bug revealed by the new yast2-core - a mocked Pkg implementation did not implement all called methods.

Note: The commits are in an unusual order - the first is the changelog to demonstrate the failure in Travis, second commit is the fix to show the fixed state. I'll squash them at merge to not have this issue in `master`.