### PR TITLE
Merge workflow and add support to disable buttons on CWM::Dialog

### DIFF
--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -419,4 +419,33 @@ describe Yast::WorkflowManager do
       subject.addon_control_dir(src_id)
     end
   end
+
+  describe "#merge_product_workflow" do
+    let(:product) do
+      instance_double("Y2Packager::Product", label: "SLES", installation_package: "package")
+    end
+
+    before do
+      subject.main
+      allow(subject).to receive(:AddWorkflow)
+      allow(subject).to receive(:MergeWorkflows)
+      allow(subject).to receive(:RedrawWizardSteps)
+    end
+
+    it "merges installation package workflow" do
+      expect(subject).to receive(:AddWorkflow).with(:package, 0, "package")
+      subject.merge_product_workflow(product)
+    end
+
+    context "when other product's workflow was previously merged" do
+      before do
+        subject.merge_product_workflow(product)
+      end
+
+      it "removes the previous workflow" do
+        expect(subject).to receive(:RemoveWorkflow).with(:package, 0, "package")
+        subject.merge_product_workflow(product)
+      end
+    end
+  end
 end

--- a/library/cwm/src/lib/cwm/dialog.rb
+++ b/library/cwm/src/lib/cwm/dialog.rb
@@ -71,6 +71,11 @@ module CWM
       []
     end
 
+    # @return [Array<Symbol>] Buttons to disable (:back, :next
+    def disable_buttons
+      []
+    end
+
   private
 
     # Create a wizard dialog, run the *block*, ensure the dialog is closed.
@@ -87,11 +92,12 @@ module CWM
     def cwm_show
       Yast::CWM.show(
         contents,
-        caption:        title,
-        back_button:    back_button,
-        abort_button:   abort_button,
-        next_button:    next_button,
-        skip_store_for: skip_store_for
+        caption:         title,
+        back_button:     back_button,
+        abort_button:    abort_button,
+        next_button:     next_button,
+        skip_store_for:  skip_store_for,
+        disable_buttons: disable_buttons
       )
     end
   end

--- a/library/cwm/src/modules/CWM.rb
+++ b/library/cwm/src/modules/CWM.rb
@@ -943,7 +943,8 @@ module Yast
     #   like a reset button or a redrawing.  It will skip also validation, because it is not needed
     #   as nothing is stored.
     # @return [Symbol] wizard sequencer symbol
-    def show(contents, caption: nil, back_button: nil, next_button: nil, abort_button: nil, skip_store_for: [])
+    def show(contents, caption: nil, back_button: nil, next_button: nil, abort_button: nil, skip_store_for: [],
+      disable_buttons: [])
       widgets = widgets_in_contents(contents)
       options = {
         "contents"     => widgets_contents(contents),
@@ -955,6 +956,7 @@ module Yast
       options["next_button"] = next_button if next_button
       options["abort_button"] = abort_button if abort_button
       options["skip_store_for"] = skip_store_for
+      options["disable_buttons"] = disable_buttons
 
       ShowAndRun(options)
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -4,6 +4,7 @@ Thu Aug 31 15:30:24 UTC 2017 - igonzalezsosa@suse.com
 - Add support to disable buttons on CWM::Dialog
 - Add a method WorkflowManager#merge_product_workflow which allows
   to merge a product workflow (fate#322267)
+- 4.0.2
 
 -------------------------------------------------------------------
 Wed Aug 30 14:02:08 UTC 2017 - knut.anderssen@suse.com

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 31 15:30:24 UTC 2017 - igonzalezsosa@suse.com
+
+- Add support to disable buttons on CWM::Dialog
+- Add a method WorkflowManager#merge_product_workflow which allows
+  to merge a product workflow (fate#322267)
+
+-------------------------------------------------------------------
 Wed Aug 30 14:02:08 UTC 2017 - knut.anderssen@suse.com
 
 - Added UI:TextHelpers with a wrap_text method moved from

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.1
+Version:        4.0.2
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
This PR add support to:

* Merge product's workflow (moving the logic from [ProductSelector widget](https://github.com/yast/yast-installation/blob/master/src/lib/installation/dialogs/product_selection.rb#L45).
* Extends CWM::Dialog to support disabling buttons.