### PR TITLE
Firewalld API: running? return false if the package is not installed

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -83,6 +83,7 @@ module Y2Firewall
       # @return [Boolean] true if the state is running; false otherwise
       def running?
         return false if Yast::Stage.initial
+        return false if !Yast::PackageSystem.Installed(Firewalld::PACKAGE)
 
         state == "running"
       end

--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -27,6 +27,7 @@ require "yast2/execute"
 
 Yast.import "Stage"
 Yast.import "Service"
+Yast.import "PackageSystem"
 
 module Y2Firewall
   class Firewalld
@@ -45,6 +46,8 @@ module Y2Firewall
 
       # Map firewalld modes with their command line tools
       COMMAND = { offline: "firewall-offline-cmd", running: "firewall-cmd" }.freeze
+      # FIXME: Do not like to define twice
+      PACKAGE = "firewalld".freeze
 
       # Determines the mode in which firewalld is running and as consequence the
       # command to be used.
@@ -83,7 +86,7 @@ module Y2Firewall
       # @return [Boolean] true if the state is running; false otherwise
       def running?
         return false if Yast::Stage.initial
-        return false if !Yast::PackageSystem.Installed(Firewalld::PACKAGE)
+        return false if !Yast::PackageSystem.Installed(PACKAGE)
 
         state == "running"
       end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  3 15:39:25 UTC 2017 - knut.anderssen@suse.com
+
+- Firewalld API: running? return false if the package is not
+  installed (fate#323460)
+- 4.0.13
+
+-------------------------------------------------------------------
 Thu Oct 26 09:03:03 UTC 2017 - knut.anderssen@suse.com
 
 - Network (Firewall):

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.12
+Version:        4.0.13
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- Avoid to call firewallctl if it is not installed.
- related to https://build.suse.de/package/live_build_log/SUSE:SLE-15:GA:Staging:Y/yast2-nfs-client/standard/x86_64