### PR TITLE
Additional "CWM::RadioButtons" tests

### DIFF
--- a/library/cwm/src/lib/cwm/rspec.rb
+++ b/library/cwm/src/lib/cwm/rspec.rb
@@ -88,9 +88,26 @@ RSpec.shared_examples "CWM::PushButton" do
   include_examples "CWM::AbstractWidget"
 end
 
+RSpec.shared_examples "CWM spacing" do |method|
+  describe "##{method}" do
+    it "returns and Integer or a Float number if defined" do
+      if subject.respond_to?(method)
+        expect(subject.send(method)).to be_an(Integer).or be_a(Float)
+      end
+    end
+
+    it "returns a positive number or zero if defined" do
+      expect(subject.send(method)).to be >= 0 if subject.respond_to?(method)
+    end
+  end
+end
+
 RSpec.shared_examples "CWM::RadioButtons" do
   include_examples "CWM::AbstractWidget"
   include_examples "CWM::ItemsSelection"
+
+  include_examples "CWM spacing", :hspacing
+  include_examples "CWM spacing", :vspacing
 end
 
 RSpec.shared_examples "CWM::ValueBasedWidget" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 21 14:18:57 UTC 2017 - lslezak@suse.cz
+
+- cwm/rspec.rb: added tests in "CWM::RadioButtons" group for
+  optional #hspacing and #vspacing methods
+
+-------------------------------------------------------------------
 Thu Jul 20 08:17:41 UTC 2017 - jreidinger@suse.com
 
 - CWM::WrapperWidget#cwm_defintion: also include widget id,


### PR DESCRIPTION
- No version change, for using it at Travis commit to YaST:Head is enough

Originally I wanted to put the `if subject.respond_to?(method)` check before the `describe` block so RSpec does not print bogus test results when the method is not defined. But that resulted in a `#let or #subject called without a block` error, so it seems it cannot be improved in that way.