### PR TITLE
Handle GPG check during installation

### DIFF
--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -2899,6 +2899,7 @@ module Yast
       Pkg.CallbackStartPackage(nil)
       Pkg.CallbackProgressPackage(nil)
       Pkg.CallbackDonePackage(nil)
+      Pkg.CallbackPkgGpgCheck(nil)
 
       nil
     end

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -417,8 +417,8 @@ module Yast
     #   a blank string is returned (so no decision is made).
     def pkg_gpg_check(data)
       log.debug("pkgGpgCheck data: #{data}")
-      return "I" if Stage.initial && Linuxrc.InstallInf("Insecure") == "1"
-      ""
+      insecure = Stage.initial && Linuxrc.InstallInf("Insecure") == "1"
+      insecure ? "I" : ""
     end
 
     #  After package install.

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -406,6 +406,7 @@ module Yast
     # Handle GPG check result (pkgGpgCheck)
     #
     # If insecure mode is set to '1', the check result is ignored. Otherwise, no decision is made.
+    # When running on an installed system, it always return "".
     #
     # @param data [Hash] Output from `pkgGpgCheck` callback.
     # @option data [Integer] "CheckPackageResult" Check result code according to libzypp.
@@ -416,7 +417,8 @@ module Yast
     #   a blank string is returned (so no decision is made).
     def pkg_gpg_check(data)
       log.debug("pkgGpgCheck data: #{data}")
-      Linuxrc.InstallInf("Insecure") == "1" ? "I" : ""
+      return "I" if Stage.initial && Linuxrc.InstallInf("Insecure") == "1"
+      ""
     end
 
     #  After package install.

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -66,6 +66,7 @@ module Yast
       Yast.import "Progress"
       Yast.import "FileUtils"
       Yast.import "SignatureCheckCallbacks"
+      Yast.import "Linuxrc"
 
       @_provide_popup = false
       @_package_popup = false
@@ -400,6 +401,22 @@ module Yast
       end
 
       true
+    end
+
+    # Handle GPG check result (pkgGpgCheck)
+    #
+    # If insecure mode is set to '1', the check result is ignored. Otherwise, no decision is made.
+    #
+    # @param data [Hash] Output from `pkgGpgCheck` callback.
+    # @option data [Integer] "CheckPackageResult" Check result code according to libzypp.
+    # @option data [String]  "Package" Package's name.
+    # @option data [String]  "Localpath" Path to RPM file.
+    # @option data [String]  "RepoMediaUrl" Media URL.
+    # @return [String] "I" if the package should be accepted; otherwise
+    #   a blank string is returned (so no decision is made).
+    def pkg_gpg_check(data)
+      log.debug("pkgGpgCheck data: #{data}")
+      Linuxrc.InstallInf("Insecure") == "1" ? "I" : ""
     end
 
     #  After package install.
@@ -2663,6 +2680,9 @@ module Yast
       )
       Pkg.CallbackDonePackage(
         fun_ref(method(:DonePackage), "string (integer, string)")
+      )
+      Pkg.CallbackPkgGpgCheck(
+        fun_ref(method(:pkg_gpg_check), "string(map)")
       )
 
       nil

--- a/library/packages/test/package_callbacks_test.rb
+++ b/library/packages/test/package_callbacks_test.rb
@@ -207,4 +207,36 @@ describe Yast::PackageCallbacks do
       expect(cds).to eq []
     end
   end
+
+  describe "#pkp_gpg_check" do
+    let(:data) { { "CheckResult" => 1 } }
+
+    before do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("Insecure").and_return(insecure)
+    end
+
+    context "when insecure is not set" do
+      let(:insecure) { nil }
+
+      it "returns ''" do
+        expect(subject.pkg_gpg_check(data)).to eq("")
+      end
+    end
+
+    context "when Insecure is set to '1'" do
+      let(:insecure) { "1" }
+
+      it "returns 'I'" do
+        expect(subject.pkg_gpg_check(data)).to eq("I")
+      end
+    end
+
+    context "when Insecure is set but different to '1'" do
+      let(:insecure) { "0" }
+
+      it "returns ''" do
+        expect(subject.pkg_gpg_check(data)).to eq("")
+      end
+    end
+  end
 end

--- a/library/packages/test/package_callbacks_test.rb
+++ b/library/packages/test/package_callbacks_test.rb
@@ -213,26 +213,40 @@ describe Yast::PackageCallbacks do
 
     before do
       allow(Yast::Linuxrc).to receive(:InstallInf).with("Insecure").and_return(insecure)
+      allow(Yast::Stage).to receive(:initial).and_return(initial)
     end
 
-    context "when insecure is not set" do
-      let(:insecure) { nil }
+    context "during installation" do
+      let(:initial) { true }
 
-      it "returns ''" do
-        expect(subject.pkg_gpg_check(data)).to eq("")
+      context "and when insecure is not set" do
+        let(:insecure) { nil }
+
+        it "returns ''" do
+          expect(subject.pkg_gpg_check(data)).to eq("")
+        end
+      end
+
+      context "and when Insecure is set to '1'" do
+        let(:insecure) { "1" }
+
+        it "returns 'I'" do
+          expect(subject.pkg_gpg_check(data)).to eq("I")
+        end
+      end
+
+      context "and when Insecure is set but different to '1'" do
+        let(:insecure) { "0" }
+
+        it "returns ''" do
+          expect(subject.pkg_gpg_check(data)).to eq("")
+        end
       end
     end
 
-    context "when Insecure is set to '1'" do
+    context "on an installed system" do
+      let(:initial) { false }
       let(:insecure) { "1" }
-
-      it "returns 'I'" do
-        expect(subject.pkg_gpg_check(data)).to eq("I")
-      end
-    end
-
-    context "when Insecure is set but different to '1'" do
-      let(:insecure) { "0" }
 
       it "returns ''" do
         expect(subject.pkg_gpg_check(data)).to eq("")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep  7 12:15:56 UTC 2017 - igonzalezsosa@suse.com
+
+- Fix handling of PGP signatures when running in insecure mode
+  (bsc#1054663)
+- 4.0.4
+
+-------------------------------------------------------------------
 Mon Sep  4 11:32:04 UTC 2017 - ancor@suse.com
 
 - Added methods to Yast2::FsSnapshot allowing to finish the

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.3
+Version:        4.0.4
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
This simple fix should solve [bsc#1054663](https://bugzilla.opensuse.org/show_bug.cgi?id=1054663). This callback is only called when validation fails and it should be ignored if Insecure=1.

Finally, it does not share code with [AutoYaST counterpart](https://github.com/yast/yast-autoinstallation/blob/676f7f03c907d212c483731651f1e5edfed041b5/src/modules/AutoInstall.rb#L326) because requirements are totally different.