### PR TITLE
Fall back to smaller and/or hicolor icon if the icon can't be found.

### DIFF
--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -32,9 +32,7 @@ require "yast"
 
 module Yast
   class WizardClass < Module
-
-    # Default icon name to use.
-    DefaultIconName = "yast"
+    DEFAULT_ICON_NAME = "yast".freeze
 
     def main
       Yast.import "UI"
@@ -69,7 +67,7 @@ module Yast
       @relnotes_button_id = ""
 
       # Current icon name to set.
-      @icon_name = DefaultIconName
+      @icon_name = DEFAULT_ICON_NAME
     end
 
     def haveFancyUI
@@ -1870,14 +1868,19 @@ module Yast
     # This should be called only immediately before opening a dialog; premature
     # UI calls can interfere with the CommandLine mode.
     def set_icon
-      icon_glob = File.join("{" + Directory.icondir + ",/usr/share/icons/hicolor}",
-                            "{64x64,48x48,32x32,22x22,16x16}", "apps", "#{@icon_name}.png")
+      icon_glob = File.join(
+        "{" + Directory.icondir + ",/usr/share/icons/hicolor}", 
+        "{64x64,48x48,32x32,22x22,16x16}", "apps", "#{@icon_name}.png"
+      )
       icon_path = ""
-      Dir.glob(icon_glob) { |p| icon_path = p; break }
+      Dir.glob(icon_glob) do |path|
+        icon_path = path
+        break
+      end
 
       if icon_path.empty?
         Builtins.y2warning("Cannot set application icon to \"%1.png\"", @icon_name)
-        @icon_name = DefaultIconName
+        @icon_name = DEFAULT_ICON_NAME
         return false
       end
 

--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -1869,7 +1869,7 @@ module Yast
     # UI calls can interfere with the CommandLine mode.
     def set_icon
       icon_glob = File.join(
-        "{" + Directory.icondir + ",/usr/share/icons/hicolor}", 
+        "{" + Directory.icondir + ",/usr/share/icons/hicolor}",
         "{64x64,48x48,32x32,22x22,16x16}", "apps", "#{@icon_name}.png"
       )
       icon_path = ""


### PR DESCRIPTION
Themed YaST module icons may not be available in 64x64.
The default YaST app. icon is not in the theme but in hicolor.

Possible fix for boo#902067 and boo#909730.