### PR TITLE
Shared RSpec examples for CWM widgets

### DIFF
--- a/library/cwm/src/lib/cwm/custom_widget.rb
+++ b/library/cwm/src/lib/cwm/custom_widget.rb
@@ -45,6 +45,7 @@ module CWM
     end
 
     # Returns all nested widgets used in contents
+    # @return [Array<AbstractWidget>]
     def nested_widgets
       Yast.import "CWM"
 

--- a/library/cwm/src/lib/cwm/rspec.rb
+++ b/library/cwm/src/lib/cwm/rspec.rb
@@ -1,0 +1,76 @@
+# in your specs:
+#   require "cwm/rspec"
+
+RSpec.shared_examples "CWM::AbstractWidget" do
+  context "these methods are only tested if they exist" do
+    describe "#label" do
+      it "produces a String" do
+        next unless subject.respond_to?(:label)
+        expect(subject.label).to be_a String
+      end
+    end
+
+    describe "#help" do
+      it "produces a String" do
+        next unless subject.respond_to?(:help)
+        expect(subject.help).to be_a String
+      end
+    end
+
+    describe "#opt" do
+      it "produces Symbols" do
+        next unless subject.respond_to?(:opt)
+        expect(subject.opt).to be_an Enumerable
+        subject.opt.each do |o|
+          expect(o).to be_a Symbol
+        end
+      end
+    end
+
+    describe "#handle" do
+      it "produces a Symbol or nil" do
+        next unless subject.respond_to?(:handle)
+        m = subject.method(:handle)
+        args = m.arity == 0 ? [] : [:dummy_event]
+        expect(subject.handle(* args)).to be_a(Symbol).or be_nil
+      end
+    end
+
+    describe "#validate" do
+      it "produces a Boolean (or nil)" do
+        next unless subject.respond_to?(:validate)
+        expect(subject.validate).to be(true).or be(false).or be_nil
+      end
+    end
+  end
+end
+
+RSpec.shared_examples "CWM::CustomWidget" do
+  include_examples "CWM::AbstractWidget"
+  describe "#contents" do
+    it "produces a Term" do
+      expect(subject.contents).to be_a Yast::Term
+    end
+  end
+end
+
+RSpec.shared_examples "CWM::Tab" do
+  include_examples "CWM::CustomWidget"
+end
+
+RSpec.shared_examples "CWM::ItemsSelection" do
+  describe "#items" do
+    it "produces an array of pairs of strings" do
+      expect(subject.items).to be_an Enumerable
+      subject.items.each do |i|
+        expect(i[0]).to be_a String
+        expect(i[1]).to be_a String
+      end
+    end
+  end
+end
+
+RSpec.shared_examples "CWM::ComboBox" do
+  include_examples "CWM::AbstractWidget"
+  include_examples "CWM::ItemsSelection"
+end

--- a/library/cwm/test/abstract_widget_test.rb
+++ b/library/cwm/test/abstract_widget_test.rb
@@ -3,8 +3,11 @@
 require_relative "test_helper"
 
 require "cwm/abstract_widget"
+require "cwm/rspec"
 
 describe CWM::AbstractWidget do
+  include_examples "CWM::AbstractWidget"
+
   describe "#widget_id" do
     class T1 < CWM::AbstractWidget
       def initialize(id: nil)

--- a/library/cwm/test/custom_widget_test.rb
+++ b/library/cwm/test/custom_widget_test.rb
@@ -1,27 +1,34 @@
 require_relative "test_helper"
 
 require "cwm/custom_widget"
+require "cwm/rspec"
 
 describe CWM::CustomWidget do
-  describe "#description" do
-    context "handle_all_events is false" do
-      class CustomTestWidget < CWM::CustomWidget
-        def initialize
-          self.handle_all_events = false
-          self.widget_id = "test_widget"
-        end
+  class CustomTestWidget < CWM::CustomWidget
+    def contents
+      HBox(
+        InputField(Id(:first), "test"),
+        PushButton(Id("second"), "Discover 42")
+      )
+    end
+  end
+  subject { CustomTestWidget.new }
 
-        def contents
-          HBox(
-            InputField(Id(:first), "test"),
-            PushButton(Id("second"), "Discover 42")
-          )
-        end
+  include_examples "CWM::CustomWidget"
+
+  context "handle_all_events is false" do
+    class IsolationistTestWidget < CustomTestWidget
+      def initialize
+        self.handle_all_events = false
+        self.widget_id = "test_widget"
       end
-      subject { CustomTestWidget.new }
+    end
+    describe "#cwm_definition" do
+      subject { IsolationistTestWidget.new }
 
       it "adds to description to handle only ids in contents and widget_id" do
-        expect(subject.cwm_definition["handle_events"]).to eq [:first, "second", "test_widget"]
+        expect(subject.cwm_definition["handle_events"])
+          .to eq [:first, "second", "test_widget"]
       end
     end
   end

--- a/library/cwm/test/widgets_test.rb
+++ b/library/cwm/test/widgets_test.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 
 require "cwm/widget"
+require "cwm/rspec"
 
 describe CWM::RadioButtons do
 
@@ -86,6 +87,8 @@ describe CWM::ReplacePoint do
     def cleanup
     end
   end
+
+  include_examples "CWM::CustomWidget"
 
   describe ".new" do
     it "has widget_id as passed" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 16 12:04:40 UTC 2017 - mvidner@suse.com
+
+- Added cwm/rspec with shared_examples for CWM::AbstractWidget
+  and its children (boo#1039302)
+- 3.2.29
+
+-------------------------------------------------------------------
 Wed Apr 19 14:16:33 UTC 2017 - lslezak@suse.cz
 
 - Fixed parsing whitespace lines in /etc/fstab (bsc#1030425)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.28
+Version:        3.2.29
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
to enable stupid but easy test coverage