### PR TITLE
Added known zones to firewalld (fate#323460)

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld.rb
+++ b/library/network/src/lib/y2firewall/firewalld.rb
@@ -23,6 +23,7 @@
 # ***************************************************************************
 
 require "y2firewall/firewalld/api"
+require "y2firewall/firewalld/zone"
 require "singleton"
 
 Yast.import "PackageSystem"

--- a/library/network/src/lib/y2firewall/firewalld/zone.rb
+++ b/library/network/src/lib/y2firewall/firewalld/zone.rb
@@ -1,0 +1,67 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2firewall/firewalld/api"
+
+module Y2Firewall
+  class Firewalld
+    # Class to work with Firewalld zones
+    class Zone
+      include Yast::I18n
+      extend Yast::I18n
+      # Map of known zone names and description
+      KNOWN_ZONES = {
+        "block"    => N_(
+          "Block Zone"
+        ),
+        "dmz"      => N_(
+          "Demilitarized Zone"
+        ),
+        "drop"     => N_(
+          "Drop Zone"
+        ),
+        "external" => N_(
+          "External Zone"
+        ),
+        "home"     => N_(
+          "Home Zone"
+        ),
+        "internal" => N_(
+          "Internal Zone"
+        ),
+        "public"   => N_(
+          "Public Zone"
+        ),
+        "trusted"  => N_(
+          "Trusted Zone"
+        ),
+        "work"     => N_(
+          "Work Zone"
+        )
+      }.freeze
+
+      def self.known_zones
+        KNOWN_ZONES
+      end
+    end
+  end
+end

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -958,6 +958,7 @@ module Yast
               # TODO : delete PREFIXLEN from config file
             end
           end
+          devmap["ZONE"] = nil if devmap["ZONE"] && devmap["ZONE"].empty?
           # write all keys to config
           Builtins.maplist(
             Convert.convert(

--- a/library/network/test/y2firewall/firewalld/zone_test.rb
+++ b/library/network/test/y2firewall/firewalld/zone_test.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+#
+# Copyright (c) [2017] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2firewall/firewalld/zone"
+
+describe Y2Firewall::Firewalld::Zone do
+  describe ".known_zones" do
+    it "returns a hash with known zone names and descriptions" do
+      expect(described_class.known_zones).to be_a(Hash)
+      expect(described_class.known_zones).to include "public"
+      expect(described_class.known_zones["dmz"]).to eq(N_("Demilitarized Zone"))
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Nov 24 11:42:49 UTC 2017 - knut.anderssen@suse.com
+
+- Network:
+  - Do not depent on SuSEFirewall to list the known zones anymore.
+  - NetworkInterfaces: Remove ZONE attribute if it is empty when
+    writing.
+- 4.0.17
+
+-------------------------------------------------------------------
 Wed Nov 22 09:38:59 UTC 2017 - knut.anderssen@suse.com
 
 - Added RSpec shared example for CWM::CheckBox (bsc#1068354).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.16
+Version:        4.0.17
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,6 +24,9 @@ RSpec.configure do |config|
       mocks.verify_partial_doubles = true
     end
   end
+
+  config.extend Yast::I18n  # available in context/describe
+  config.include Yast::I18n # available in it/let/before/...
 end
 
 if ENV["COVERAGE"]


### PR DESCRIPTION
- needed in https://github.com/yast/yast-network/pull/586
- trello card: https://trello.com/c/Yw5lJeGN/1092-5-firewall-firewalld-is-the-new-susefirewall-support-for-network-installer

- Removed the knowledge of zones from SuSEFirewall module, and remote the ZONE attribute if empty.

- The zone class will have more responsibilities but by now I have just commit the strictly necessary for current code.