### PR TITLE
Improved run_ifconfig.scr parser (bsc#811760)

### DIFF
--- a/library/general/src/scrconf/run_ifconfig.scr
+++ b/library/general/src/scrconf/run_ifconfig.scr
@@ -15,7 +15,7 @@
  *   Read(.run.ifconfig)
  *   ([$["name":"eth0",
  *       "value":$["flags":["UP", "BROADCAST", "RUNNING", "MULTICAST",
- *                          " MTU:1500", " Metric:1"],
+ *                          "MTU:1500", "Metric:1"],
  *                 "inet":$["addr":168427678,
  *                          "bcast":168493055,
  *                          "mask":4294901760],
@@ -24,7 +24,7 @@
  *     ],
  *     $["name":"lo",
  *       "value":$["flags":["UP", "LOOPBACK", "RUNNING",
- *                          " MTU:3924", " Metric:1"],
+ *                          "MTU:3924", "Metric:1"],
  *                 "inet":$["addr":2130706433,
  *                          "mask":4278190080],
  *                 "link":"Link encap:Local Loopback  "]
@@ -53,8 +53,8 @@
 	    `Tuple(
 		`name(`String("^\t ")),
 		`value(`Tuple(
-		    `Whitespace(), `link(`String("^\n")), "\n",
-		    `Whitespace(), "inet", `inet(
+		    `Whitespace(), `link(`String("^\n", " ")), "\n",
+		    `Optional(`Sequence(`Whitespace(), "inet", `inet(
 			`Tuple (
 			    `Optional (`Whitespace ()),
 			    `Choice (
@@ -80,9 +80,10 @@
 				    ]
 				),
 			    `Continue (`Whitespace ())
-			    )
-			), "\n",
-		    `Whitespace(), `flags(`List(`Sequence(`Optional(`Whitespace()), `String("^ \n")), " ")), "\n",
+			    )),
+			"\n")),
+
+		    `Whitespace(), `flags(`List(`Sequence(`Optional(`Whitespace()), `String("^ \n")), `Separator("\t "))), "\n",
 		    // the rest is not important
 		    `List(
 			`Sequence(`Whitespace(), `String("^\n")),

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  3 07:39:49 UTC 2017 - lslezak@suse.cz
+
+- run_ifconfig.scr - make "inet" section optional, handle
+  additional whitespace characters (bsc#811760)
+- 3.3.7
+
+-------------------------------------------------------------------
 Wed Aug  2 15:39:25 UTC 2017 - jlopez@suse.com
 
 - More robust systemctl test to avoid possible timeout error

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.3.6
+Version:        3.3.7
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- Make "inet" section optional, handle additional whitespace characters
- The fix has been confirmed by customer [bsc#811760#c13](https://bugzilla.suse.com/show_bug.cgi?id=811760#c13)
- I grepped all YaST sources, the agent is used only at **one** place in whole YaST, in the `instserver` module - so the change is safe, it cannot break anything else™.
- 3.3.7