### PR TITLE
Stop using tmpnam, it is no longer supported in perl 5.26

### DIFF
--- a/library/cron/src/servers_non_y2/ag_cron
+++ b/library/cron/src/servers_non_y2/ag_cron
@@ -7,9 +7,6 @@ use ycp;
 use YaST::SCRAgent;
 use Config::Crontab;
 use diagnostics;
-#use Data::Dumper;
-
-use POSIX qw(tmpnam);
 
 our @ISA = ("YaST::SCRAgent");
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  5 13:04:46 UTC 2017 - mvidner@suse.com
+
+- Stop using tmpnam, it is no longer supported in perl 5.26
+  (bsc#1061620)
+- 4.0.9
+
+-------------------------------------------------------------------
 Tue Sep 26 10:31:03 UTC 2017 - jreidinger@suse.com
 
 - Add support for merging to workflow extensions from modules

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.8
+Version:        4.0.9
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
[bsc#1061620](https://bugzilla.suse.com/show_bug.cgi?id=1061620)
https://trello.com/c/EVu9oWwb

BTW the whole ag_cron + Yast::CronClass combo seem to be unused. We may want to drop them.