### PR TITLE
Use full type detection when building device cache

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -791,7 +791,9 @@ module Yast
     # @param [Hash] a map with netconfig (ifcfg) configuration
     #
     def add_device(device, ifcfg)
-      devtype = GetTypeFromIfcfg(ifcfg) || GetType(device)
+      # if possible use dev type as available in /sys otherwise use ifcfg config 
+      # as a fallback for device type detection
+      devtype = GetTypeFromIfcfgOrName(device, ifcfg)
       @Devices[devtype] ||= {}
       @Devices[devtype][device] = ifcfg
     end

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -791,7 +791,7 @@ module Yast
     # @param [Hash] a map with netconfig (ifcfg) configuration
     #
     def add_device(device, ifcfg)
-      # if possible use dev type as available in /sys otherwise use ifcfg config 
+      # if possible use dev type as available in /sys otherwise use ifcfg config
       # as a fallback for device type detection
       devtype = GetTypeFromIfcfgOrName(device, ifcfg)
       @Devices[devtype] ||= {}

--- a/library/network/testsuite/tests/NetworkInterfaces2.out
+++ b/library/network/testsuite/tests/NetworkInterfaces2.out
@@ -37,6 +37,8 @@ Dir	.network.value."eth0.3": ["BOOTPROTO", "ETHERDEVICE", "STARTMODE"]
 Read	.network.value."eth0.3".BOOTPROTO "dhcp"
 Read	.network.value."eth0.3".ETHERDEVICE "eth0"
 Read	.network.value."eth0.3".STARTMODE "manual"
+Read	.target.stat "/sys/class/net/eth0.3/type" nil
+Read	.target.string "/sys/class/net/eth0.3/type" nil
 Dir	.network.value."eth5": ["BOOTPROTO", "STARTMODE"]
 Read	.network.value."eth5".BOOTPROTO "dhcp"
 Read	.network.value."eth5".STARTMODE "manual"
@@ -112,6 +114,8 @@ Read	.network.value."myvlantoo".BOOTPROTO "dhcp"
 Read	.network.value."myvlantoo".ETHERDEVICE "eth0"
 Read	.network.value."myvlantoo".STARTMODE "manual"
 Read	.network.value."myvlantoo".VLAN_ID "2"
+Read	.target.stat "/sys/class/net/myvlantoo/type" nil
+Read	.target.string "/sys/class/net/myvlantoo/type" nil
 Dir	.network.value."ppp5": ["BOOTPROTO", "STARTMODE"]
 Read	.network.value."ppp5".BOOTPROTO "dhcp"
 Read	.network.value."ppp5".STARTMODE "manual"
@@ -126,10 +130,14 @@ Dir	.network.value."virtlan4": ["BOOTPROTO", "ETHERDEVICE", "STARTMODE"]
 Read	.network.value."virtlan4".BOOTPROTO "dhcp"
 Read	.network.value."virtlan4".ETHERDEVICE "eth0"
 Read	.network.value."virtlan4".STARTMODE "manual"
+Read	.target.stat "/sys/class/net/virtlan4/type" nil
+Read	.target.string "/sys/class/net/virtlan4/type" nil
 Dir	.network.value."vlan3": ["BOOTPROTO", "ETHERDEVICE", "STARTMODE"]
 Read	.network.value."vlan3".BOOTPROTO "dhcp"
 Read	.network.value."vlan3".ETHERDEVICE "eth0"
 Read	.network.value."vlan3".STARTMODE "manual"
+Read	.target.stat "/sys/class/net/vlan3/type" nil
+Read	.target.string "/sys/class/net/vlan3/type" nil
 Return	true
 Dump	all=$["arc":$["arc5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "atm":$["atm5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "ci":$["ci5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "ctc":$["ctc5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "dummy":$["dummy5":$["BOOTPROTO":"static", "IPADDR":"1.2.3.4", "NETMASK":"255.0.0.0", "PREFIXLEN":"8", "STARTMODE":"manual"]], "escon":$["escon5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "eth":$["eth5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"], "eth6":$["BOOTPROTO":"static", "IPADDR":"1.2.3.4", "NETMASK":"255.255.255.255", "PREFIXLEN":"32", "STARTMODE":"manual"], "eth7":$["STARTMODE":"manual"], "eth8":$["IPADDR":"1.2.3.4", "NETMASK":"255.0.0.0", "PREFIXLEN":"8", "STARTMODE":"manual"], "eth9":$["IPADDR":"1.2.3.4", "NETMASK":"255.0.0.0", "PREFIXLEN":"8", "STARTMODE":"manual"]], "fddi":$["fddi5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "hippi":$["hippi5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "hsi":$["hsi5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "ippp":$["ippp5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "iucv":$["iucv5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "lo":$["lo":$["BROADCAST":"127.255.255.255", "IPADDR":"127.0.0.1", "NETMASK":"255.0.0.0", "NETWORK":"127.0.0.0", "PREFIXLEN":"8", "STARTMODE":"auto"]], "mynet":$["mynet0":$["BOOTPROTO":"dhcp", "STARTMODE":"auto"]], "myri":$["myri5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "ppp":$["ppp5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "tr":$["tr5":$["BOOTPROTO":"dhcp", "STARTMODE":"manual"]], "vlan":$["eth0.3":$["BOOTPROTO":"dhcp", "ETHERDEVICE":"eth0", "STARTMODE":"manual"], "myvlantoo":$["BOOTPROTO":"dhcp", "ETHERDEVICE":"eth0", "STARTMODE":"manual", "VLAN_ID":"2"], "virtlan4":$["BOOTPROTO":"dhcp", "ETHERDEVICE":"eth0", "STARTMODE":"manual"], "vlan3":$["BOOTPROTO":"dhcp", "ETHERDEVICE":"eth0", "STARTMODE":"manual"]]]
 Dump	NetworkInterfaces::Write

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Nov 24 17:55:50 UTC 2017 - mfilka@suse.com
+
+- bnc#956755, bnc#1061306
+  - fixed storing device information to avoid incorrect "not found"
+    states when querying NetworkInterfaces subsequently
+- 3.1.218
+
+-------------------------------------------------------------------
 Fri Oct  6 11:02:12 UTC 2017 - knut.anderssen@suse.com
 
 - Adapted SuSEFirewallIsInstalled() to return true only when the

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.217
+Version:        3.1.218
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Replaces https://github.com/yast/yast-yast2/pull/527

The fix replaces ifcfg only type detection by full type detection when building device config cache. type detection based on ifcfg can differ from the reality mainly in situations when the config file contains some unexpected option. E.g. when user leaves `ETHERDEVICE=eth0` in eth device's config file then ifcfg based type detection can report type `vlan` but correct one is `eth`.