### PR TITLE
Wrap text (bsc#1055643)

### DIFF
--- a/library/general/src/Makefile.am
+++ b/library/general/src/Makefile.am
@@ -90,6 +90,7 @@ ylib2_DATA = \
   lib/ui/event_dispatcher.rb \
   lib/ui/greasemonkey.rb \
   lib/ui/service_status.rb \
+  lib/ui/text_helpers.rb \
   lib/ui/widgets.rb
 
 EXTRA_DIST = $(module_DATA) $(client_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ydata_DATA) $(fillup_DATA) $(ylib_DATA) $(ylib2_DATA)

--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -1,0 +1,57 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail, you may find
+# current contact information at www.novell.com.
+# ------------------------------------------------------------------------------
+
+module UI
+  # Provides a set of methods to manipulate and transform UI text
+  module TextHelpers
+    # Wrap given text breaking lines longer than given wrap size. It supports
+    # custom separator, max number of lines to split in and cut text to add
+    # as last line if cut was needed.
+    #
+    # @param [String] text to be wrapped
+    # @param [String] wrap size
+    # @param [Hash <String>] optional parameters as separator and prepend_text.
+    # @return [String] wrap text
+    def wrap_text(text, wrap = 76, separator: " ", prepend_text: "",
+      n_lines: nil, cut_text: nil)
+      lines = []
+      message_line = prepend_text
+      text.split(/\s+/).each_with_index do |t, i|
+        if !message_line.empty? && "#{message_line}#{t}".size > wrap
+          lines << message_line
+          message_line = ""
+        end
+
+        message_line << separator if !message_line.empty? && i != 0
+        message_line << t
+      end
+
+      lines << message_line if !message_line.empty?
+
+      if n_lines && lines.size > n_lines
+        lines = lines[0..n_lines - 1]
+        lines << cut_text if cut_text
+      end
+
+      lines.join("\n")
+    end
+  end
+end

--- a/library/general/test/Makefile.am
+++ b/library/general/test/Makefile.am
@@ -11,8 +11,9 @@ TESTS = \
   os_release_test.rb \
   popup_test.rb \
   proposal_client_test.rb \
-  service_status_test.rb \
   report_test.rb \
+  service_status_test.rb \
+  text_helpers_test.rb \
   widgets_test.rb \
   agents_test/proc_meminfo_agent_test.rb
 

--- a/library/general/test/text_helpers_test.rb
+++ b/library/general/test/text_helpers_test.rb
@@ -1,0 +1,52 @@
+#! /usr/bin/env rspec
+
+require_relative "test_helper"
+
+require "ui/text_helpers"
+
+class TestTextHelpers
+  include UI::TextHelpers
+end
+
+describe ::UI::TextHelpers do
+  describe ".wrap_text" do
+    subject { TestTextHelpers.new }
+    let(:devices) { ["eth0", "eth1", "eth2", "eth3", "a_very_long_device_name"] }
+    let(:more_devices) do
+      [
+        "enp5s0", "enp5s1", "enp5s2", "enp5s3",
+        "enp5s4", "enp5s5", "enp5s6", "enp5s7"
+      ]
+    end
+
+    context "given a text" do
+      it "returns same text if it does not exceed the wrap size" do
+        text = "eth0, eth1, eth2, eth3, a_very_long_device_name"
+
+        expect(subject.wrap_text(devices.join(", "))).to eql(text)
+      end
+
+      context "and a line size" do
+        it "returns given text splitted in lines by given line size" do
+          text = "eth0, eth1, eth2,\n"     \
+                 "eth3,\n"                 \
+                 "a_very_long_device_name"
+
+          expect(subject.wrap_text(devices.join(", "), 16)).to eql(text)
+        end
+      end
+
+      context "and a number of lines and '...' as cut text" do
+        it "returns wrapped text until given line's number adding '...' as a new line" do
+          devices_s = (devices + more_devices).join(", ")
+          text = "eth0, eth1, eth2,\n"        \
+                 "eth3,\n"                    \
+                 "a_very_long_device_name,\n" \
+                 "..."
+
+          expect(subject.wrap_text(devices_s, 20, n_lines: 3, cut_text: "...")).to eql(text)
+        end
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 30 14:02:08 UTC 2017 - knut.anderssen@suse.com
+
+- Added UI:TextHelpers with a wrap_text method moved from
+  yast2-network (bsc#1055643)
+- 4.0.1
+
+-------------------------------------------------------------------
 Tue Aug 29 14:57:52 UTC 2017 - lslezak@suse.cz
 
 - Fixed the cursor theme in the installation (the DMZ theme has

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
I added a wrap_text method to some time ago yast/yast-network#403

https://github.com/yast/yast-network/pull/403/files#diff-72293d1fba24e0701afaa84e81e1af12R734

At that moment we commented that would be better to have it in a common place. 

This bug https://bugzilla.suse.com/show_bug.cgi?id=1055643 remembered me it, so I just take the opportunity to move to a common UI module.

There is a similar method in Rails ActionView https://github.com/rails/rails/blob/0732ea7136da43cf3d84d8ce20dd7105a16e78b0/actionview/lib/action_view/helpers/text_helper.rb#L258 which looks better, but for the this bug I just moved the current functionality.