### PR TITLE
Fixing "disable_remote" function in Linuxrc

### DIFF
--- a/library/general/src/modules/Linuxrc.rb
+++ b/library/general/src/modules/Linuxrc.rb
@@ -244,12 +244,16 @@ module Yast
     # Reset settings for vnc, ssh,... in install.inf which have been made
     # by linuxrc settings.
     #
-    # @param [Array<String>] list of services which will be disabled.
+    # @param [Array<String>] list of remote-management services that will be disabled.
     def disable_remote(services)
       return if !services || services.empty?
-      log.warn "Disabling #{services} due missing packages."
+
+      log.warn "Disabling #{services} due to missing packages."
       services.each do |service|
-        case service
+        # Service IDs are also used in another context in the code
+        # Making sure we always compare apples with apples
+        case polish(service.dup)
+
         when "vnc"
           SCR.Write(path(".etc.install_inf.VNC"), 0)
           SCR.Write(path(".etc.install_inf.VNCPassword"), "")
@@ -257,10 +261,11 @@ module Yast
           SCR.Write(path(".etc.install_inf.UseSSH"), 0)
         when "braille"
           SCR.Write(path(".etc.install_inf.Braille"), 0)
-        when "display-ip"
+        when "displayip"
           SCR.Write(path(".etc.install_inf.DISPLAY_IP"), 0)
         else
-          log.error "#{service} not supported"
+          log.error "Unknown service #{service}"
+          raise ArgumentError.new "Cannot disable #{service}: Unknown service."
         end
       end
       SCR.Write(path(".etc.install_inf"), nil) # Flush the cache

--- a/library/general/src/modules/Linuxrc.rb
+++ b/library/general/src/modules/Linuxrc.rb
@@ -265,7 +265,7 @@ module Yast
           SCR.Write(path(".etc.install_inf.DISPLAY_IP"), 0)
         else
           log.error "Unknown service #{service}"
-          raise ArgumentError.new "Cannot disable #{service}: Unknown service."
+          raise ArgumentError, "Cannot disable #{service}: Unknown service."
         end
       end
       SCR.Write(path(".etc.install_inf"), nil) # Flush the cache

--- a/library/general/test/linuxrc_test.rb
+++ b/library/general/test/linuxrc_test.rb
@@ -237,31 +237,41 @@ describe Yast::Linuxrc do
         .with(path(".etc.install_inf"), nil)
     end
 
-    context "when vnc will be disabled" do
+    context "when vnc should be disabled" do
       it "updates install.inf" do
         expect(Yast::SCR).to receive(:Write)
-          .with(path(".etc.install_inf.VNC"), 0)
+          .with(path(".etc.install_inf.VNC"), 0).twice
         expect(Yast::SCR).to receive(:Write)
-          .with(path(".etc.install_inf.VNCPassword"), "")
-        subject.disable_remote(["vnc"])
+          .with(path(".etc.install_inf.VNCPassword"), "").twice
+        subject.disable_remote(["vnc", "VNC"])
       end
     end
 
-    context "when ssh will be disabled" do
+    context "when ssh should be disabled" do
       it "updates install.inf" do
         expect(Yast::SCR).to receive(:Write)
-          .with(path(".etc.install_inf.UseSSH"), 0)
-        subject.disable_remote(["ssh"])
+          .with(path(".etc.install_inf.UseSSH"), 0).twice
+        subject.disable_remote(["sSh", "ssh"])
       end
     end
 
-    context "when braille and dispaly_ip will be disabled" do
+    context "when braille and dispaly_ip should be disabled" do
       it "updates install.inf" do
         expect(Yast::SCR).to receive(:Write)
           .with(path(".etc.install_inf.Braille"), 0)
         expect(Yast::SCR).to receive(:Write)
-          .with(path(".etc.install_inf.DISPLAY_IP"), 0)
-        subject.disable_remote(["braille", "display-ip"])
+          .with(path(".etc.install_inf.DISPLAY_IP"), 0).twice
+        subject.disable_remote(["braille", "display-ip", "DiSplaY_IP"])
+      end
+    end
+
+    context "when trying to disable an unknown service" do
+      it "throws an exception" do
+        # for other (valid) services
+        allow(Yast::SCR).to receive(:Write)
+
+        unknown_service = "uNkNown-ser_vice"
+        expect { subject.disable_remote(["SSH", unknown_service]) }.to raise_error(ArgumentError, /Cannot disable #{unknown_service}/)
       end
     end
   end

--- a/library/general/test/linuxrc_test.rb
+++ b/library/general/test/linuxrc_test.rb
@@ -239,8 +239,10 @@ describe Yast::Linuxrc do
 
     context "when vnc should be disabled" do
       it "updates install.inf" do
+        # twice, because there are two services, thus two calls to do the same
         expect(Yast::SCR).to receive(:Write)
           .with(path(".etc.install_inf.VNC"), 0).twice
+        # twice, because there are two services, thus two calls to do the same
         expect(Yast::SCR).to receive(:Write)
           .with(path(".etc.install_inf.VNCPassword"), "").twice
         subject.disable_remote(["vnc", "VNC"])
@@ -249,6 +251,7 @@ describe Yast::Linuxrc do
 
     context "when ssh should be disabled" do
       it "updates install.inf" do
+        # twice, because there are two services, thus two calls to do the same
         expect(Yast::SCR).to receive(:Write)
           .with(path(".etc.install_inf.UseSSH"), 0).twice
         subject.disable_remote(["sSh", "ssh"])
@@ -259,6 +262,7 @@ describe Yast::Linuxrc do
       it "updates install.inf" do
         expect(Yast::SCR).to receive(:Write)
           .with(path(".etc.install_inf.Braille"), 0)
+        # twice, because there are two services, thus two calls to do the same
         expect(Yast::SCR).to receive(:Write)
           .with(path(".etc.install_inf.DISPLAY_IP"), 0).twice
         subject.disable_remote(["braille", "display-ip", "DiSplaY_IP"])

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Oct 19 14:42:09 CEST 2017 - locilka@suse.com
+
+- Fixing disabling vnc, ssh, ... installation to handle service
+  names independently on using upper/lower case as they are used
+  in different context at different places of the code
+  (bsc#1055279).
+- 4.0.11
+
+-------------------------------------------------------------------
 Thu Oct  5 14:04:46 UTC 2017 - schubi@suse.de
 
 - Disable vnc, ssh,... installation in install.inf if it is not

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.10
+Version:        4.0.11
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- bsc#1055279
- Arguments "vnc", "ssh" were expected lower-cased in the function, but the code uses them ALSO upper-cased
- I've fixed it in a way that it just does not matter
- Plus if the argument is unknown, error is raised
- Plus it's covered by unit tests