### PR TITLE
Revert to using separate property options to keep old tests working.

### DIFF
--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -255,7 +255,8 @@ module Yast
 
       def load_systemd_properties
         names = systemd_unit.propmap.values
-        systemd_unit.command("show", options: "--property=" + names.join(","))
+        opts = names.map { |property_name| " --property=#{property_name} " }
+        systemd_unit.command("show", options: opts.join)
       end
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 14 07:51:58 UTC 2017 - mvidner@suse.com
+
+- systemd services (bsc#1045658)
+  - reverted a command change that broke brittle tests
+- 3.2.37.3
+
+-------------------------------------------------------------------
 Wed Aug 30 13:29:54 UTC 2017 - mvidner@suse.com
 
 - systemd services (bsc#1045658)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.37.2
+Version:        3.2.37.3
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
yast2-dhcp-server and yast2-samba-server log the exact command used by
us in their tests :-(
