### PR TITLE
Translation fix (bsc#1038077)

### DIFF
--- a/library/packages/src/lib/packages/update_messages_view.rb
+++ b/library/packages/src/lib/packages/update_messages_view.rb
@@ -20,8 +20,8 @@ module Packages
     #
     # @return [String] Richtext representation of the list of messages
     def richtext
-      text = "<h1>#{_("Packages notifications")}</h1>\n" \
-        "<p>#{_("You have notifications from the following packages:")}</p>"
+      text = "<h1>" + _("Packages notifications") + "</h1>\n<p>" \
+        + _("You have notifications from the following packages:") + "</p>"
       text << richtext_toc(@messages) if @messages.size > 1
       text << @messages.map { |m| message_to_richtext(m) }.join("<hr>")
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 18 13:35:05 UTC 2017 - lslezak@suse.cz
+
+- Translation fix: Ruby gettext cannot extract translatable texts
+  from interpolated strings (bsc#1038077)
+- 3.2.30
+
+-------------------------------------------------------------------
 Tue May 16 12:04:40 UTC 2017 - mvidner@suse.com
 
 - Added cwm/rspec with shared_examples for CWM::AbstractWidget

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.29
+Version:        3.2.30
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Ruby gettext cannot extract translatable texts from interpolated strings.

- 3.2.30