### PR TITLE
Add yast-rake dependency

### DIFF
--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -39,6 +39,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:cheetah)
 BuildRequires:  update-desktop-files
 # For running RSpec tests during build
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
+# YaST rake tasks
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 # Needed already in build time
 BuildRequires:  yast2-core >= 2.18.12
 BuildRequires:  yast2-devtools >= 3.1.10
@@ -52,8 +54,6 @@ BuildRequires:  yast2-ycp-ui-bindings >= 3.2.0
 # these should be installed in the default build anyway
 BuildRequires:  rpm
 BuildRequires:  cpio
-# YaST rake tasks
-BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 
 # for ag_tty (/bin/stty)
 # for /usr/bin/md5sum

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -52,6 +52,8 @@ BuildRequires:  yast2-ycp-ui-bindings >= 3.2.0
 # these should be installed in the default build anyway
 BuildRequires:  rpm
 BuildRequires:  cpio
+# YaST rake tasks
+BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake)
 
 # for ag_tty (/bin/stty)
 # for /usr/bin/md5sum


### PR DESCRIPTION
Add missing yast-rake dependency. It should help with some of the packages that are now failing to build.