### PR TITLE
Do a full type detection when creating cache

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -789,7 +789,7 @@ module Yast
     # @param [Hash] a map with netconfig (ifcfg) configuration
     #
     def add_device(device, ifcfg)
-      devtype = GetTypeFromIfcfg(ifcfg) || GetType(device)
+      devtype = GetType(device)
       @Devices[devtype] ||= {}
       @Devices[devtype][device] = ifcfg
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan  5 11:58:05 UTC 2017 - mfilka@suse.com
+
+- bnc#956755
+  - Use full type detection when caching network configuration to
+    solve ambiguos configurations (like bridge over wlan).
+- 3.2.12
+
+-------------------------------------------------------------------
 Thu Jan  5 11:35:23 UTC 2017 - mfilka@suse.com
 
 - bnc#1017716

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.11
+Version:        3.2.12
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
It avoids ambiguous categorization of a device like in [bsc#956755](https://bugzilla.suse.com/show_bug.cgi?id=956755)
another one: https://bugzilla.suse.com/show_bug.cgi?id=1061306