### PR TITLE
SlideShow: escape license in plain text. (backport from SP3)

### DIFF
--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -568,7 +568,15 @@ module Yast
     # @return	A term describing the widgets
     #
     def RelNotesPageWidgets(id)
-      widgets = AddProgressWidgets(:relNotesPage, RichText(@_rn_tabs[id]))
+      # Release notes in plain text need to be escaped to be shown properly (bsc#1028721)
+      rel_notes =
+        if @_rn_tabs[id] =~ /<\/.*>/
+          @_rn_tabs[id]
+        else
+          "<pre>#{String.EscapeTags(@_rn_tabs[id])}</pre>"
+        end
+
+      widgets = AddProgressWidgets(:relNotesPage, RichText(rel_notes))
       Builtins.y2debug("widget term: \n%1", widgets)
       deep_copy(widgets)
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 28 10:19:44 WEST 2017 - knut.anderssen@suse.com
+
+- backported
+  - SlideShow: Escape plain text release notes being shown properly
+    in RichText (bsc#1028721).
+- 3.1.215
+
+-------------------------------------------------------------------
 Thu Mar 16 13:48:06 CET 2017 - schubi@suse.de
 
 - UnitFileState will be used for evaluating enable state of

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.214
+Version:        3.1.215
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
It is a backport from #560 where you can see screenshots and more details.