### PR TITLE
Speed up service manager

### DIFF
--- a/library/systemd/src/lib/yast2/systemctl.rb
+++ b/library/systemd/src/lib/yast2/systemctl.rb
@@ -27,6 +27,7 @@ module Yast
       # @return [#command,#stdout,#stderr,#exit]
       # @raise [SystemctlError] if it times out
       def execute(command)
+        log.info("systemctl #{command}")
         command = SYSTEMCTL + command
         log.debug "Executing `systemctl` command: #{command}"
         result = timeout(TIMEOUT) { SCR.Execute(Path.new(".target.bash_output"), command) }

--- a/library/systemd/src/lib/yast2/systemctl.rb
+++ b/library/systemd/src/lib/yast2/systemctl.rb
@@ -4,12 +4,15 @@ require "timeout"
 module Yast
   # Exception when systemctl command failed
   class SystemctlError < StandardError
-    def initialize(struct)
-      super "Systemctl command failed: #{struct}"
+    # @param details [#to_s]
+    def initialize(details)
+      super "Systemctl command failed: #{details}"
     end
   end
 
-  # Wrapper around systemctl command
+  # Wrapper around `systemctl` command.
+  # - uses non-interactive flags
+  # - has a timeout
   module Systemctl
     include Yast::Logger
 
@@ -20,6 +23,9 @@ module Yast
     TIMEOUT         = 30 # seconds
 
     class << self
+      # @param command [String]
+      # @return [#command,#stdout,#stderr,#exit]
+      # @raise [SystemctlError] if it times out
       def execute(command)
         command = SYSTEMCTL + command
         log.debug "Executing `systemctl` command: #{command}"
@@ -29,6 +35,7 @@ module Yast
         raise SystemctlError, "Timeout #{TIMEOUT} seconds: #{command}"
       end
 
+      # @return [Array<String>] like ["a.socket", "b.socket"]
       def socket_units
         sockets_from_files = list_unit_files(type: :socket).lines.map do |line|
           first_column(line)
@@ -41,6 +48,7 @@ module Yast
         (sockets_from_files | sockets_from_units).compact
       end
 
+      # @return [Array<String>] like ["a.service", "b.service"]
       def service_units
         services_from_files = list_unit_files(type: :service).lines.map do |line|
           first_column(line)
@@ -53,6 +61,7 @@ module Yast
         (services_from_files | services_from_units).compact
       end
 
+      # @return [Array<String>] like ["a.target", "b.target"]
       def target_units
         targets_from_files = list_unit_files(type: :target).lines.map do |line|
           first_column(line)

--- a/library/systemd/src/lib/yast2/systemctl.rb
+++ b/library/systemd/src/lib/yast2/systemctl.rb
@@ -23,6 +23,8 @@ module Yast
     TIMEOUT         = 30 # seconds
 
     class << self
+      BASH_SCR_PATH = Yast::Path.new(".target.bash_output")
+
       # @param command [String]
       # @return [#command,#stdout,#stderr,#exit]
       # @raise [SystemctlError] if it times out
@@ -30,7 +32,7 @@ module Yast
         log.info("systemctl #{command}")
         command = SYSTEMCTL + command
         log.debug "Executing `systemctl` command: #{command}"
-        result = timeout(TIMEOUT) { SCR.Execute(Path.new(".target.bash_output"), command) }
+        result = timeout(TIMEOUT) { SCR.Execute(BASH_SCR_PATH, command) }
         OpenStruct.new(result.merge!(command: command))
       rescue Timeout::Error
         raise SystemctlError, "Timeout #{TIMEOUT} seconds: #{command}"

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -83,7 +83,9 @@ module Yast
       @propmap = propmap.merge!(DEFAULT_PROPMAP)
 
       @properties = show
+      # eg "Failed to get properties: Unit name apache2@.service is not valid."
       @error = properties.error
+      # Id is not present when the unit name is not valid
       @name = id.to_s.split(".").first || unit_name
     end
 

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -225,10 +225,8 @@ module Yast
       end
 
       def load_systemd_properties
-        properties = systemd_unit.propmap.map do |_, property_name|
-          " --property=#{property_name} "
-        end
-        systemd_unit.command("show", options: properties.join)
+        names = systemd_unit.propmap.values
+        systemd_unit.command("show", options: "--property=" + names.join(","))
       end
     end
 

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -76,8 +76,8 @@ module Yast
 
     # @param propmap [Hash{Symbol => String}]
     def initialize(full_unit_name, propmap = {})
-      @unit_name, @unit_type = full_unit_name.split(".")
-      raise "Missing unit type suffix" unless unit_type
+      @unit_name, dot, @unit_type = full_unit_name.rpartition(".")
+      raise "Missing unit type suffix" if dot.empty?
 
       log.warn "Unsupported unit type '#{unit_type}'" unless SUPPORTED_TYPES.include?(unit_type)
       @propmap = propmap.merge!(DEFAULT_PROPMAP)

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -41,8 +41,14 @@ module Yast
     #
     # systemctl.c:check_unit_active uses (active, reloading)
     # For bsc#884756 we also consider "activating" to be active.
-    #
     # (The remaining states are "deactivating", "inactive", "failed".)
+    #
+    # Yes, depending on systemd states that are NOT covered by their
+    # interface stability promise is fragile.
+    # But: 10 to 50ms per call of systemctl is-active, times 100 to 300 services
+    # (depending on hardware and software installed, VM or not)
+    # is a 1 to 15 second delay (bsc#1045658).
+    # That is why we try hard to avoid many systemctl calls.
     ACTIVE_STATES = ["active", "activating", "reloading"].freeze
 
     # A Property Map is a plain Hash(Symbol => String).

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -112,7 +112,7 @@ module Yast
     # @return [Properties]
     def show(property_text = nil)
       # Using different handler during first stage (installation, update, ...)
-      Stage.initial ? InstallationProperties.new(self, property_text) : Properties.new(self, property_text)
+      Stage.initial ? InstallationProperties.new(self) : Properties.new(self, property_text)
     end
 
     def status
@@ -271,7 +271,7 @@ module Yast
     class InstallationProperties < OpenStruct
       include Yast::Logger
 
-      def initialize(systemd_unit, _property_text)
+      def initialize(systemd_unit)
         super()
         self[:systemd_unit] = systemd_unit
         self[:status]       = read_status

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -136,7 +136,6 @@ module Yast
     # @return [#command,#stdout,#stderr,#exit]
     def command(command_name, options = {})
       command = "#{command_name} #{unit_name}.#{unit_type} #{options[:options]}"
-      log.info "`#{Systemctl::CONTROL} #{command}`"
       Systemctl.execute(command)
     end
 

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -37,6 +37,14 @@ module Yast
     SUPPORTED_TYPES  = %w(service socket target).freeze
     SUPPORTED_STATES = %w(enabled disabled).freeze
 
+    # Values of {#active_state} fow which we consider a unit "active".
+    #
+    # systemctl.c:check_unit_active uses (active, reloading)
+    # For bsc#884756 we also consider "activating" to be active.
+    #
+    # (The remaining states are "deactivating", "inactive", "failed".)
+    ACTIVE_STATES = ["active", "activating", "reloading"].freeze
+
     # A Property Map is a plain Hash(Symbol => String).
     # It
     # 1. enumerates the properties we're interested in
@@ -190,7 +198,7 @@ module Yast
         end
 
         extract_properties
-        self[:active?]    = active_state == "active" || active_state == "activating"
+        self[:active?]    = ACTIVE_STATES.include?(active_state)
         self[:running?]   = sub_state    == "running"
         self[:loaded?]    = load_state   == "loaded"
         self[:not_found?] = load_state   == "not-found"

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -72,7 +72,7 @@ module Yast
 
     # @param service_name [String] "foo" or "foo.service"
     # @param propmap [SystemdUnit::PropMap]
-    # @return [Service,nil]
+    # @return [Service,nil] `nil` if not found
     def find(service_name, propmap = {})
       service_name += UNIT_SUFFIX unless service_name.end_with?(UNIT_SUFFIX)
       service = Service.new(service_name, propmap)
@@ -90,7 +90,7 @@ module Yast
 
     # @param service_names [Array<String>] "foo" or "foo.service"
     # @param propmap [SystemdUnit::PropMap]
-    # @return [Array<Service>]
+    # @return [Array<Service,nil>] `nil` if not found
     # @raise [SystemdServiceNotFound] if an unexpected problem occurs
     def find_many!(service_names, propmap = {})
       snames = service_names.map { |n| n + UNIT_SUFFIX unless n.end_with?(UNIT_SUFFIX) }

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -86,6 +86,11 @@ module Yast
       find(service_name, propmap) || raise(SystemdServiceNotFound, service_name)
     end
 
+    def find_many(service_names, propmap = {})
+      # naive impl first, then optimize it
+      service_names.map { |n| find(n, propmap) }
+    end
+
     # @param propmap [SystemdUnit::PropMap]
     # @return [Array<Service>]
     def all(propmap = {})

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -69,25 +69,28 @@ module Yast
     UNIT_SUFFIX = ".service".freeze
 
     # @param service_name [String] "foo" or "foo.service"
+    # @param propmap [SystemdUnit::PropMap]
     # @return [Service,nil]
-    def find(service_name, properties = {})
+    def find(service_name, propmap = {})
       service_name += UNIT_SUFFIX unless service_name.end_with?(UNIT_SUFFIX)
-      service = Service.new(service_name, properties)
+      service = Service.new(service_name, propmap)
       return nil if service.properties.not_found?
       service
     end
 
     # @param service_name [String] "foo" or "foo.service"
+    # @param propmap [SystemdUnit::PropMap]
     # @return [Service]
     # @raise [SystemdServiceNotFound]
-    def find!(service_name, properties = {})
-      find(service_name, properties) || raise(SystemdServiceNotFound, service_name)
+    def find!(service_name, propmap = {})
+      find(service_name, propmap) || raise(SystemdServiceNotFound, service_name)
     end
 
+    # @param propmap [SystemdUnit::PropMap]
     # @return [Array<Service>]
-    def all(properties = {})
+    def all(propmap = {})
       Systemctl.service_units.map do |service_unit|
-        Service.new(service_unit, properties)
+        Service.new(service_unit, propmap)
       end
     end
 

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -91,9 +91,12 @@ module Yast
 
     # @param service_names [Array<String>] "foo" or "foo.service"
     # @param propmap [SystemdUnit::PropMap]
-    # @return [Array<Service,nil>] `nil` if not found, [] if no can do
-    # @raise [SystemdServiceNotFound] if an unexpected problem occurs
-    def find_many_at_once(service_names, propmap = {})
+    # @return [Array<Service,nil>] `nil` if a service is not found,
+    #   [] if this helper cannot be used:
+    #   either we're in the inst-sys without systemctl,
+    #   or it has returned fewer services than requested
+    #   (and we cannot match them up)
+    private def find_many_at_once(service_names, propmap = {})
       return [] if Stage.initial
 
       snames = service_names.map { |n| n + UNIT_SUFFIX unless n.end_with?(UNIT_SUFFIX) }

--- a/library/systemd/src/modules/systemd_socket.rb
+++ b/library/systemd/src/modules/systemd_socket.rb
@@ -68,20 +68,23 @@ module Yast
   class SystemdSocketClass < Module
     UNIT_SUFFIX = ".socket".freeze
 
-    def find(socket_name, properties = {})
+    # @param propmap [SystemdUnit::PropMap]
+    def find(socket_name, propmap = {})
       socket_name += UNIT_SUFFIX unless socket_name.end_with?(UNIT_SUFFIX)
-      socket = Socket.new(socket_name, properties)
+      socket = Socket.new(socket_name, propmap)
       return nil if socket.properties.not_found?
       socket
     end
 
-    def find!(socket_name, properties = {})
-      find(socket_name, properties) || raise(SystemdSocketNotFound, socket_name)
+    # @param propmap [SystemdUnit::PropMap]
+    def find!(socket_name, propmap = {})
+      find(socket_name, propmap) || raise(SystemdSocketNotFound, socket_name)
     end
 
-    def all(properties = {})
+    # @param propmap [SystemdUnit::PropMap]
+    def all(propmap = {})
       sockets = Systemctl.socket_units.map do |socket_unit|
-        Socket.new(socket_unit, properties)
+        Socket.new(socket_unit, propmap)
       end
       sockets.select { |s| s.properties.supported? }
     end

--- a/library/systemd/src/modules/systemd_target.rb
+++ b/library/systemd/src/modules/systemd_target.rb
@@ -45,11 +45,13 @@ module Yast
 
     UNIT_SUFFIX    = ".target".freeze
     DEFAULT_TARGET = "default.target".freeze
-    PROPERTIES     = { allow_isolate: "AllowIsolate" }.freeze
+    # @return [SystemdUnit::PropMap]
+    PROPMAP        = { allow_isolate: "AllowIsolate" }.freeze
 
-    def find(target_name, properties = {})
+    # @param propmap [SystemdUnit::PropMap]
+    def find(target_name, propmap = {})
       target_name += UNIT_SUFFIX unless target_name.end_with?(UNIT_SUFFIX)
-      target = Target.new(target_name, PROPERTIES.merge(properties))
+      target = Target.new(target_name, PROPMAP.merge(propmap))
 
       if target.properties.not_found?
         log.error "Target #{target_name} not found: #{target.properties.inspect}"
@@ -59,13 +61,15 @@ module Yast
       target
     end
 
-    def find!(target_name, properties = {})
-      find(target_name, properties) || raise(SystemdTargetNotFound, target_name)
+    # @param propmap [SystemdUnit::PropMap]
+    def find!(target_name, propmap = {})
+      find(target_name, propmap) || raise(SystemdTargetNotFound, target_name)
     end
 
-    def all(properties = {})
+    # @param propmap [SystemdUnit::PropMap]
+    def all(propmap = {})
       targets = Systemctl.target_units.map do |target_unit_name|
-        find(target_unit_name, properties)
+        find(target_unit_name, propmap)
       end
       targets.compact
     end

--- a/library/systemd/test/systemd_unit_test.rb
+++ b/library/systemd/test/systemd_unit_test.rb
@@ -73,7 +73,7 @@ module Yast
     describe "#properties" do
       it "always returns struct including default properties" do
         unit = SystemdUnit.new("iscsi.socket")
-        expect(unit.properties.to_h.keys).to include(*SystemdUnit::DEFAULT_PROPERTIES.keys)
+        expect(unit.properties.to_h.keys).to include(*SystemdUnit::DEFAULT_PROPMAP.keys)
       end
 
       it "provides status properties methods" do
@@ -106,7 +106,7 @@ module Yast
       end
 
       it "raises an exception if an incomplete unit name is passed" do
-        expect { SystemdUnit.new("sshd") }.to raise_error
+        expect { SystemdUnit.new("sshd") }.to raise_error(RuntimeError)
       end
 
       it "allows to create supported units" do

--- a/library/systemd/test/systemd_unit_test.rb
+++ b/library/systemd/test/systemd_unit_test.rb
@@ -99,10 +99,17 @@ module Yast
 
     describe ".new" do
       it "creates a new SystemdUnit instance with unit name and type parsed from first parameter" do
-        instance = SystemdUnit.new("random.socket")
-        expect { SystemdUnit.new("random.socket") }.not_to raise_error
+        instance = nil
+        expect { instance = SystemdUnit.new("random.socket") }.not_to raise_error
         expect(instance.unit_name).to eq("random")
         expect(instance.unit_type).to eq("socket")
+      end
+
+      it "correctly parses a name with many dots" do
+        instance = nil
+        expect { instance = SystemdUnit.new("dbus-org.freedesktop.hostname1.service") }.not_to raise_error
+        expect(instance.unit_name).to eq("dbus-org.freedesktop.hostname1")
+        expect(instance.unit_type).to eq("service")
       end
 
       it "raises an exception if an incomplete unit name is passed" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Aug 30 13:29:54 UTC 2017 - mvidner@suse.com
+
+- systemd services (bsc#1045658)
+  - add SystemdService.find_many for a speed-up
+  - SystemdUnit fix for units with multiple dots in name
+  - consistent logging of systemctl calls
+- 3.2.37.2
+
+-------------------------------------------------------------------
 Thu Jul 20 11:27:46 UTC 2017 - jreidinger@suse.com
 
 - Add hint for UI about application name and its icon (bsc#1037891)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.37.1
+Version:        3.2.37.2
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
References
- https://trello.com/c/IiJYLiBk/1110-3-speedup-reading-services-state-services-manager 
- [bsc#1045658](https://bugzilla.suse.com/show_bug.cgi?id=1045658)

Changes
- add `SystemdService.find_many` for a speed-up
- `SystemdUnit` fix for units with multiple dots in name
- consistent logging of `systemctl` calls
- better Yardoc