### PR TITLE
[WIP] Fstab agent - handle better white space only lines (bsc#1030425)

### DIFF
--- a/library/general/src/scrconf/etc_fstab.scr
+++ b/library/general/src/scrconf/etc_fstab.scr
@@ -42,6 +42,12 @@
  */
 .etc.fstab
 
+/*
+ * Note: the same agent definition is used in
+ * https://github.com/yast/yast-update/blob/e2052274034f5240e9f09bceae7c6d888b18468d/src/modules/RootPart.rb#L812
+ * apply any fixes also there.
+ */
+
 `ag_anyagent(
   `Description (
       (`File("/etc/fstab")),	// real file name

--- a/library/general/src/scrconf/etc_fstab.scr
+++ b/library/general/src/scrconf/etc_fstab.scr
@@ -45,7 +45,8 @@
 `ag_anyagent(
   `Description (
       (`File("/etc/fstab")),	// real file name
-      "#\n",			// Comment
+      // tab and space is a workaround for white space only lines (bsc#1030425)
+      "#\n\t ",			// Comment
       false,			// read-only
       (`List (
 	`Tuple (

--- a/library/general/test/agents_test/fstab_agent_test.rb
+++ b/library/general/test/agents_test/fstab_agent_test.rb
@@ -21,7 +21,14 @@ describe ".etc.fstab" do
       root = File.join(File.dirname(__FILE__), "test_root2")
       change_scr_root(root)
       expect(content).to be_a(Array)
+    end
 
+    it "can read fstab containing just whitespace lines" do
+      reset_scr_root
+      root = File.join(File.dirname(__FILE__), "test_root3")
+      change_scr_root(root)
+      # all lines are returned
+      expect(content.size).to eq(6)
     end
 
     it "returns an array containing nfs entries" do

--- a/library/general/test/agents_test/test_root3/etc/fstab
+++ b/library/general/test/agents_test/test_root3/etc/fstab
@@ -1,0 +1,8 @@
+UUID=b66c1028-cd4a-4c08-b92d-fc4b9840845d	/	ext4	noatime,data=writeback,acl,user_xattr 1 1 
+UUID=d2811ace-66e0-4ef2-9b68-9b2758359391	/home	ext4	noatime,data=writeback,acl 1 2 
+         
+192.168.1.2:/home/kv	/home/kv2	nfs	defaults 0 0 
+192.168.1.2:/media/new2	/media/new2	nfs	defaults 0 0 
+192.168.1.2:/media/new	/media/new	nfs	defaults 0 0 
+# my fine comment
+tmpfs                /tmp                 tmpfs      defaults,size=25%              0 0

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 19 14:16:33 UTC 2017 - lslezak@suse.cz
+
+- Fixed parsing whitespace lines in /etc/fstab (bsc#1030425)
+- 3.2.28
+
+-------------------------------------------------------------------
 Mon Apr 10 15:23:06 UTC 2017 - jreidinger@suse.com
 
 - Set correct title when wizard is supported (bsc#1033161#c4)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.27
+Version:        3.2.28
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
The lines containing just spaces are not handled by the agent and the parser stops ignoring the rest of the file. See [bsc#1030425](https://bugzilla.suse.com/show_bug.cgi?id=1030425) for more details.

This patch defines space and tab at the beginning as a comment so a line containing only spaces is ignored.

### Disadvanatages

The drawback is that a space at the beginning of a valid line makes it a comment as well. But that's actually not a regression, the original code did not handle it as well and the rest of the file was ignored.
With this change it is still not perfect, but at least it parses the other lines so it is still an improvement.

### More Fixes Still Needed

This patch does not fix the upgrade issue completely, the same fix needs to applied at https://github.com/yast/yast-update/blob/master/src/modules/RootPart.rb#L819.

### Note

I tried a different approach using `:Or()` any_agent feature but the result then contained empty strings (in the list of Hashes!) or with `:Tuple()` it contained an empty hash. This could break some code as the `ret["file"]` would result in `nil` which might not be handled at all places.

But as this issue is there probably since the beginning of YaST2 this simple fix is good enough. For more robust fstab parsing we should switch to Augeas, it already has a fstab lense defined...

