### PR TITLE
SlideShow: escape license in plain text (bsc#1028721).

### DIFF
--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -568,6 +568,7 @@ module Yast
     # @return	A term describing the widgets
     #
     def RelNotesPageWidgets(id)
+      # Release notes in plain text need to be escaped to be shown properly (bsc#1028721)
       rel_notes =
         if @_rn_tabs[id] =~ /<\/.*>/
           @_rn_tabs[id]

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -568,7 +568,14 @@ module Yast
     # @return	A term describing the widgets
     #
     def RelNotesPageWidgets(id)
-      widgets = AddProgressWidgets(:relNotesPage, RichText(@_rn_tabs[id]))
+      rel_notes =
+        if @_rn_tabs[id] =~ /<\/.*>/
+          @_rn_tabs[id]
+        else
+          "<pre>#{String.EscapeTags(@_rn_tabs[id])}</pre>"
+        end
+
+      widgets = AddProgressWidgets(:relNotesPage, RichText(rel_notes))
       Builtins.y2debug("widget term: \n%1", widgets)
       deep_copy(widgets)
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 28 07:25:39 WEST 2017 - knut.anderssen@suse.com
+
+- SlideShow: Escape plain text release notes being shown properly
+  in RichText (bsc#1028721).
+- 3.2.23
+
+-------------------------------------------------------------------
 Fri Mar 24 09:37:44 UTC 2017 - lslezak@suse.cz
 
 - Download the addon installation.xml file from a package

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.22
+Version:        3.2.23
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1028721

Just applied the same fix already in [ProductLicense](https://github.com/yast/yast-packager/blob/dff498280c3969db2a386e9face338af36e24a4b/src/modules/ProductLicense.rb#L179)

### Before the fix:

![screenshot_sles12sp3_2017-03-28_07 28 12](https://cloud.githubusercontent.com/assets/7056681/24392973/1b883e98-138e-11e7-86df-094bcf3c6381.png)

### After the fix
![screenshot_sled12sp3_2017-03-28_07 18 54](https://cloud.githubusercontent.com/assets/7056681/24392974/1b8b2158-138e-11e7-9eae-1ecae9b4b88b.png)

![screenshot_sles12sp3_2017-03-28_08 10 46](https://cloud.githubusercontent.com/assets/7056681/24392972/1b87bb3a-138e-11e7-9a69-3a756c6ee108.png)
