### PR TITLE
Include cwm/rspec in the RPM

### DIFF
--- a/library/cwm/src/Makefile.am
+++ b/library/cwm/src/Makefile.am
@@ -18,6 +18,7 @@ ycwm_DATA = \
   lib/cwm/page.rb \
   lib/cwm/pager.rb \
   lib/cwm/replace_point.rb \
+  lib/cwm/rspec.rb \
   lib/cwm/table.rb \
   lib/cwm/tabs.rb \
   lib/cwm/tree.rb \


### PR DESCRIPTION
I wanted to use it in https://github.com/yast/yast-partitioner/pull/5 and found it was missing :-/ 