### PR TITLE
Docker sle12 sp2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.pot
+*.log
+*.trs
 Makefile
 /Makefile.am
 Makefile.am.common
@@ -12,6 +15,7 @@ config.*
 configure
 configure.in
 configure.ac
+coverage/
 install-sh
 pluglib-bindings.ami
 */.dep

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: required
-language: bash
+language: ruby
 services:
   - docker
 
 before_install:
   - docker build -t yast-yast2-image .
-
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ services:
 
 before_install:
   - docker build -t yast-yast2-image .
+  # list the installed packages (just for easier debugging)
+  - docker run --rm -it yast-yast2-image rpm -qa | sort
+
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,12 @@
-language: cpp
-compiler:
-    - gcc
-before_install:
-    # disable rvm, use system Ruby
-    - rvm reset
-    - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "rake yast2-core yast2-devtools yast2-testsuite yast2-ruby-bindings yast2-pkg-bindings ruby2.1-dev libaugeas-dev pkg-config gettext" -g "rspec:3.3.0 yast-rake gettext coveralls rubocop:0.41.2 cheetah abstract_method cfa"
-script:
-    - rake check:pot
-    - rubocop
-    - make -s -f Makefile.cvs
-    - make -s
-    - sudo make -s install
-    # English messages, UTF-8, "C" locale for numeric formatting tests
-    - LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C make -s check
-    # English messages, UTF-8, "C" locale for numeric formatting tests, enable test coverage report
-    - LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C COVERAGE=1 rake test:unit
+sudo: required
+language: bash
+services:
+  - docker
 
+before_install:
+  - docker build -t yast-yast2-image .
+
+script:
+  # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
+  # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
+  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-yast2-image yast-travis-ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM yastdevel/ruby:sle12-sp2
+FROM yastdevel/ruby
 COPY . /usr/src/app
 # English messages, UTF-8, "C" locale for numeric formatting tests
 ENV LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM yastdevel/ruby:sle12-sp2
+COPY . /usr/src/app
+# English messages, UTF-8, "C" locale for numeric formatting tests
+ENV LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C

--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -24,6 +24,94 @@ class DummyPkg
   def CallbackFileConflictFinish(func)
     @fc_finish = func
   end
+
+  # run this command in "irb -ryast" to obtain the method names:
+  # Yast.import "Pkg"; Yast::Pkg.methods.select {|m| m.to_s.start_with?("Callback")}
+  # (Remove the methods which are defined above.)
+  MOCK_METHODS = [
+    :CallbackAcceptFileWithoutChecksum,
+    :CallbackAcceptUnknownDigest,
+    :CallbackAcceptUnknownGpgKey,
+    :CallbackAcceptUnsignedFile,
+    :CallbackAcceptVerificationFailed,
+    :CallbackAcceptWrongDigest,
+    :CallbackAuthentication,
+    :CallbackDestDownload,
+    :CallbackDoneDownload,
+    :CallbackDonePackage,
+    :CallbackDoneProvide,
+    :CallbackDoneRefresh,
+    :CallbackDoneScanDb,
+    :CallbackErrorScanDb,
+    :CallbackFinishDeltaApply,
+    :CallbackFinishDeltaDownload,
+    :CallbackImportGpgKey,
+    :CallbackInitDownload,
+    :CallbackMediaChange,
+    :CallbackMessage,
+    :CallbackNotifyConvertDb,
+    :CallbackNotifyRebuildDb,
+    :CallbackPkgGpgCheck,
+    :CallbackProblemDeltaApply,
+    :CallbackProblemDeltaDownload,
+    :CallbackProcessDone,
+    :CallbackProcessNextStage,
+    :CallbackProcessProgress,
+    :CallbackProcessStart,
+    :CallbackProgressConvertDb,
+    :CallbackProgressDeltaApply,
+    :CallbackProgressDeltaDownload,
+    :CallbackProgressDownload,
+    :CallbackProgressPackage,
+    :CallbackProgressProvide,
+    :CallbackProgressRebuildDb,
+    :CallbackProgressReportEnd,
+    :CallbackProgressReportProgress,
+    :CallbackProgressReportStart,
+    :CallbackProgressScanDb,
+    :CallbackResolvableReport,
+    :CallbackScriptFinish,
+    :CallbackScriptProblem,
+    :CallbackScriptProgress,
+    :CallbackScriptStart,
+    :CallbackSourceChange,
+    :CallbackSourceCreateDestroy,
+    :CallbackSourceCreateEnd,
+    :CallbackSourceCreateError,
+    :CallbackSourceCreateInit,
+    :CallbackSourceCreateProgress,
+    :CallbackSourceCreateStart,
+    :CallbackSourceProbeEnd,
+    :CallbackSourceProbeError,
+    :CallbackSourceProbeFailed,
+    :CallbackSourceProbeProgress,
+    :CallbackSourceProbeStart,
+    :CallbackSourceProbeSucceeded,
+    :CallbackSourceReportDestroy,
+    :CallbackSourceReportEnd,
+    :CallbackSourceReportError,
+    :CallbackSourceReportInit,
+    :CallbackSourceReportProgress,
+    :CallbackSourceReportStart,
+    :CallbackStartConvertDb,
+    :CallbackStartDeltaApply,
+    :CallbackStartDeltaDownload,
+    :CallbackStartDownload,
+    :CallbackStartPackage,
+    :CallbackStartProvide,
+    :CallbackStartRebuildDb,
+    :CallbackStartRefresh,
+    :CallbackStartScanDb,
+    :CallbackStopConvertDb,
+    :CallbackStopRebuildDb,
+    :CallbackTrustedKeyAdded,
+    :CallbackTrustedKeyRemoved
+  ].freeze
+
+  MOCK_METHODS.each do |method|
+    # mock empty methods with a single argument
+    define_method(method) { |arg| }
+  end
 end
 
 describe Packages::FileConflictCallbacks do
@@ -42,10 +130,10 @@ describe Packages::FileConflictCallbacks do
 
   describe ".register" do
     it "calls the Pkg methods for registering the file conflicts handlers" do
-      expect(dummy_pkg).to receive(:CallbackFileConflictStart)
-      expect(dummy_pkg).to receive(:CallbackFileConflictProgress)
-      expect(dummy_pkg).to receive(:CallbackFileConflictReport)
-      expect(dummy_pkg).to receive(:CallbackFileConflictFinish)
+      expect(dummy_pkg).to receive(:CallbackFileConflictStart).at_least(:once)
+      expect(dummy_pkg).to receive(:CallbackFileConflictProgress).at_least(:once)
+      expect(dummy_pkg).to receive(:CallbackFileConflictReport).at_least(:once)
+      expect(dummy_pkg).to receive(:CallbackFileConflictFinish).at_least(:once)
 
       Packages::FileConflictCallbacks.register
     end
@@ -71,6 +159,10 @@ describe Packages::FileConflictCallbacks do
     end
 
     context "in UI mode" do
+      before do
+        allow(Yast::Mode).to receive(:commandline).and_return(false)
+      end
+
       it "reuses the package installation progress" do
         expect(Yast::UI).to receive(:WidgetExists).and_return(true)
         expect(Yast::UI).to receive(:ChangeWidget).twice
@@ -121,6 +213,10 @@ describe Packages::FileConflictCallbacks do
     end
 
     context "in UI mode" do
+      before do
+        allow(Yast::Mode).to receive(:commandline).and_return(false)
+      end
+
       it "returns false to abort if user clicks Abort" do
         expect(Yast::UI).to receive(:PollInput).and_return(:abort)
 
@@ -232,6 +328,7 @@ describe Packages::FileConflictCallbacks do
 
       context "in UI mode" do
         before do
+          allow(Yast::Mode).to receive(:commandline).and_return(false)
           allow(Yast::UI).to receive(:OpenDialog)
           allow(Yast::UI).to receive(:CloseDialog)
           allow(Yast::UI).to receive(:SetFocus)
@@ -280,6 +377,10 @@ describe Packages::FileConflictCallbacks do
     end
 
     context "in UI mode" do
+      before do
+        allow(Yast::Mode).to receive(:commandline).and_return(false)
+      end
+
       it "no change if installation progress was already displayed" do
         ui = double("no method call expected", WidgetExists: true)
         stub_const("Yast::UI", ui)


### PR DESCRIPTION
- This is basically a copy from `master`
- Only `yastdevel/ruby:sle12-sp2` is used instead of `yastdevel/ruby`
- Testsuite and .gitignore updated