### PR TITLE
Force using Term::ReadLine::Perl library (bsc#966042)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Aug  4 12:15:23 UTC 2017 - lslezak@suse.cz
+
+- Force using Term::ReadLine::Perl library instead of the broken
+  Term::ReadLine::Gnu default to avoid ugly error message printed
+  in command line mode (bsc#966042)
+- 3.3.8
+
+-------------------------------------------------------------------
 Thu Aug  3 07:39:49 UTC 2017 - lslezak@suse.cz
 
 - run_ifconfig.scr - make "inet" section optional, handle

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.3.7
+Version:        3.3.8
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -35,6 +35,10 @@ export QT_IM_MODULE=xim GTK_IM_MODULE=xim
 # used correctly (see bnc#866692 for details).
 export PX_MODULE_PATH=""
 
+# Force using Perl readline library instead of the broken default Gnu variant
+# to avoid ugly error message printed in command line mode (bsc#966042)
+export PERL_RL=Perl
+
 # allow for a different prefix
 # strip the basename off $0, which can be: (bnc#382216, bnc#458385)
 # /sbin/yast2, /sbin/yast, yast2 (sh -x yast2 ...), /sbin/yast2 (PATH=/sbin/:...)


### PR DESCRIPTION
- Use `Term::ReadLine::Perl` instead of the broken `Term::ReadLine::Gnu` default to avoid ugly error message printed in command line mode.
- The bug has been reported more than one year ago upstream: https://rt.cpan.org/Public/Bug/Display.html?id=110943
- But as it has not been fixed since that, so let's apply the workaround in YaST
- See more details in https://bugzilla.suse.com/show_bug.cgi?id=966042#c4
- 3.3.8