### PR TITLE
log calculated proposal in yaml format into separate files (fate#318196)

### DIFF
--- a/library/general/src/lib/installation/proposal_client.rb
+++ b/library/general/src/lib/installation/proposal_client.rb
@@ -291,7 +291,7 @@ module Installation
       # doing nothing is OK. or is it? clarify the API, the docs, actual usage!
     end
 
-  private
+  protected
 
     # Log current device graph in yaml format.
     def log_proposal_as_yaml

--- a/library/general/src/lib/installation/proposal_client.rb
+++ b/library/general/src/lib/installation/proposal_client.rb
@@ -291,8 +291,6 @@ module Installation
       # doing nothing is OK. or is it? clarify the API, the docs, actual usage!
     end
 
-  protected
-
     # Log current device graph in yaml format.
     def log_proposal_as_yaml
       dg = Y2Storage::StorageManager.instance.staging

--- a/library/general/src/lib/installation/proposal_client.rb
+++ b/library/general/src/lib/installation/proposal_client.rb
@@ -1,4 +1,5 @@
 require "yast"
+require "y2storage"
 
 module Installation
   # Abstract class that simplifies writing proposal clients for installation.
@@ -83,7 +84,9 @@ module Installation
 
       case func
       when "MakeProposal"
-        make_proposal(param)
+        result = make_proposal(param)
+        log_proposal_as_yaml
+        result
       when "AskUser"
         ask_user(param)
       when "Description"
@@ -286,6 +289,17 @@ module Installation
 
     def write
       # doing nothing is OK. or is it? clarify the API, the docs, actual usage!
+    end
+
+  private
+
+    # Log current device graph in yaml format.
+    def log_proposal_as_yaml
+      dg = Y2Storage::StorageManager.instance.staging
+      time_suffix = Time.now.strftime("_%F_%H:%M:%S.%N")
+      file_name = "/var/log/YaST2/proposed_devicegraph#{time_suffix}.yml"
+      log.info "Save proposed device graph to #{file_name}"
+      Y2Storage::YamlWriter.write(dg, file_name)
     end
   end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 23 18:24:53 CEST 2017 - snwint@suse.de
+
+- log calculated proposal in yaml format into separate files (fate#318196)
+- 4.0.12
+
+-------------------------------------------------------------------
 Thu Oct 19 14:42:09 CEST 2017 - locilka@suse.com
 
 - Fixing disabling vnc, ssh, ... installation to handle service

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.11
+Version:        4.0.12
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Looking at y2log alone is not helpful. Log the devicegraph into
human-readable files.