### PR TITLE
Fixed the cursor theme in the installation (bsc#1051664)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 29 14:57:52 UTC 2017 - lslezak@suse.cz
+
+- Fixed the cursor theme in the installation (the DMZ theme has
+  been replaced by DMZ-White and DMZ-Black) (bsc#1051664)
+- 4.0.0
+
+-------------------------------------------------------------------
 Fri Aug 25 11:10:29 UTC 2017 - igonzalezsosa@suse.com
 
 - Restore Packages::Repository and Packages::Product in order

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.3.10
+Version:        4.0.0
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0

--- a/scripts/yast2-funcs
+++ b/scripts/yast2-funcs
@@ -129,7 +129,7 @@ function set_qt_env()
 
 function set_inst_qt_env()
 {
-    export XCURSOR_THEME="DMZ"
+    export XCURSOR_THEME="DMZ-White"
     export Y2STYLE="installation.qss"
     export QT_HOME_DIR="/tmp/.qt/"
     if [ "$Screenmode" != "" ] && [ "$Screenmode" != "default" ]; then
@@ -150,7 +150,7 @@ function clr_inst_qt_env()
 
 function set_inst_gtk_env()
 {
-    export XCURSOR_THEME="DMZ"
+    export XCURSOR_THEME="DMZ-White"
 }
 
 


### PR DESCRIPTION
- Fixes https://bugzilla.suse.com/show_bug.cgi?id=1051664
- The `DMZ` theme has been replaced by `DMZ-White` and `DMZ-Black`.
- Version 4.0.0

### Before

![cursor_bad](https://user-images.githubusercontent.com/907998/29828479-18bc1b6c-8cdd-11e7-8694-a77f8720738b.png)


### After

![cursor_correct](https://user-images.githubusercontent.com/907998/29828452-0839f76e-8cdd-11e7-8467-09ac70b9a20d.png)
