### PR TITLE
Avoid timeout error

### DIFF
--- a/library/systemd/test/systemctl_test.rb
+++ b/library/systemd/test/systemctl_test.rb
@@ -22,7 +22,7 @@ module Yast
 
       it "raises exception if the execution has timed out" do
         stub_const("Yast::Systemctl::TIMEOUT", 1)
-        allow(SCR).to receive(:Execute) { sleep 1.1 }
+        allow(SCR).to receive(:Execute) { sleep 5 }
         expect(SCR).to receive(:Execute)
         expect { Systemctl.execute("disable cups.service") }.to raise_error(SystemctlError)
       end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Aug  2 15:39:25 UTC 2017 - jlopez@suse.com
+
+- More robust systemctl test to avoid possible timeout error
+
+-------------------------------------------------------------------
 Mon Jul 31 08:23:57 UTC 2017 - jreidinger@suse.com
 
 - WorkflowManager: allow to extend workflow from rpm package


### PR DESCRIPTION
Avoid possible timeout error in tests.

See problem with s390: https://build.opensuse.org/package/live_build_log/YaST:storage-ng/yast2/openSUSE_Factory_zSystems_images/s390x.