### PR TITLE
Fixed downloading installer extension package (FATE#320772)

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -426,11 +426,11 @@ module Yast
 
       log.info("installation.xml path: #{path}")
       path
-    rescue Packages::PackageDownloader::FetchError
+    rescue ::Packages::PackageDownloader::FetchError
       # TRANSLATORS: an error message
       Report.Error(_("Downloading the installer extension package failed."))
       nil
-    rescue Packages::PackageExtractor::ExtractionFailed
+    rescue ::Packages::PackageExtractor::ExtractionFailed
       # TRANSLATORS: an error message
       Report.Error(_("Extracting the installer extension failed."))
       nil
@@ -1550,14 +1550,14 @@ module Yast
     # Download and extract a package from a repository.
     # @param repo_id [Fixnum] repository ID
     # @param package [String] name of the package
-    # @raise [Packages::PackageDownloader::FetchError] if package download failed
-    # @raise [Packages::PackageExtractor::ExtractionFailed] if package extraction failed
+    # @raise [::Packages::PackageDownloader::FetchError] if package download failed
+    # @raise [::Packages::PackageExtractor::ExtractionFailed] if package extraction failed
     def fetch_package(repo_id, package, dir)
-      downloader = Packages::PackageDownloader.new(repo_id, package)
+      downloader = ::Packages::PackageDownloader.new(repo_id, package)
 
       Tempfile.open("downloaded-package-") do |tmp|
         downloader.download(tmp.path)
-        extract(tmp, dir)
+        extract(tmp.path, dir)
         # the RPM package file is not needed after extracting it's content,
         # remove it explicitly now, do not wait for the garbage collector
         # (in inst-syst it is stored in a RAM disk and eats the RAM memory)
@@ -1568,10 +1568,10 @@ module Yast
     # Extract an RPM package into the given directory.
     # @param package_file [String] the RPM package path
     # @param dir [String] a directory where the package will be extracted to
-    # @raise [Packages::PackageExtractor::ExtractionFailed] if package extraction failed
+    # @raise [::Packages::PackageExtractor::ExtractionFailed] if package extraction failed
     def extract(package_file, dir)
       log.info("Extracting file #{package_file}")
-      extractor = Packages::PackageExtractor.new(package_file)
+      extractor = ::Packages::PackageExtractor.new(package_file)
       extractor.extract(dir)
     end
   end

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -362,9 +362,9 @@ describe Yast::WorkflowManager do
     end
 
     it "downloads and extracts the extension package" do
-      expect_any_instance_of(Packages::PackageDownloader).to receive(:download)
+      expect_any_instance_of(Packages::PackageDownloader).to receive(:download).with(instance_of(String))
       expect(Packages::PackageExtractor).to receive(:new).with(instance_of(String)).and_call_original
-      expect_any_instance_of(Packages::PackageExtractor).to receive(:extract)
+      expect_any_instance_of(Packages::PackageExtractor).to receive(:extract).with(instance_of(String))
       allow(File).to receive(:exist?)
       subject.addon_control_file(repo_id)
     end

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -363,6 +363,7 @@ describe Yast::WorkflowManager do
 
     it "downloads and extracts the extension package" do
       expect_any_instance_of(Packages::PackageDownloader).to receive(:download)
+      expect(Packages::PackageExtractor).to receive(:new).with(instance_of(String)).and_call_original
       expect_any_instance_of(Packages::PackageExtractor).to receive(:extract)
       allow(File).to receive(:exist?)
       subject.addon_control_file(repo_id)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 30 11:51:43 UTC 2017 - lslezak@suse.cz
+
+- Fixed downloading installer extension package (FATE#320772)
+- 3.2.24
+
+-------------------------------------------------------------------
 Tue Mar 28 07:25:39 WEST 2017 - knut.anderssen@suse.com
 
 - SlideShow: Escape plain text release notes being shown properly

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.23
+Version:        3.2.24
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
This is an fix up for #559.

I tested the latest SP3 build with my example extension, it revealed some bugs not found by unit tests:

- A conflict between `Yast::Packages` (from `modules/Packages.rb`) and the `::Packages` name space. Fixed by full qualification.
- The `extract` method argument was a `Tempfile` object instead of a `String` - the call was mocked in the test so it was not found. Fixed and improved the test to check also the passed argument type to avoid regressions.