### PR TITLE
Infrastructure for preserving comments in config files

### DIFF
--- a/library/system/src/lib/yast2/column_config_file.rb
+++ b/library/system/src/lib/yast2/column_config_file.rb
@@ -116,6 +116,8 @@ class ColumnConfigFile < CommentedConfigFile
   #
   # @return [Array<Fixnum>] column widths
   #
+  # rubocop:disable Style/For
+  #
   def calc_column_widths
     return [] unless @pad_columns
     @column_widths = []
@@ -136,7 +138,7 @@ class ColumnConfigFile < CommentedConfigFile
     ColumnConfigFile::Entry.new(self)
   end
 
-  protected
+protected
 
   # Count the maximum number of columns amont all entries.
   #
@@ -254,7 +256,7 @@ class ColumnConfigFile < CommentedConfigFile
       format
     end
 
-    protected
+  protected
 
     # Return the column delimiter used for input (parsing).
     #

--- a/library/system/src/lib/yast2/column_config_file.rb
+++ b/library/system/src/lib/yast2/column_config_file.rb
@@ -1,0 +1,290 @@
+#!/usr/bin/env ruby
+#
+# CommentedConfigFile class
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+require "yast2/commented_config_file"
+
+# Utility class to read and write column-oriented config files that might
+# contain comments that should be preserved when writing the file.
+#
+# One example for this would be /etc/fstab:
+#
+#    # /etc/fstab
+#    #
+#    # <file system>	<mount point>  <type> <options>	    <dump> <pass>
+#
+#    /dev/disk/by-label/swap	 none	swap  sw		 0  0
+#    /dev/disk/by-label/Ubuntu	 /	ext4  errors=remount-ro	 0  1
+#    /dev/disk/by-label/work	 /work	ext4  defaults		 0  2
+#
+# There are 6 columns, separated by whitespace. This class is a refinement of
+# the more generic CommentedConfigFile class to handle such cases.
+#
+class ColumnConfigFile < CommentedConfigFile
+  DEFAULT_MAX_COLUMN_WIDTH = 40
+  DEFAULT_INPUT_DELIMITER = /\s+/
+  DEFAULT_OUTPUT_DELIMITER = "  ".freeze
+
+  # @return [Fixnum] the fallback value for the maximum column width if no
+  # per-column value is specified for a column.
+  #
+  attr_accessor :fallback_max_column_width
+
+  # @return [Array<Fixnum>] Per-column maximum width for each column. If not
+  # specified for a column, 'fallback_max_column_width' is used.
+  #
+  attr_accessor :max_column_widths
+
+  # @return [Boolean] Flag: Pad the columns to a common width (up to each
+  # column's maximum width) or not?
+  #
+  attr_accessor :pad_columns
+
+  # @return [Regexp] Input column delimiter, used for parsing content lines.
+  # This is usually one or more whitespace characters, but it might also be
+  # something completely different like one colon for /etc/passwd.
+  #
+  # If this is non-blank, pad_columns should probably also set to 'false'
+  # because it will always pad with blanks which would probably not be
+  # appropriate for that file format.
+  attr_accessor :input_delimiter
+
+  # @return [String] Output column delimiter; this is used when formatting
+  # columns. The default is " " (two blanks).
+  attr_accessor :output_delimiter
+
+  # @return [Array<Fixnum>] The last column widths calculated.
+  #
+  attr_reader :column_widths
+
+  def initialize
+    super
+    @max_column_widths = []
+    @fallback_max_column_width = DEFAULT_MAX_COLUMN_WIDTH
+    @pad_columns = true
+    @input_delimiter = DEFAULT_INPUT_DELIMITER
+    @output_delimiter = DEFAULT_OUTPUT_DELIMITER
+    @column_widths = []
+  end
+
+  # Format only the entries without header or footer comments, but with
+  # comments before each entry and with the line comments.
+  #
+  # Reimplemented from CommentedConfigFile.
+  #
+  # @return [Array<String>] formatted entries
+  #
+  def format_entries
+    populate_columns
+    calc_column_widths
+    super
+  end
+
+  # Get the column with for one column.
+  # If padding is not enabled, this returns 0.
+  #
+  # @param column_no [Fixnum] number of the column (from 0)
+  #
+  # @return [Fixnum] column width
+  #
+  def get_column_width(column_no)
+    return 0 unless @pad_columns
+    calc_column_widths if @column_widths.empty?
+    @column_widths[column_no] || 0
+  end
+
+  # Get the maximum column with for a column.
+  #
+  # @param column_no [Fixnum] number of the column (from 0)
+  #
+  # @return [Fixnum] column width
+  #
+  def get_max_column_width(column_no)
+    @max_column_widths[column_no] || @fallback_max_column_width
+  end
+
+  # If @pad_columns is set, calculate the best column widths for all columns
+  # and store the result in @column_widths.
+  #
+  # @return [Array<Fixnum>] column widths
+  #
+  def calc_column_widths
+    return [] unless @pad_columns
+    @column_widths = []
+
+    for col in 0...count_max_columns
+      @column_widths[col] = calc_column_width(col)
+    end
+    @column_widths
+  end
+
+  # Create a new entry.
+  #
+  # Reimplemented from CommentedConfigFile.
+  #
+  # @return [ColumnConfigFile::Entry] new entry
+  #
+  def create_entry
+    ColumnConfigFile::Entry.new(self)
+  end
+
+  protected
+
+  # Count the maximum number of columns amont all entries.
+  #
+  # @return [Fixnum]
+  #
+  def count_max_columns
+    reduce(0) { |old_max, entry| [old_max, entry.columns.size].max }
+  end
+
+  # Populate all columns of all entries.
+  #
+  # This is intended for derived entry classes to copy their internal content
+  # to the columns just prior to formatting output.
+  #
+  def populate_columns
+    each(&:populate_columns)
+  end
+
+  # Find the maximum column width for one column, limited by that column's
+  # maximum width.
+  def calc_column_width(column_no)
+    max_width = get_max_column_width(column_no)
+
+    reduce(0) do |old_max, entry|
+      col = entry.columns[column_no]
+      next old_max if col.nil? # This entry doesn't have that many columns
+
+      # Only take the width of this column of this entry into account if it is
+      # not wider than the maximum for this column; otherwise we will always
+      # end up with the maximum width for any column that has just one item the
+      # maximum width, but for that one item the maximum will be exceeded
+      # anyway (otherwise we'd have to cut if off which we clearly can't). So
+      # oversize column items should not be part of this calculation; we want
+      # to know the widths of the "normal" items only.
+
+      if col.size > max_width && max_width > 0
+        old_max
+      else
+        [col.size, old_max].max
+      end
+    end
+  end
+
+  # Class representing one content line with all its columns and the preceding
+  # comments.
+  #
+  # When subclassing this, don't forget to also overwrite
+  # ColumnConfigFile::create_entry!
+  #
+  class Entry < CommentedConfigFile::Entry
+    attr_accessor :columns
+
+    # Constructor. Notice that while the parent class does not really do
+    # anything with the parent, this class does, so it is important to set it.
+    #
+    # @param parent [ColumnConfigFile]
+    #
+    def initialize(parent)
+      super
+      @columns = []
+    end
+
+    # Parse a content line. This expects any line comment and the newline to be
+    # stripped off already.
+    #
+    # Reimplemented from CommentedConfigFile::Entry.
+    #
+    # @param line [String] content line without any line comment
+    # @param line_no [Fixnum] line number for error reporting
+    #
+    # @return [Boolean] true if success, false if error
+    #
+    def parse(line, _line_no = -1)
+      super
+      @columns = line.split(input_delimiter)
+      true
+    end
+
+    # Format the content (without the line comment) as a string.
+    # Derived classes might choose to override this.
+    #
+    # Reimplemented from CommentedConfigFile::Entry.
+    #
+    # @return [String] formatted line without line comment.
+    #
+    def format
+      line = ""
+      @columns.each_with_index do |_col, i|
+        line << output_delimiter unless line.empty?
+        line << pad_column(i)
+      end
+      line
+    end
+
+    # Populate the columns. This is called just prior to calculating the column
+    # widths and formatting the columns. Derived classes can use this to fill
+    # the columns with values from any other fields.
+    #
+    # This default implementation does nothing.
+    #
+    def populate_columns
+    end
+
+    # String conversion, mostly for debugging.
+    #
+    # Make sure that the columns are updated: Derived classes (e.g. EtcFstab)
+    # typically operate on data members that are parsed from the individual
+    # columns, so we need to give the derived class a chance to update the
+    # columns from those data members to get meaningful output.
+    #
+    # @return [String]
+    #
+    def to_s
+      populate_columns
+      format
+    end
+
+    protected
+
+    # Return the column delimiter used for input (parsing).
+    #
+    # @return [Regexp] delimiter
+    #
+    def input_delimiter
+      return DEFAULT_INPUT_DELIMITER unless parent && parent.respond_to?(:input_delimiter)
+      parent.input_delimiter
+    end
+
+    # Return the column delimiter used for output, usually two blanks.
+    #
+    # @return [String] delimiter
+    #
+    def output_delimiter
+      return DEFAULT_OUTPUT_DELIMITER unless parent && parent.respond_to?(:output_delimiter)
+      parent.output_delimiter
+    end
+
+    # Pad column no. 'column_no' to the desired witdh.
+    #
+    # @param [Fixnum] column_no
+    #
+    # @return [String] padded column text
+    #
+    def pad_column(column_no)
+      col = @columns[column_no]
+      return col unless parent && parent.respond_to?(:pad_columns)
+      return col unless parent.pad_columns
+      col.ljust(parent.get_column_width(column_no), " ")
+    end
+  end
+end

--- a/library/system/src/lib/yast2/column_config_file.rb
+++ b/library/system/src/lib/yast2/column_config_file.rb
@@ -88,7 +88,7 @@ class ColumnConfigFile < CommentedConfigFile
     super
   end
 
-  # Get the column with for one column.
+  # Get the column width for one column.
   # If padding is not enabled, this returns 0.
   #
   # @param column_no [Fixnum] number of the column (from 0)
@@ -101,7 +101,7 @@ class ColumnConfigFile < CommentedConfigFile
     @column_widths[column_no] || 0
   end
 
-  # Get the maximum column with for a column.
+  # Get the maximum column width for a column.
   #
   # @param column_no [Fixnum] number of the column (from 0)
   #

--- a/library/system/src/lib/yast2/commented_config_file.rb
+++ b/library/system/src/lib/yast2/commented_config_file.rb
@@ -274,7 +274,7 @@ class CommentedConfigFile
     Entry.new(self)
   end
 
-  protected
+protected
 
   # Parse the entries in 'lines'. Header and footer comments should already
   # removed from 'lines'.
@@ -287,6 +287,8 @@ class CommentedConfigFile
   # @param to   [Fixnum] line number of the last  line to parse
   #
   # @return [Boolean] true if success, false if error
+  #
+  # rubocop:disable Style/For
   #
   def parse_entries(lines, from, to)
     clear_entries

--- a/library/system/src/lib/yast2/commented_config_file.rb
+++ b/library/system/src/lib/yast2/commented_config_file.rb
@@ -91,12 +91,16 @@ class CommentedConfigFile
   # @return [String] The comment marker; "#" by default.
   attr_accessor :comment_marker
 
+  # @return [Boolean] Enable end-of-line-comments? true by default.
+  attr_accessor :line_comments_enabled
+
   def initialize
     @comment_marker = "#"
     @header_comments = nil
     @footer_comments = nil
     @entries = []
     @filename = nil
+    @line_comments_enabled = true
   end
 
   def header_comments?
@@ -178,6 +182,8 @@ class CommentedConfigFile
   # @return [Array<String>] [content, comment]
   #
   def split_off_comment(line)
+    return [line.strip, nil] unless @line_comments_enabled
+
     match = /^(.*)(#{comment_marker}.*)/.match(line)
     return [line.strip, nil] if match.nil?
 

--- a/library/system/src/lib/yast2/commented_config_file.rb
+++ b/library/system/src/lib/yast2/commented_config_file.rb
@@ -1,0 +1,460 @@
+#!/usr/bin/env ruby
+#
+# CommentedConfigFile class
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+# Utility class to read and write config files that might contain comments.
+# This class tries to preserve any existing comments and keep them together
+# with the content line immediately following them.
+#
+# This class supports the notion of a header comment block, a footer comment
+# block, a comment block preceding any content line and a line comment on the
+# content line itself.
+#
+# A comment preceding a content line is stored together with the content line,
+# so moving around entries in the file will keep the comment with the content
+# line it belongs to.
+#
+# The default comment marker is '#' like in most Linux config files, but it
+# can be set with setCommentMarker().
+#
+# Example (line numbers added for easier reference):
+#
+#   001    # Header comment 1
+#   002    # Header comment 2
+#   003    # Header comment 3
+#   004
+#   005
+#   006    # Header comment 4
+#   007    # Header comment 5
+#   008
+#   009    # Content line 1 comment 1
+#   010    # Content line 1 comment 2
+#   011    content line 1
+#   012    content line 2
+#   013
+#   014    content line 3
+#   015
+#   016    content line 4
+#   017    content line 5 # Line comment 5
+#   018    # Content line 6 comment 1
+#   019
+#   020    content line 6 # Line comment 6
+#   021    content line 7
+#   022
+#   023    # Footer comment 1
+#   024    # Footer comment 2
+#   025
+#   026    # Footer comment 3
+#
+#
+# Empty lines or lines that have only whitespace belong to the next comment
+# block: The footer comment consists of lines 022..026.
+#
+# The only exception is the header comment that stretches from the start of
+# the file to the last empty line preceding a content line. This is what
+# separates the header comment from the comment that belongs to the first
+# content line. In this example, the header comment consists of lines
+# 001..008.
+#
+# Content line 1 in line 011 has comments 009..010.
+# Content line 2 in line 012 has no comment.
+# Content line 3 in line 014 has comment 013 (an empty line).
+# Content line 5 in line 017 has a line comment "# Line comment 5".
+# Content line 6 in line 020 has comments 018..019 and a line comment.
+#
+# Applications using this class can largely just ignore all the comment stuff;
+# the class will handle the comments automagically.
+#
+class CommentedConfigFile
+  include Enumerable
+
+  # @return [Array<Entry>] The config file entries.
+  attr_accessor :entries
+
+  # @return [Array<String>] The header comments
+  attr_accessor :header_comments
+
+  # @return [Array<String>] The footer comments
+  attr_accessor :footer_comments
+
+  # @return [String] The last filename that content was read from.
+  attr_reader :filename
+
+  # @return [String] The comment marker; "#" by default.
+  attr_accessor :comment_marker
+
+  def initialize
+    @comment_marker = "#"
+    @header_comments = nil
+    @footer_comments = nil
+    @entries = []
+    @filename = nil
+  end
+
+  def header_comments?
+    !@header_comments.nil? && !@header_comments.empty?
+  end
+
+  def footer_comments?
+    !@footer_comments.nil? && !@footer_comments.empty?
+  end
+
+  # Provide iterator infrastructure. Together with the Enumerable mixin this
+  # provides each, select, reject, map, find, first (but not last) and some
+  # more.
+  #
+  def each(&block)
+    @entries.each(&block)
+  end
+
+  # Get the last entry. Surprisingly enough, this is not provided by
+  # Enumerable.
+  #
+  # @return [Entry]
+  #
+  def last
+    @entries.last
+  end
+
+  def delete_if(&block)
+    @entries.delete_if(&block)
+  end
+
+  # Return the number of entries
+  #
+  # @return [Fixnum]
+  #
+  def size
+    @entries.size
+  end
+
+  def clear_entries
+    @entries = []
+  end
+
+  def clear_all
+    clear_entries
+    @header_comments = nil
+    @footer_comments = nil
+  end
+
+  # Check if a line is a comment line (not an empty line!).
+  #
+  # @param line [String] line to check
+  # @return [Boolean] true if comment, false otherwise
+  #
+  def comment_line?(line)
+    line =~ /^\s*#{@comment_marker}.*/ ? true : false
+  end
+
+  # Check if a line is an empty line, i.e. it is completely empty or it only
+  # contains whitespace.
+  #
+  # @param line [String] line to check
+  # @return [Boolean] true if empty, false otherwise
+  #
+  def empty_line?(line)
+    # /m : multi-line mode
+    # \z : end of string; different from $ (end of line) in multi-line strings.
+    line =~ /^\s*\z/m ? true : false
+  end
+
+  # Split a content line into the real content and any potential line comment:
+  # "foo = bar   # baz" -> ["foo=bar", "# baz"]
+  #
+  # The content is also stripped of any leading and trailing whitespace.
+  # The line comment, if present, contains the leading comment marker.
+  #
+  # @param line [String]
+  # @return [Array<String>] [content, comment]
+  #
+  def split_off_comment(line)
+    match = /^(.*)(#{comment_marker}.*)/.match(line)
+    return [line.strip, nil] if match.nil?
+
+    content = match[1]
+    comment = match[2]
+
+    [content.strip, comment]
+  end
+
+  # Parse lines: Split the file content up between header comment, content,
+  # footer content. Parse each content line, breaking it up into its comment
+  # before each entry, the content itself and the line comment.
+  #
+  def parse(lines)
+    clear_all
+    header_end = store_header_comments(lines)
+    footer_start = store_footer_comments(lines, header_end + 1)
+
+    # We need to just store the header and footer comments and leave 'lines'
+    # untouched so any error handling in the parser can return the real line
+    # numbers of an error; if we would split off the comments, those line
+    # numbers would be off.
+
+    parse_entries(lines, header_end + 1, footer_start - 1)
+  end
+
+  # Format the complete file content into separate lines, including header and
+  # footer comments. This is the reverse operation of 'parse'.
+  #
+  # @return [Array<String>] formatted content
+  #
+  def format_lines
+    lines = []
+    lines.concat(@header_comments) if header_comments?
+    lines.concat(format_entries)
+    lines.concat(@footer_comments) if footer_comments?
+    lines
+  end
+
+  # Format only the entries without header or footer comments, but with
+  # comments before each entry and with the line comments.
+  #
+  # @return [Array<String>] formatted entries
+  #
+  def format_entries
+    lines = []
+    each do |entry|
+      lines.concat(entry.comment_before) if entry.comment_before?
+      content_line = entry.format
+      content_line += " " + entry.line_comment if entry.line_comment?
+      lines << content_line
+    end
+    lines
+  end
+
+  # Format the complete file content into a single multi-line string.
+  #
+  # @return [String] formatted content
+  #
+  def to_s
+    format_lines.join("\n")
+  end
+
+  # Read a file and parse it.
+  #
+  # @param filename [String]
+  #
+  def read(filename)
+    @filename = filename
+    lines = []
+    open(filename).each { |line| lines << line.chomp }
+    parse(lines)
+  end
+
+  # Write the stored content to a file. If no filename is specified, reuse the
+  # filename the content was read from.
+  #
+  # @param filename [String]
+  #
+  def write(filename = nil)
+    filename ||= @filename
+    open(filename, "w") do |file|
+      format_lines.each { |line| file.puts(line) }
+    end
+  end
+
+  # Create a new entry.
+  #
+  # Derived classes might choose to override this and return an instance of
+  # their own entry class.
+  #
+  # @return [CommentedConfigFile::Entry] new entry
+  #
+  def create_entry
+    Entry.new(self)
+  end
+
+  protected
+
+  # Parse the entries in 'lines'. Header and footer comments should already
+  # removed from 'lines'.
+  #
+  # This will create a new Entry object for each content line and add it to the
+  # internal array of entries.
+  #
+  # @param lines [Array<String>]
+  # @param from [Fixnum] line number of the first line to parse
+  # @param to   [Fixnum] line number of the last  line to parse
+  #
+  # @return [Boolean] true if success, false if error
+  #
+  def parse_entries(lines, from, to)
+    clear_entries
+    comment_before = []
+    success = true
+
+    for line_no in from..to
+      line = lines[line_no]
+      if empty_line?(line) || comment_line?(line)
+        comment_before << line
+      else # found a content line
+        entry = create_entry
+        entry.comment_before = comment_before unless comment_before.empty?
+        comment_before = []
+        content, entry.line_comment = split_off_comment(line)
+        if entry.parse(content, line_no)
+          @entries << entry
+        else
+          success = false
+        end
+      end
+    end
+    success
+  end
+
+  # Identify the header comments from 'lines' and store them in
+  # 'header_comments'. Leave 'lines' untouched.
+  #
+  # @param lines [Array<String>]
+  # @return [Fixnum] header end
+  #
+  def store_header_comments(lines)
+    header_end = find_header_comment_end(lines)
+    @header_comments = lines.slice(0, header_end + 1)
+    header_end
+  end
+
+  # Identify the footer comments from 'lines' and store them in
+  # 'footer_comments'. Leave 'lines' untouched.
+  #
+  # @param lines [Array<String>]
+  # @return [Fixnum] footer start
+  #
+  def store_footer_comments(lines, from)
+    footer_start = find_footer_comment_start(lines, from)
+    footer_length = lines.size - footer_start
+    @footer_comments = lines.slice(footer_start, footer_length)
+    footer_start
+  end
+
+  # Find the line number of the end of the header comment.
+  #
+  # @param lines [Array<String>]
+  # @return [Fixnum] line number or -1 if there is no header comment
+  #
+  def find_header_comment_end(lines)
+    header_end = -1
+    last_empty_line = -1
+
+    lines.each_with_index do |line, i|
+      if empty_line?(line)
+        last_empty_line = i
+      elsif comment_line?(line)
+        header_end = i
+      else # found the first content line
+        break
+      end
+    end
+
+    if last_empty_line > 0
+      header_end = last_empty_line
+      # This covers two cases:
+      #
+      # - If there were empty lines and no more comment lines before the
+      #   first content line, the empty lines belong to the header comment.
+      #
+      # - If there were empty lines and then some more comment lines before
+      #   the first content line, the comments after the last empty line no
+      #   longer belong to the header comment, but to the first content
+      #   entry. So let's go back to that last empty line.
+    end
+
+    header_end
+  end
+
+  # Find the line numer of the first line of the footer comment.
+  #
+  # @param lines [Array<String>]
+  # @return [Fixnum] line number or lines.size if there is no footer comment
+  #
+  def find_footer_comment_start(lines, from)
+    footer_start = lines.size
+
+    lines.reverse_each.each_with_index do |line, i|
+      line_no = lines.size - 1 - i
+      break if line_no < from
+      break unless empty_line?(line) || comment_line?(line)
+      footer_start = line_no
+    end
+
+    footer_start
+  end
+
+  # Class representing one content line and the preceding comments.
+  #
+  # When subclassing this, don't forget to also overwrite
+  # CommentedConfigFile::create_entry!
+  #
+  class Entry
+    # @return [CommentedConfigFile] The parent CommentedConfigFile.
+    #
+    # While this base class does not really use the parent, derived classes
+    # will so they can access data from their parent config file.
+    attr_accessor :parent
+
+    # @return [String] Content without any comment.
+    attr_accessor :content
+
+    # @return [Array<String>] Comment lines before the entry.
+    attr_accessor :comment_before
+
+    # @return [String] Comment on the same line as the entry (without trailing
+    # newline).
+    attr_accessor :line_comment
+
+    # Constructor.
+    #
+    # @param parent [CommentedConfigFile]
+    #
+    def initialize(parent = nil)
+      @parent = parent
+      @content = nil
+      @comment_before = nil
+      @line_comment = nil
+    end
+
+    def comment_before?
+      !@comment_before.nil? && !@comment_before.empty?
+    end
+
+    def line_comment?
+      !@line_comment.nil? && !@line_comment.empty?
+    end
+
+    # Parse a content line. This expects any line comment and the newline to be
+    # stripped off already.
+    #
+    # Derived classes might choose to override this.
+    #
+    # @param line [String] content line without any line comment
+    # @param line_no [Fixnum] line number for error reporting
+    #
+    # @return [Boolean] true if success, false if error
+    #
+    def parse(line, _line_no = -1)
+      @content = line
+      true
+    end
+
+    # Format the content (without the line comment) as a string.
+    # Derived classes might choose to override this.
+    #
+    # @return [String] formatted line without line comment.
+    #
+    def format
+      content
+    end
+
+    alias_method :to_s, :format
+  end
+end

--- a/library/system/src/lib/yast2/commented_config_file.rb
+++ b/library/system/src/lib/yast2/commented_config_file.rb
@@ -163,8 +163,9 @@ class CommentedConfigFile
   #
   def empty_line?(line)
     # /m : multi-line mode
+    # \A : start of string; different from ^ in multi-line strings.
     # \z : end of string; different from $ (end of line) in multi-line strings.
-    line =~ /^\s*\z/m ? true : false
+    line =~ /\A\s*\z/m ? true : false
   end
 
   # Split a content line into the real content and any potential line comment:

--- a/library/system/src/lib/yast2/etc_fstab.rb
+++ b/library/system/src/lib/yast2/etc_fstab.rb
@@ -1,0 +1,566 @@
+#!/usr/bin/env ruby
+#
+# CommentedConfigFile class
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+require "yast2/column_config_file"
+
+# Class to handle /etc/fstab of a Linux/Unix system.
+#
+# This includes parsing and formatting, accessing and modifying entries,
+# maintaining the correct order between them (since they might have
+# dependencies between mount points) and keeping comments in the file intact
+# (see the CommentedConfigFile and ColumnConfigFile base classes).
+#
+# Use the "entries" member variable (inherited from CommentedConfigFile) to
+# access the entries.
+#
+# To add a new entry, it is strongly advised to use add_entry from this class
+# rather than just appending an entry via the inherited "entries" member:
+# add_entry takes care of the correct order of mount points in case there are
+# depencencies.
+#
+# For example, an entry for /var/lib/myapp should appear AFTER the entry for
+# /var/lib, otherwise /var/lib (if mounted after /var/lib/myapp) would shadow
+# the already mounted /var/lib/myapp which is typically not desired.
+#
+# Important / useful inherited methods:
+# read, write, parse, format;
+# each, select, reject, map, first, last, delete_if
+#
+class EtcFstab < ColumnConfigFile
+  # The usual name of that file
+  ETC_FSTAB = "/etc/fstab".freeze
+
+  # Constructor.
+  #
+  # @param filename [String] File to read if specified.
+  #
+  def initialize(filename = nil)
+    super()
+    @max_column_widths = [45, 25, 7, 30, 1, 1]
+    @pad_columns = true
+    read(filename) unless filename.nil?
+  end
+
+  # Add an entry. The entry can be created with EtcFstab::Entry.create_entry or
+  # with plain EtcFstab::Entry.new; it will always be reparented to this
+  # EtcFstab instance.
+  #
+  # It is strongly advised to use this add_entry method rather than just
+  # appending an entry via the inherited "entries" member: add_entry takes care
+  # of the correct order of mount points in case there are depencencies:
+  #
+  # For example, an entry for /var/lib/myapp should appear AFTER the entry for
+  # /var/lib, otherwise /var/lib (if mounted after /var/lib/myapp) would shadow
+  # the already mounted /var/lib/myapp which is typically not desired.
+  #
+  # @param entry [EtcFstab::Entry]
+  #
+  def add_entry(entry)
+    entry.parent = self
+    index = find_sort_index(entry)
+    @entries.insert(index, entry)
+  end
+
+  # Return all devices in this fstab in the order in which they appear.
+  #
+  # @return [Array<String>]
+  #
+  def devices
+    map(&:device)
+  end
+
+  # Return all mount points in this fstab in the order in which they appear.
+  #
+  # @return [Array<String>]
+  #
+  def mount_points
+    map(&:mount_point)
+  end
+
+  # Return all filesystem types in this fstab in the order in which they appear.
+  #
+  # This does not filter out duplicates; use Array::uniq on the result if this
+  # is desired.
+  #
+  # @return [Array<String>]
+  #
+  def fs_types
+    map(&:fs_type)
+  end
+
+  # Find the (first) entry with the specified mount point. Return nil if there
+  # is no such entry.
+  #
+  # @param mount_point [String]
+  #
+  # @return [EtcFstab::Entry] or nil if not found
+  #
+  def find_mount_point(mount_point)
+    find { |entry| entry.mount_point == mount_point }
+  end
+
+  # Find the (first) entry with the specified device. Return nil if there
+  # is no such entry.
+  #
+  # @param device [String]
+  #
+  # @return [EtcFstab::Entry] or nil if not found
+  #
+  def find_device(device)
+    find { |entry| entry.device == device }
+  end
+
+  # Check the mount order of all the entries, i.e. if all entries are listed
+  # after any mount points they depend on. Call fix_mount_order to fix the
+  # problem.
+  #
+  # For example, if an entry for /var/lib/myapp appears before the entry for
+  # /var/lib, the /var/lib would shadow /var/lib/myapp, so this method would
+  # return 'false'.
+  #
+  # @return [Boolean] 'true' if okay, 'false' if there are mount order problems.
+  #
+  def check_mount_order
+    next_mount_order_problem == -1
+  end
+
+  # Fix any mount order problems: Make sure the entries are listed in the
+  # correct order.
+  #
+  # For example, if an entry for /var/lib/myapp appears before the entry for
+  # /var/lib, the /var/lib would shadow /var/lib/myapp. This method fixes this
+  # if possible.
+  #
+  # Notice that it is still possible that some problems cannot be fixed (in
+  # which case this method returns 'false'): For example, if somebody edited
+  # /etc/fstab manually and added the same mount point for two entries. This is
+  # wrong, but this cannot be fixed automatically (we'd have to decide which
+  # one to remove). Don't call this again and again if there are such unfixable
+  # problems.
+  #
+  # @return [Boolean] 'true' if all problems are fixed, 'false' if not
+  #
+  def fix_mount_order
+    reordered = []
+    start_index = 0
+    success = true
+
+    while start_index < @entries.size
+      # problem_index = next_mount_order_problem(start_index)
+      problem_index = next_mount_order_problem(start_index)
+      return success if problem_index == -1 # No more problem -> we are finished.
+
+      entry = @entries[problem_index]
+      if reordered.include?(entry)
+        # We already reordered this entry. This should not happen, but now we
+        # have to prevent an endless loop; so let's skip over this entry now.
+        start_index = problem_index + 1
+        success = false
+
+        # There is one pathological case where this could happen:
+        #
+        # When two or more entries have the same mount point (which is illegal,
+        # but somebody might write such an fstab manuallly), there is no
+        # correct mount order; this algorithm would get into an endless loop if
+        # we now checked the same index again. But by just proceeding with the
+        # next one (and silently assuming that the one we just changed is well
+        # and truly fixed), we can avoid that endless loop.
+        #
+        # The fstab is of course still incorrect, but there is nothing we can
+        # do about that at this point.
+      else
+        # Take this entry out of the entries and put it back at the correct
+        # place.
+        @entries.delete_at(problem_index)
+        add_entry(entry)
+
+        # Keep track of the reordered entries to avoid an endless loop
+        reordered << entry
+      end
+    end
+    success
+  end
+
+  # Find the the entry index of the next mount order problem starting from
+  # 'start_index' or -1 if there is no more.
+  #
+  # @param start_index [Fixnum]
+  #
+  # @return [Fixnum] Next problematic entry index or -1 if no more problems
+  #
+  def next_mount_order_problem(start_index = 0)
+    each_with_index do |entry, index|
+      next if index < start_index
+      sort_index = find_sort_index(entry)
+      next if sort_index == -1
+      return index if sort_index < index
+    end
+    -1
+  end
+
+  protected
+
+  # Find the correct index for an entry if it depends on any other entry or -1
+  # if no other entry depends on this one, i.e. it can safely added to the end
+  # of the list.
+  #
+  # @param new_entry [EtcFstab::Entry]
+  #
+  # @return [Fixnum] correct index or -1 if there is no dependency
+  #
+  def find_sort_index(new_entry)
+    mount_point = new_entry.mount_point
+    each_with_index do |entry, index|
+      next if entry.equal?(new_entry)
+      return index if entry.mount_point.start_with?(mount_point)
+    end
+    -1
+  end
+
+  public
+
+  # Get the "mount by" type of a device entry in /etc/fstab.
+  # See also EtcFstab::Entry.get_mount_by.
+  #
+  # @param device [String] device field or complete entry line
+  # @return [Symbol] One of :uuid, :label, :id, :path, :device
+  #
+  def self.get_mount_by(device)
+    case device
+    when /^UUID=/, %r{^/dev/disk/by-uuid/}
+      :uuid
+    when /^LABEL=/, %r{^/dev/disk/by-label/}
+      :label
+    when %r{^/dev/disk/by-id/}
+      :id
+    when %r{^/dev/disk/by-path/}
+      :path
+    else
+      :device
+    end
+  end
+
+  # Encode an fstab entry. It may sound surprising, but the file format
+  # actually allows space characters in certain places, such as the mount
+  # point; the reasoning is that a space character is a permitted character in
+  # a directory name, so there has to be a way to specify such a path without
+  # breaking the file format. According to "man fstab", this is done by
+  # encoding the space character in octal, i.e. as \040. This is the function
+  # to do it.
+  #
+  # This class and the corresponding entry class handles this transparently, so
+  # this should never be necessary to use from the outside.
+  #
+  # @param unencoded [String] String with possible space characters
+  # @return [String] String with space characters replaced by \040
+  #
+  def self.fstab_encode(unencoded)
+    unencoded.gsub(" ", '\\\\040')
+    # We need four (!) backslashes here because otherwise gsub will assume this
+    # is a back-reference to a grouped regexp part in the search expression:
+    # \\1 would be the first (..) group, \\2 the second etc.
+  end
+
+  # Decode an fstab entry. This is the inverse operation to fstab_encode.
+  #
+  # @param encoded [String] String with possible \040 sequences
+  # @return [String] String with \040 replaced by a space character each
+  #
+  def self.fstab_decode(encoded)
+    encoded.gsub('\\040', " ")
+    # Unlike in fstab_encode, only two backslashes are needed here because it
+    # is in the original expression, so it cannot be a back-reference.
+  end
+
+  # Create a new entry.
+  #
+  # Reimplemented from CommentedConfigFile.
+  #
+  # @param args [Hash] or [Array]
+  #
+  # @return [ColumnConfigFile::Entry] new entry
+  #
+  def create_entry(*args)
+    entry = EtcFstab::Entry.new(*args)
+    entry.parent = self
+    entry
+  end
+
+  #
+  #----------------------------------------------------------------------
+  #
+  #
+  # Entry class for /etc/fstab. This gives each field it semantics rather than
+  # just being numbered columns like in the ColumnConfigFile superclass.
+  #
+  class Entry < ColumnConfigFile::Entry
+    # The columns of each EtcFstab entry; see also "man fstab".
+    #
+    # @return [String] The device that is mounted, including prefixes like
+    # "UUID=" or "LABEL=".
+    attr_accessor :device
+
+    # @return [String] The mount point where the device is mounted.
+    #
+    # This value may contain space characters (because space is a permitted
+    # character in directory names). In the file, those are escaped with
+    # '\040'. This escaping is handled by the parse and format methods of this
+    # class, so don't attempty to do it again when setting or getting this
+    # value.
+    attr_accessor :mount_point
+
+    # @return [String] The filesystem type as specified in /etc/fstab,
+    # i.e. lowercase; typically one of "ext2", "ext3", "btrfs", "xfs", "nfs",
+    # "vfat" etc.
+    attr_accessor :fs_type
+
+    # @return [Array<String>] The mount options, split up in their individual
+    # comma-separated parts. This does not ever contain "default"; in that
+    # case, the array is empty. The parser and formatter take care of removing
+    # or adding "default" if necessary (i.e., when the mount options are
+    # empty).
+    attr_accessor :mount_opts
+
+    # @return [Fixnum] This field is pretty much obsolete; it was there for the
+    # sake of the long obsolete Unix "dump" command, a very old backup
+    # tool. This field is (almost?) always 0 nowadays.
+    attr_accessor :dump_pass
+
+    # @return [Fixnum] The filesystem check pass. This is typically 1 for the
+    # root filesystem, 2 for most others and 0 if no filesystem check should
+    # ever be performed on this device (typically for networked devices such as
+    # NFS or CIFS (Samba)).
+    attr_accessor :fsck_pass
+
+    # Constructor: Create a new Entry either empty or from a hash or from an
+    # array.
+    #
+    # Use a hash with keys :device, :mount_point, :fs_type, :mount_opts,
+    # :dump_pass, :fsck_pass, :comment_before to fill the corresponding
+    # fields. All keys are optional.
+    #
+    # Use an array with the same meaning as in /etc/fstab to fill the
+    # corresponding fields: device, mount_point, fs_type, mount_opts,
+    # dump_pass, fsck_pass.
+    #
+    # In either case, mount_opts can be specified as a string (in which case it
+    # will be parsed just like when it is read from file, removing "defaults"
+    # in the process), or as an array.
+    #
+    # Of course, you can always create the entry empty and use the accessors to
+    # set values.
+    #
+    # @param args [Hash] or [Array]
+    #
+    def initialize(*args)
+      super(nil)
+      @device = nil
+      @mount_point = nil
+      @fs_type = nil
+      @mount_opts = []
+      @dump_pass = 0
+      @fsck_pass = 0
+
+      return if args.empty?
+
+      if args.first.is_a?(Hash)
+        from_hash(args.first)
+      elsif args.first.is_a?(Array)
+        from_array(args.first)
+      else
+        from_array(args)
+      end
+    end
+
+    # Initialize an entry from a hash.
+    # The mount options can be specified as an array or as a string.
+    #
+    # @param args [Hash]
+    #
+    def from_hash(args)
+      @device         = args[:device] || @device
+      @mount_point    = args[:mount_point] || @mount_point
+      @fs_type        = args[:fs_type] || @fs_type
+      @dump_pass      = args[:dump_pass] || @dump_pass
+      @fsck_pass      = args[:fsck_pass] || @dump_pass
+      @comment_before = args[:comment_before] || @comment_before
+
+      return unless args.key?(:mount_opts)
+
+      @mount_opts = args[:mount_opts]
+      parse_mount_opts(@mount_opts) if @mount_opts.is_a?(String)
+    end
+
+    # Initialize an entry from an array.
+    #
+    # The order in the array is the same as in /etc/fstab;
+    # the array may contain 1..6 elements.
+    #
+    # The mount options can be specified as a sub-array or as a string.
+    #
+    # @param args [Array]
+    #
+    def from_array(args)
+      args = args.dup
+      @device      = args.shift unless args.empty?
+      @mount_point = args.shift unless args.empty?
+      @fs_type     = args.shift unless args.empty?
+
+      if !args.empty?
+        @mount_opts = args.shift
+        parse_mount_opts(@mount_opts) if @mount_opts.is_a?(String)
+      end
+
+      @dump_pass = args.shift unless args.empty?
+      @fsck_pass = args.shift unless args.empty?
+    end
+
+    # Convert to an array in the same order as in /etc/fstab.
+    # mount_opts remains an array (and without "defaults").
+    #
+    # @return [Array]
+    #
+    def to_a
+      [@device, @mount_point, @fs_type, @mount_opts, @dump_pass, @fsck_pass]
+    end
+
+    # Convert to a hash with keys :device, :mount_point, :fs_type,
+    # :mount:opts, :dump_pass, :fsck_pass.
+    #
+    # mount_opts remains an array (and without "defaults").
+    #
+    # @return [Hash]
+    #
+    def to_h
+      {
+        device:      @device,
+        mount_point: @mount_point,
+        fs_type:     @fs_type,
+        mount_opts:  @mount_opts,
+        dump_pass:   @dump_pass,
+        fsck_pass:   @fsck_pass
+      }
+    end
+
+    # Parse a content line. This expects any line comment and the newline to be
+    # stripped off already.
+    #
+    # Reimplemented from ColumnConfigFile::Entry.
+    #
+    # @param line [String] content line without any line comment
+    # @param line_no [Fixnum] line number for error reporting
+    #
+    # @return [Boolean] true if success, false if error
+    #
+    # @raise [EtcFstab::ParseError] Incorrect file format
+    #
+    def parse(line, line_no = -1)
+      super
+      if @columns.size != 6
+        msg = "Wrong number of columns"
+        msg += " in line #{line_no + 1}" if line_no >= 0
+        raise EtcFstab::ParseError, msg
+      end
+      decoded_col = @columns.map { |col| EtcFstab.fstab_decode(col) }
+      @device, @mount_point, @fs_type, opt, @dump_pass, @fsck_pass = decoded_col
+      parse_mount_opts(opt)
+      @dump_pass = @dump_pass.to_i
+      @fsck_pass = @fsck_pass.to_i
+      true # success
+    end
+
+    # Populate the columns: Fill the columns with values from the other fields.
+    #
+    # This is called just prior to calculating the column widths and formatting
+    # the columns.
+    #
+    # Reimplemented from ColumnConfigFile::Entry.
+    #
+    def populate_columns
+      @columns =
+        [@device,
+         @mount_point,
+         @fs_type,
+         format_mount_opts,
+         @dump_pass.to_s,
+         @fsck_pass.to_s]
+
+      # Strictly speaking, space characters are only permitted in the
+      # mount_point column according to "man fstab". But better be safe than
+      # sorry; there might be a space character also in a device label or in
+      # the mount options, and if the kernel / the mount command / systemd can
+      # handle it, we want to support that, too; so let's simply encode all the
+      # fields.
+      #
+      # On the downside, this does not let us strip all the other fields
+      # because we might strip away a space character that was intentional; so
+      # it's the caller's responsibility to make sure that there are no
+      # unintended space characters in any of the fields.
+
+      @columns.map! { |col| EtcFstab.fstab_encode(col) }
+    end
+
+    # Get the "mount_by" type of this entry. See EtcFstab::get_mount_by.
+    #
+    # @return [Symbol]
+    #
+    # Rubocop thinks this is an accessor, but it's not
+    # rubocop:disable Style/AccessorMethodName
+    #
+    def get_mount_by
+      EtcFstab.get_mount_by(@device)
+    end
+    # rubocop:enable Style/AccessorMethodName
+
+    # Parse a mount options field and store the result in @mount_opts.
+    #
+    # This removes any occurrence of "defaults" (which really only makes sense
+    # if the field would otherwise be empty which is not permitted by the file
+    # format).
+    #
+    # @param opts [String] mount options field
+    #
+    def parse_mount_opts(opts)
+      if opts.nil?
+        @mount_opts = []
+        return
+      end
+      @mount_opts = opts.split(/,/)
+      @mount_opts.delete_if { |opt| opt == "defaults" }
+    end
+
+    # Format the mount options from @mount_opts. If they are empty (and only
+    # then) this returns "defaults" to make sure the file format is still
+    # intact.
+    #
+    # @return [String] Formatted mount options
+    #
+    def format_mount_opts
+      return "defaults" if @mount_opts.empty?
+      @mount_opts.join(",")
+    end
+
+    # Return the column delimiter used for input (parsing).
+    #
+    # Reimplemented from ColumnConfigFile::Entry.
+    #
+    # @return [Regexp] delimiter
+    #
+    def input_delimiter
+      ColumnConfigFile::DEFAULT_INPUT_DELIMITER
+    end
+  end
+
+  # Error class for parsing
+  class ParseError < RuntimeError
+  end
+end

--- a/library/system/src/lib/yast2/etc_fstab.rb
+++ b/library/system/src/lib/yast2/etc_fstab.rb
@@ -47,6 +47,13 @@ class EtcFstab < ColumnConfigFile
     super()
     @max_column_widths = [45, 25, 7, 30, 1, 1]
     @pad_columns = true
+
+    # /etc/fstab does not support end-of-line comments.
+    #
+    # There might be a literal '#' character somewhere, though, in particular
+    # in the mount options.
+    @line_comments_enabled = false
+
     read(filename) unless filename.nil?
   end
 

--- a/library/system/src/lib/yast2/etc_fstab.rb
+++ b/library/system/src/lib/yast2/etc_fstab.rb
@@ -102,7 +102,7 @@ class EtcFstab < ColumnConfigFile
   #
   # @param mount_point [String]
   #
-  # @return [EtcFstab::Entry] or nil if not found
+  # @return [EtcFstab::Entry, nil]
   #
   def find_mount_point(mount_point)
     find { |entry| entry.mount_point == mount_point }
@@ -113,7 +113,7 @@ class EtcFstab < ColumnConfigFile
   #
   # @param device [String]
   #
-  # @return [EtcFstab::Entry] or nil if not found
+  # @return [EtcFstab::Entry, nil]
   #
   def find_device(device)
     find { |entry| entry.device == device }

--- a/library/system/src/lib/yast2/etc_fstab.rb
+++ b/library/system/src/lib/yast2/etc_fstab.rb
@@ -72,6 +72,7 @@ class EtcFstab < ColumnConfigFile
   # @param entry [EtcFstab::Entry]
   #
   def add_entry(entry)
+    raise ArgumentError, "Trying to add nil entry" if entry.nil?
     entry.parent = self
     index = find_sort_index(entry)
     @entries.insert(index, entry)

--- a/library/system/src/lib/yast2/etc_fstab.rb
+++ b/library/system/src/lib/yast2/etc_fstab.rb
@@ -45,7 +45,7 @@ class EtcFstab < ColumnConfigFile
   #
   def initialize(filename = nil)
     super()
-    @max_column_widths = [45, 25, 7, 30, 1, 1]
+    @max_column_widths = [45, 25, 8, 30, 1, 1]
     @pad_columns = true
 
     # /etc/fstab does not support end-of-line comments.

--- a/library/system/src/lib/yast2/etc_fstab.rb
+++ b/library/system/src/lib/yast2/etc_fstab.rb
@@ -207,7 +207,7 @@ class EtcFstab < ColumnConfigFile
     -1
   end
 
-  protected
+protected
 
   # Find the correct index for an entry if it depends on any other entry or -1
   # if no other entry depends on this one, i.e. it can safely added to the end
@@ -226,7 +226,7 @@ class EtcFstab < ColumnConfigFile
     -1
   end
 
-  public
+public
 
   # Get the "mount by" type of a device entry in /etc/fstab.
   # See also EtcFstab::Entry.get_mount_by.

--- a/library/system/test/column_config_file_test.rb
+++ b/library/system/test/column_config_file_test.rb
@@ -90,23 +90,27 @@ describe ColumnConfigFile do
 
   context "Formatter" do
     describe("#format_lines") do
-      def read_twice(filename)
-        orig = File.read(filename).chomp
+      def read_orig(filename)
+        File.read(filename).chomp
+      end
+
+      def reformat(filename)
         file = described_class.new
         file.read(filename)
         file.max_column_widths = [45, 25, 7, 30, 1, 1]
         file.pad_columns = true
-        formatted = file.to_s
-        [orig, formatted]
+        file.to_s
       end
 
       it "reproduces exactly the original format with header and footer" do
-        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab")
+        orig = read_orig(TEST_DATA + "fstab/demo-fstab")
+        formatted = reformat(TEST_DATA + "fstab/demo-fstab")
         expect(formatted).to eq orig
       end
 
       it "reproduces exactly the original format without header or footer" do
-        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab-no-header")
+        orig = read_orig(TEST_DATA + "fstab/demo-fstab-no-header")
+        formatted = reformat(TEST_DATA + "fstab/demo-fstab-no-header")
         expect(formatted).to eq orig
       end
     end

--- a/library/system/test/column_config_file_test.rb
+++ b/library/system/test/column_config_file_test.rb
@@ -15,12 +15,13 @@ require "yast2/column_config_file"
 
 describe ColumnConfigFile do
   # rubocop:disable Lint/AmbiguousRegexpLiteral
+
   context "Parser" do
     describe "#parse" do
       context "Demo /etc/fstab with header and footer comments" do
         before(:all) do
           @file = described_class.new
-          @file.read("data/fstab/demo-fstab")
+          @file.read(TEST_DATA + "fstab/demo-fstab")
         end
         subject { @file }
 
@@ -100,12 +101,12 @@ describe ColumnConfigFile do
       end
 
       it "reproduces exactly the original format with header and footer" do
-        orig, formatted = read_twice("data/fstab/demo-fstab")
+        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab")
         expect(formatted).to eq orig
       end
 
       it "reproduces exactly the original format without header or footer" do
-        orig, formatted = read_twice("data/fstab/demo-fstab-no-header")
+        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab-no-header")
         expect(formatted).to eq orig
       end
     end

--- a/library/system/test/column_config_file_test.rb
+++ b/library/system/test/column_config_file_test.rb
@@ -14,6 +14,7 @@ require_relative "test_helper"
 require "yast2/column_config_file"
 
 describe ColumnConfigFile do
+  # rubocop:disable Lint/AmbiguousRegexpLiteral
   context "Parser" do
     describe "#parse" do
       context "Demo /etc/fstab with header and footer comments" do

--- a/library/system/test/column_config_file_test.rb
+++ b/library/system/test/column_config_file_test.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/rspec
+#
+# Unit test for ColumnConfigFile
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+require_relative "test_helper"
+require "yast2/column_config_file"
+
+describe ColumnConfigFile do
+  context "Parser" do
+    describe "#parse" do
+      context "Demo /etc/fstab with header and footer comments" do
+        before(:all) do
+          @file = described_class.new
+          @file.read("data/fstab/demo-fstab")
+        end
+        subject { @file }
+
+        it "Has the correct header comments" do
+          header = subject.header_comments
+          expect(header.size).to eq 15
+          expect(header[0]).to match /static file system information/
+          expect(header[-2]).to match /mount point.*type.*dump.*pass/
+          expect(header[-1]).to match /^\s*$/
+        end
+
+        it "Has the correct footer comments" do
+          footer = subject.footer_comments
+          expect(footer.size).to eq 1
+          expect(footer[0]).to match /^\s*$/
+        end
+
+        it "Has the correct number of entries" do
+          expect(subject.size).to eq 9
+        end
+
+        it "The first entry ('swap') is correct" do
+          entry = subject.first
+          expect(entry.columns.size).to eq 6
+
+          expect(entry.columns[0]).to eq "/dev/disk/by-label/swap"
+          expect(entry.columns[1]).to eq "none"
+          expect(entry.columns[2]).to eq "swap"
+          expect(entry.columns[3]).to eq "sw"
+          expect(entry.columns[4]).to eq "0"
+          expect(entry.columns[5]).to eq "0"
+
+          expect(entry.comment_before.size).to eq 1
+          expect(entry.comment_before.first).to match /Linux disk/
+        end
+
+        it "The root filesystem entry is correct" do
+          entry = subject.entries[2]
+          expect(entry.columns.size).to eq 6
+
+          expect(entry.columns[0]).to eq "/dev/disk/by-label/Ubuntu"
+          expect(entry.columns[1]).to eq "/"
+          expect(entry.columns[2]).to eq "ext4"
+          expect(entry.columns[3]).to eq "errors=remount-ro"
+          expect(entry.columns[4]).to eq "0"
+          expect(entry.columns[5]).to eq "1"
+
+          expect(entry.comment_before?).to eq false
+          expect(entry.line_comment?).to eq false
+        end
+
+        it "The last entry ('fritz.nas') is correct" do
+          entry = subject.last
+          expect(entry.columns.size).to eq 6
+
+          expect(entry.columns[0]).to eq "//fritz.box/fritz.nas/"
+          expect(entry.columns[1]).to eq "/fritz.nas"
+          expect(entry.columns[2]).to eq "cifs"
+          expect(entry.columns[3]).to match /^credentials.*forcegid$/
+          expect(entry.columns[4]).to eq "0"
+          expect(entry.columns[5]).to eq "0"
+        end
+      end
+    end
+  end
+
+  context "Formatter" do
+    describe("#format_lines") do
+      def read_twice(filename)
+        orig = File.read(filename).chomp
+        file = described_class.new
+        file.read(filename)
+        file.max_column_widths = [45, 25, 7, 30, 1, 1]
+        file.pad_columns = true
+        formatted = file.to_s
+        [orig, formatted]
+      end
+
+      it "reproduces exactly the original format with header and footer" do
+        orig, formatted = read_twice("data/fstab/demo-fstab")
+        expect(formatted).to eq orig
+      end
+
+      it "reproduces exactly the original format without header or footer" do
+        orig, formatted = read_twice("data/fstab/demo-fstab-no-header")
+        expect(formatted).to eq orig
+      end
+    end
+  end
+end

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -164,29 +164,55 @@ describe CommentedConfigFile do
     end
 
     describe "#split_off_comment" do
-      it "Splits a simple line with a comment correctly" do
-        expect(subject.split_off_comment("foo = bar # baz")).to eq ["foo = bar", "# baz"]
+      context "with line comments enabled (default)" do
+        it "Splits a simple line with a comment correctly" do
+          expect(subject.split_off_comment("foo = bar # baz")).to eq ["foo = bar", "# baz"]
+        end
+
+        it "Strips leading and trailing whitespace off the content" do
+          expect(subject.split_off_comment("  foo =  bar   # baz")).to eq ["foo =  bar", "# baz"]
+        end
+
+        it "Leaves whitespace in the comment alone" do
+          expect(subject.split_off_comment("foo = bar #  baz  ")).to eq ["foo = bar", "#  baz  "]
+        end
+
+        it "Handles lines without comments well" do
+          expect(subject.split_off_comment("foo = bar")).to eq ["foo = bar", nil]
+        end
+
+        it "Handles comment lines without content well" do
+          expect(subject.split_off_comment("# foo = bar")).to eq ["", "# foo = bar"]
+          expect(subject.split_off_comment("   # foo = bar")).to eq ["", "# foo = bar"]
+        end
+
+        it "Handles empty lines well" do
+          expect(subject.split_off_comment("")).to eq ["", nil]
+        end
       end
 
-      it "Strips leading and trailing whitespace off the content" do
-        expect(subject.split_off_comment("  foo =  bar   # baz")).to eq ["foo =  bar", "# baz"]
-      end
+      context "with line comments disabled (nonstandard configuration)" do
+        before(:all) do
+          @file = described_class.new
+          @file.line_comments_enabled = false
+        end
+        subject { @file }
 
-      it "Leaves whitespace in the comment alone" do
-        expect(subject.split_off_comment("foo = bar #  baz  ")).to eq ["foo = bar", "#  baz  "]
-      end
+        it "Splits a simple line with a comment marker correctly" do
+          expect(subject.split_off_comment("foo = bar # baz")).to eq ["foo = bar # baz", nil]
+        end
 
-      it "Handles lines without comments well" do
-        expect(subject.split_off_comment("foo = bar")).to eq ["foo = bar", nil]
-      end
+        it "Strips leading and trailing whitespace off the content" do
+          expect(subject.split_off_comment("  foo =  bar # baz  ")).to eq ["foo =  bar # baz", nil]
+        end
 
-      it "Handles comment lines without content well" do
-        expect(subject.split_off_comment("# foo = bar")).to eq ["", "# foo = bar"]
-        expect(subject.split_off_comment("   # foo = bar")).to eq ["", "# foo = bar"]
-      end
+        it "Handles lines without comments well" do
+          expect(subject.split_off_comment("foo = bar")).to eq ["foo = bar", nil]
+        end
 
-      it "Handles empty lines well" do
-        expect(subject.split_off_comment("")).to eq ["", nil]
+        it "Handles empty lines well" do
+          expect(subject.split_off_comment("")).to eq ["", nil]
+        end
       end
     end
   end

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -14,6 +14,7 @@ require_relative "test_helper"
 require "yast2/commented_config_file"
 
 describe CommentedConfigFile do
+  # rubocop:disable Lint/AmbiguousRegexpLiteral
   context "when created empty" do
     subject { described_class.new }
 

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -246,7 +246,6 @@ describe CommentedConfigFile do
       context "Demo /etc/fstab without header and footer comments" do
         before(:all) do
           @file = described_class.new
-          puts("TEST_DATA: #{TEST_DATA}")
           @file.read(TEST_DATA + "fstab/demo-fstab-no-header")
         end
         subject { @file }

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -17,8 +17,6 @@ describe CommentedConfigFile do
   # rubocop:disable Lint/AmbiguousRegexpLiteral
 
   context "when created empty" do
-    subject { described_class.new }
-
     describe "#new" do
       it "has no content" do
         expect(subject.header_comments).to be_nil
@@ -87,8 +85,6 @@ describe CommentedConfigFile do
 
   context "Low-level parser" do
     describe "#comment_line?" do
-      subject { described_class.new }
-
       context "with the default '#' comment marker" do
         it "Detects a simple comment line" do
           expect(subject.comment_line?("# foo")).to eq true
@@ -143,8 +139,6 @@ describe CommentedConfigFile do
     end
 
     describe "#empty_line?" do
-      subject { described_class.new }
-
       it "Detects a completely empty line" do
         expect(subject.empty_line?("")).to eq true
       end
@@ -166,8 +160,6 @@ describe CommentedConfigFile do
     end
 
     describe "#split_off_comment" do
-      subject { described_class.new }
-
       it "Splits a simple line with a comment correctly" do
         expect(subject.split_off_comment("foo = bar # baz")).to eq ["foo = bar", "# baz"]
       end

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -15,6 +15,7 @@ require "yast2/commented_config_file"
 
 describe CommentedConfigFile do
   # rubocop:disable Lint/AmbiguousRegexpLiteral
+
   context "when created empty" do
     subject { described_class.new }
 
@@ -199,7 +200,7 @@ describe CommentedConfigFile do
       context "Demo /etc/fstab with header and footer comments" do
         before(:all) do
           @file = described_class.new
-          @file.read("data/fstab/demo-fstab")
+          @file.read(TEST_DATA + "fstab/demo-fstab")
         end
         subject { @file }
 
@@ -245,7 +246,8 @@ describe CommentedConfigFile do
       context "Demo /etc/fstab without header and footer comments" do
         before(:all) do
           @file = described_class.new
-          @file.read("data/fstab/demo-fstab-no-header")
+          puts("TEST_DATA: #{TEST_DATA}")
+          @file.read(TEST_DATA + "fstab/demo-fstab-no-header")
         end
         subject { @file }
 
@@ -294,17 +296,17 @@ describe CommentedConfigFile do
       end
 
       it "reproduces exactly the original format with header and footer" do
-        orig, formatted = read_twice("data/fstab/demo-fstab")
+        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab")
         expect(formatted).to eq orig
       end
 
       it "reproduces exactly the original format without header or footer" do
-        orig, formatted = read_twice("data/fstab/demo-fstab-no-header")
+        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab-no-header")
         expect(formatted).to eq orig
       end
 
       it "reproduces exactly the original format for demo-sudoers" do
-        orig, formatted = read_twice("data/fstab/demo-sudoers")
+        orig, formatted = read_twice(TEST_DATA + "fstab/demo-sudoers")
         expect(formatted).to eq orig
       end
     end

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -278,26 +278,31 @@ describe CommentedConfigFile do
 
   context "Formatter" do
     describe("#format_lines") do
-      def read_twice(filename)
-        orig = File.read(filename).chomp
+      def read_orig(filename)
+        File.read(filename).chomp
+      end
+
+      def reformat(filename)
         file = described_class.new
         file.read(filename)
-        formatted = file.to_s
-        [orig, formatted]
+        file.to_s
       end
 
       it "reproduces exactly the original format with header and footer" do
-        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab")
+        orig = read_orig(TEST_DATA + "fstab/demo-fstab")
+        formatted = reformat(TEST_DATA + "fstab/demo-fstab")
         expect(formatted).to eq orig
       end
 
       it "reproduces exactly the original format without header or footer" do
-        orig, formatted = read_twice(TEST_DATA + "fstab/demo-fstab-no-header")
+        orig = read_orig(TEST_DATA + "fstab/demo-fstab-no-header")
+        formatted = reformat(TEST_DATA + "fstab/demo-fstab-no-header")
         expect(formatted).to eq orig
       end
 
       it "reproduces exactly the original format for demo-sudoers" do
-        orig, formatted = read_twice(TEST_DATA + "fstab/demo-sudoers")
+        orig = read_orig(TEST_DATA + "fstab/demo-sudoers")
+        formatted = reformat(TEST_DATA + "fstab/demo-sudoers")
         expect(formatted).to eq orig
       end
     end

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -147,6 +147,7 @@ describe CommentedConfigFile do
         expect(subject.empty_line?(" ")).to eq true
         expect(subject.empty_line?("  ")).to eq true
         expect(subject.empty_line?(" \n")).to eq true
+        expect(subject.empty_line?("\n\n")).to eq true
         expect(subject.empty_line?("\t")).to eq true
         expect(subject.empty_line?("\t\n  \t\n")).to eq true
       end
@@ -156,6 +157,9 @@ describe CommentedConfigFile do
         expect(subject.empty_line?("  x")).to eq false
         expect(subject.empty_line?("  x  ")).to eq false
         expect(subject.empty_line?("  \nx  ")).to eq false
+        expect(subject.empty_line?("  x\n  ")).to eq false
+        expect(subject.empty_line?("\nx")).to eq false
+        expect(subject.empty_line?("x\n")).to eq false
       end
     end
 

--- a/library/system/test/commented_config_file_test.rb
+++ b/library/system/test/commented_config_file_test.rb
@@ -1,0 +1,311 @@
+#!/usr/bin/rspec
+#
+# Unit test for CommentedConfigFile
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+require_relative "test_helper"
+require "yast2/commented_config_file"
+
+describe CommentedConfigFile do
+  context "when created empty" do
+    subject { described_class.new }
+
+    describe "#new" do
+      it "has no content" do
+        expect(subject.header_comments).to be_nil
+        expect(subject.footer_comments).to be_nil
+        expect(subject.entries).to eq []
+        expect(subject.filename).to be_nil
+      end
+    end
+
+    describe "#header_comments?" do
+      it "is false" do
+        expect(subject.header_comments?).to eq false
+      end
+    end
+
+    describe "#footer_comments?" do
+      it "is false" do
+        expect(subject.footer_comments?).to eq false
+      end
+    end
+  end
+
+  describe "#Entry.new" do
+    let(:entry) { subject.create_entry }
+
+    it "is empty" do
+      expect(entry.content).to be_nil
+      expect(entry.comment_before).to be_nil
+      expect(entry.line_comment).to be_nil
+      expect(entry.comment_before?).to eq false
+      expect(entry.line_comment?).to eq false
+    end
+
+    it "has a parent" do
+      expect(entry.parent).not_to be_nil
+    end
+
+    it "has the correct parent" do
+      expect(entry.parent).to equal subject
+    end
+  end
+
+  describe "#Entry.parse" do
+    let(:ccf) { described_class.new }
+    subject { ccf.create_entry }
+
+    it "stores the content" do
+      expect(subject.parse("foo = bar")).to eq true
+      expect(subject.content).to eq "foo = bar"
+    end
+  end
+
+  describe "#Entry.format" do
+    let(:ccf) { described_class.new }
+    subject { ccf.create_entry }
+
+    it "formats the content without comments" do
+      line = "foo bar baz"
+      subject.parse(line)
+      subject.line_comment = "line comment"
+      subject.comment_before = "# comment\n# lines \n# before\n"
+      expect(subject.format).to eq line
+      expect(subject.to_s).to eq line
+    end
+  end
+
+  context "Low-level parser" do
+    describe "#comment_line?" do
+      subject { described_class.new }
+
+      context "with the default '#' comment marker" do
+        it "Detects a simple comment line" do
+          expect(subject.comment_line?("# foo")).to eq true
+          expect(subject.comment_line?("#foo")).to eq true
+        end
+
+        it "Can handle leading whitespace" do
+          expect(subject.comment_line?("  # foo")).to eq true
+        end
+
+        it "Can handle trailing whitespace" do
+          expect(subject.comment_line?("# foo  \n")).to eq true
+        end
+
+        it "Rejects non-comment lines" do
+          expect(subject.comment_line?("foo")).to eq false
+          expect(subject.comment_line?("  foo")).to eq false
+          expect(subject.comment_line?("foo # bar")).to eq false
+          expect(subject.comment_line?("// foo")).to eq false
+          expect(subject.comment_line?("")).to eq false
+        end
+      end
+
+      context "with a custom '//' comment marker" do
+        subject do
+          ccf = described_class.new
+          ccf.comment_marker = "//"
+          ccf
+        end
+
+        it "Detects a simple comment line" do
+          expect(subject.comment_line?("// foo")).to eq true
+          expect(subject.comment_line?("//foo")).to eq true
+        end
+
+        it "Can handle leading whitespace" do
+          expect(subject.comment_line?("  // foo")).to eq true
+        end
+
+        it "Can handle trailing whitespace" do
+          expect(subject.comment_line?("// foo  \n")).to eq true
+        end
+
+        it "Rejects non-comment lines" do
+          expect(subject.comment_line?("foo")).to eq false
+          expect(subject.comment_line?("  foo")).to eq false
+          expect(subject.comment_line?("foo # bar")).to eq false
+          expect(subject.comment_line?("# foo")).to eq false
+          expect(subject.comment_line?("")).to eq false
+        end
+      end
+    end
+
+    describe "#empty_line?" do
+      subject { described_class.new }
+
+      it "Detects a completely empty line" do
+        expect(subject.empty_line?("")).to eq true
+      end
+
+      it "Detects lines with only whitespace " do
+        expect(subject.empty_line?(" ")).to eq true
+        expect(subject.empty_line?("  ")).to eq true
+        expect(subject.empty_line?(" \n")).to eq true
+        expect(subject.empty_line?("\t")).to eq true
+        expect(subject.empty_line?("\t\n  \t\n")).to eq true
+      end
+
+      it "Rejects non-empty lines" do
+        expect(subject.empty_line?("x")).to eq false
+        expect(subject.empty_line?("  x")).to eq false
+        expect(subject.empty_line?("  x  ")).to eq false
+        expect(subject.empty_line?("  \nx  ")).to eq false
+      end
+    end
+
+    describe "#split_off_comment" do
+      subject { described_class.new }
+
+      it "Splits a simple line with a comment correctly" do
+        expect(subject.split_off_comment("foo = bar # baz")).to eq ["foo = bar", "# baz"]
+      end
+
+      it "Strips leading and trailing whitespace off the content" do
+        expect(subject.split_off_comment("  foo =  bar   # baz")).to eq ["foo =  bar", "# baz"]
+      end
+
+      it "Leaves whitespace in the comment alone" do
+        expect(subject.split_off_comment("foo = bar #  baz  ")).to eq ["foo = bar", "#  baz  "]
+      end
+
+      it "Handles lines without comments well" do
+        expect(subject.split_off_comment("foo = bar")).to eq ["foo = bar", nil]
+      end
+
+      it "Handles comment lines without content well" do
+        expect(subject.split_off_comment("# foo = bar")).to eq ["", "# foo = bar"]
+        expect(subject.split_off_comment("   # foo = bar")).to eq ["", "# foo = bar"]
+      end
+
+      it "Handles empty lines well" do
+        expect(subject.split_off_comment("")).to eq ["", nil]
+      end
+    end
+  end
+
+  context "High-level parser" do
+    describe "#parse" do
+      context "Demo /etc/fstab with header and footer comments" do
+        before(:all) do
+          @file = described_class.new
+          @file.read("data/fstab/demo-fstab")
+        end
+        subject { @file }
+
+        it "Has the correct header comments" do
+          header = subject.header_comments
+          expect(header.size).to eq 15
+          expect(header[0]).to match /static file system information/
+          expect(header[-2]).to match /mount point.*type.*dump.*pass/
+          expect(header[-1]).to match /^\s*$/
+        end
+
+        it "Has the correct footer comments" do
+          footer = subject.footer_comments
+          expect(footer.size).to eq 1
+          expect(footer[0]).to match /^\s*$/
+        end
+
+        it "Has the correct number of entries" do
+          expect(subject.size).to eq 9
+        end
+
+        it "The first entry is correct" do
+          entry = subject.first
+          expect(entry.content).to match /by-label\/swap\s+none\s+swap/
+          expect(entry.comment_before.size).to eq 1
+          expect(entry.comment_before.first).to match /Linux disk/
+        end
+
+        it "The root filesystem entry is correct" do
+          entry = subject.entries[2]
+          expect(entry.content).to match /Ubuntu.*ext4.*errors=remount-ro/
+          expect(entry.comment_before?).to eq false
+          expect(entry.line_comment?).to eq false
+        end
+
+        it "The last entry is correct" do
+          entry = subject.last
+          expect(entry.content).to match /fritz.box.fritz.nas.*cifs.*forcegid/
+          expect(entry.comment_before.first).to match /^\s*$/
+        end
+      end
+
+      context "Demo /etc/fstab without header and footer comments" do
+        before(:all) do
+          @file = described_class.new
+          @file.read("data/fstab/demo-fstab-no-header")
+        end
+        subject { @file }
+
+        it "Does not have header comments" do
+          expect(subject.header_comments?).to eq false
+        end
+
+        it "Does not have footer comments" do
+          expect(subject.footer_comments?).to eq false
+        end
+
+        it "Has the correct number of entries" do
+          expect(subject.size).to eq 9
+        end
+
+        it "The first entry is correct" do
+          entry = subject.first
+          expect(entry.content).to match /by-label\/swap\s+none\s+swap/
+          expect(entry.comment_before?).to eq false
+        end
+
+        it "The root filesystem entry is correct" do
+          entry = subject.entries[2]
+          expect(entry.content).to match /Ubuntu.*ext4.*errors=remount-ro/
+          expect(entry.comment_before?).to eq false
+          expect(entry.line_comment?).to eq false
+        end
+
+        it "The last entry is correct" do
+          entry = subject.last
+          expect(entry.content).to match /fritz.box.fritz.nas.*cifs.*forcegid/
+          expect(entry.comment_before.first).to match /^\s*$/
+        end
+      end
+    end
+  end
+
+  context "Formatter" do
+    describe("#format_lines") do
+      def read_twice(filename)
+        orig = File.read(filename).chomp
+        file = described_class.new
+        file.read(filename)
+        formatted = file.to_s
+        [orig, formatted]
+      end
+
+      it "reproduces exactly the original format with header and footer" do
+        orig, formatted = read_twice("data/fstab/demo-fstab")
+        expect(formatted).to eq orig
+      end
+
+      it "reproduces exactly the original format without header or footer" do
+        orig, formatted = read_twice("data/fstab/demo-fstab-no-header")
+        expect(formatted).to eq orig
+      end
+
+      it "reproduces exactly the original format for demo-sudoers" do
+        orig, formatted = read_twice("data/fstab/demo-sudoers")
+        expect(formatted).to eq orig
+      end
+    end
+  end
+end

--- a/library/system/test/data/fstab/demo-fstab
+++ b/library/system/test/data/fstab/demo-fstab
@@ -1,0 +1,31 @@
+# /etc/fstab: static file system information.
+#
+# [sh @ balrog] ~ %  sudo blkid | column -t
+#
+# /dev/sda1:  LABEL="Win-Boot"    UUID="C6CC71BDCC71A877"                      TYPE="ntfs"
+# /dev/sda2:  LABEL="Win-App"     UUID="3E5E77515E770147"                      TYPE="ntfs"
+#
+# /dev/sdb1:  LABEL="swap"        UUID="be72e905-a417-41a4-a75f-12c0cf774f6a"  TYPE="swap"
+# /dev/sdb2:  LABEL="openSUSE"    UUID="1d0bc24c-ae68-4c4e-82af-b3e184b2ac9d"  TYPE="ext4"
+# /dev/sdb3:  LABEL="Ubuntu"      UUID="f5c15fbd-0417-4711-a0b7-f66b608bad0c"  TYPE="ext4"
+# /dev/sdb5:  LABEL="work"        UUID="7e1d65c8-c6e3-4824-ac1c-c3a4ba90f54f"  TYPE="ext4"
+#
+#
+# <file system>              <mount point>   <type> <options>         <dump>  <pass>
+
+# Linux disk
+/dev/disk/by-label/swap      none             swap  sw                         0  0
+/dev/disk/by-label/openSUSE  /alternate-root  ext4  defaults                   0  2
+/dev/disk/by-label/Ubuntu    /                ext4  errors=remount-ro          0  1
+/dev/disk/by-label/work      /work            ext4  defaults                   0  2
+
+# Windows disk
+/dev/disk/by-label/Win-Boot  /win/boot        ntfs  defaults,umask=007,gid=46  0  0
+/dev/disk/by-label/Win-App   /win/app         ntfs  defaults,umask=007,gid=46  0  0
+
+# Network
+nas:/share/sh                /nas/sh          nfs   bg,intr,soft,retry=6       0  0
+nas:/share/work              /nas/work        nfs   bg,intr,soft,retry=6       0  0
+
+//fritz.box/fritz.nas/       /fritz.nas       cifs  credentials=/work/home/sh/.private/fritz-nas-credentials.txt,uid=sh,forceuid,gid=users,forcegid  0  0
+

--- a/library/system/test/data/fstab/demo-fstab-2-expected
+++ b/library/system/test/data/fstab/demo-fstab-2-expected
@@ -1,0 +1,32 @@
+# /etc/fstab: static file system information.
+#
+# [sh @ balrog] ~ %  sudo blkid | column -t
+#
+# /dev/sda1:  LABEL="Win-Boot"    UUID="C6CC71BDCC71A877"                      TYPE="ntfs"
+# /dev/sda2:  LABEL="Win-App"     UUID="3E5E77515E770147"                      TYPE="ntfs"
+#
+# /dev/sdb1:  LABEL="swap"        UUID="be72e905-a417-41a4-a75f-12c0cf774f6a"  TYPE="swap"
+# /dev/sdb2:  LABEL="openSUSE"    UUID="1d0bc24c-ae68-4c4e-82af-b3e184b2ac9d"  TYPE="ext4"
+# /dev/sdb3:  LABEL="Ubuntu"      UUID="f5c15fbd-0417-4711-a0b7-f66b608bad0c"  TYPE="ext4"
+# /dev/sdb5:  LABEL="work"        UUID="7e1d65c8-c6e3-4824-ac1c-c3a4ba90f54f"  TYPE="ext4"
+#
+#
+# <file system>              <mount point>   <type> <options>         <dump>  <pass>
+
+# Linux disk
+/dev/disk/by-label/swap         none       swap  sw                    0  0
+/dev/disk/by-label/Ubuntu       /          ext4  errors=remount-ro     0  1
+/dev/disk/by-label/work         /work      ext4  defaults              0  2
+
+# Network
+home_nas:/share/sh              /nas/sh    nfs   bg,intr,soft,retry=6  0  0
+home_nas:/share/work            /nas/work  nfs   bg,intr,soft,retry=6  0  0
+
+# Windows disk
+/dev/disk/by-label/Win\040Boot  /win/boot  ntfs  umask=007,gid=46      0  0
+/dev/disk/by-label/Win\040App   /win/app   ntfs  umask=007,gid=46      0  0
+
+# Data that keep growing
+LABEL=var                       /var       ext2  defaults              0  0
+LABEL=logs                      /var/log   xfs   defaults              0  0
+

--- a/library/system/test/data/fstab/demo-fstab-no-header
+++ b/library/system/test/data/fstab/demo-fstab-no-header
@@ -1,0 +1,14 @@
+/dev/disk/by-label/swap      none             swap  sw                         0  0
+/dev/disk/by-label/openSUSE  /alternate-root  ext4  defaults                   0  2
+/dev/disk/by-label/Ubuntu    /                ext4  errors=remount-ro          0  1
+/dev/disk/by-label/work      /work            ext4  defaults                   0  2
+
+# Windows disk
+/dev/disk/by-label/Win-Boot  /win/boot        ntfs  defaults,umask=007,gid=46  0  0
+/dev/disk/by-label/Win-App   /win/app         ntfs  defaults,umask=007,gid=46  0  0
+
+# Network
+nas:/share/sh                /nas/sh          nfs   bg,intr,soft,retry=6       0  0
+nas:/share/work              /nas/work        nfs   bg,intr,soft,retry=6       0  0
+
+//fritz.box/fritz.nas/       /fritz.nas       cifs  credentials=/work/home/sh/.private/fritz-nas-credentials.txt,uid=sh,forceuid,gid=users,forcegid  0  0

--- a/library/system/test/data/fstab/demo-sudoers
+++ b/library/system/test/data/fstab/demo-sudoers
@@ -1,0 +1,33 @@
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+
+# Members of the admin group may gain root privileges
+%admin ALL=(ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo	ALL=(ALL:ALL) ALL
+
+# See sudoers(5) for more information on "#include" directives:
+
+#includedir /etc/sudoers.d
+
+kilroy	ALL=(ALL) NOPASSWD: ALL
+

--- a/library/system/test/etc_fstab_entry_test.rb
+++ b/library/system/test/etc_fstab_entry_test.rb
@@ -78,6 +78,11 @@ describe EtcFstab::Entry do
       expect(subject.mount_opts).to eq ["ro", "foo"]
     end
 
+    it "keeps a literal '#' in the mount options intact" do
+      subject.parse("nas:/work /work cifs password=ab#cd,username=kilroy 0 0")
+      expect(subject.mount_opts).to eq ["password=ab#cd", "username=kilroy"]
+    end
+
     it "throws an exception if the number of columns is wrong" do
       expect { subject.parse("/dev/sda1 /data xfs duh defaults 0 1", 42) }
         .to raise_error(EtcFstab::ParseError, /in line 43/)

--- a/library/system/test/etc_fstab_entry_test.rb
+++ b/library/system/test/etc_fstab_entry_test.rb
@@ -1,0 +1,104 @@
+#!/usr/bin/rspec
+#
+# Unit test for EtcFstab::Entry
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+require_relative "test_helper"
+require "yast2/etc_fstab"
+
+describe EtcFstab::Entry do
+  describe "#new" do
+    it "can be created empty" do
+      entry = described_class.new
+      expect(entry).not_to be_nil
+      expect(entry.to_a).to eq [nil, nil, nil, [], 0, 0]
+    end
+
+    it "can be created from an array" do
+      mount_opts = []
+      arr = ["/dev/sdb3", "/data3", "btrfs", mount_opts, 7, 2]
+      entry = described_class.new(arr)
+      expect(entry).not_to be_nil
+      expect(entry.to_a).to eq arr
+    end
+
+    it "can be created with varargs" do
+      entry = described_class.new("/dev/sdb3", "/data3", "btrfs")
+      expect(entry).not_to be_nil
+      expect(entry.to_a).to eq ["/dev/sdb3", "/data3", "btrfs", [], 0, 0]
+    end
+
+    it "can be created from a hash" do
+      args =
+        {
+          device:         "/dev/vda2",
+          mount_point:    "/home",
+          fs_type:        "xfs",
+          mount_opts:     ["foo", "bar"],
+          dump_pass:      42,
+          fsck_pass:      3,
+          comment_before: ["# Home", "# sweet home"]
+        }
+
+      entry = described_class.new(args)
+      expect(entry).not_to be_nil
+      expect(entry.to_a).to eq ["/dev/vda2", "/home", "xfs", ["foo", "bar"], 42, 3]
+      expect(entry.comment_before).to eq ["# Home", "# sweet home"]
+    end
+
+    it "can be created with named parameters" do
+      entry = described_class.new(device: "/dev/sda4", mount_point: "/data", fs_type: "ext4")
+      expect(entry).not_to be_nil
+      expect(entry.to_a).to eq ["/dev/sda4", "/data", "ext4", [], 0, 0]
+    end
+  end
+
+  describe "#parse" do
+    subject { EtcFstab::Entry.new }
+
+    it "parses a correct entry correctly" do
+      subject.parse("/dev/sda1 /data xfs defaults 0 1")
+      expect(subject.device).to eq "/dev/sda1"
+      expect(subject.mount_point).to eq "/data"
+      expect(subject.fs_type).to eq "xfs"
+      expect(subject.mount_opts).to eq []
+      expect(subject.dump_pass).to eq 0
+      expect(subject.fsck_pass).to eq 1
+    end
+
+    it "removes all 'defaults' from the mount options" do
+      subject.parse("/dev/sda1 /data xfs ro,defaults,defaults,foo 0 1")
+      expect(subject.mount_opts).to eq ["ro", "foo"]
+    end
+
+    it "throws an exception if the number of columns is wrong" do
+      expect { subject.parse("/dev/sda1 /data xfs duh defaults 0 1", 42) }
+        .to raise_error(EtcFstab::ParseError, /in line 43/)
+
+      expect { subject.parse("/dev/sda1 /data xfs duh defaults 0 1") }
+        .to raise_error(EtcFstab::ParseError, "Wrong number of columns")
+
+      expect { subject.parse("/dev/sda1 /data defaults 0 1") }
+        .to raise_error(EtcFstab::ParseError)
+    end
+  end
+
+  describe "#format" do
+    subject { EtcFstab::Entry.new }
+
+    it "formats a simple entry correctly" do
+      subject.device = "/dev/sdb7"
+      subject.mount_point = "/work"
+      subject.fs_type = "ext4"
+      subject.populate_columns
+      expect(subject.format).to eq "/dev/sdb7  /work  ext4  defaults  0  0"
+    end
+  end
+end

--- a/library/system/test/etc_fstab_test.rb
+++ b/library/system/test/etc_fstab_test.rb
@@ -1,0 +1,442 @@
+#!/usr/bin/rspec
+#
+# Unit test for EtcFstab
+#
+# (c) 2017 Stefan Hundhammer <Stefan.Hundhammer@gmx.de>
+#     Donated to the YaST project
+#
+# Original project: https://github.com/shundhammer/ruby-commented-config-file
+#
+# License: GPL V2
+#
+
+require_relative "test_helper"
+require "yast2/etc_fstab"
+require "fileutils"
+
+describe EtcFstab do
+  context "with demo-fstab" do
+    before(:all) { @fstab = described_class.new("data/fstab/demo-fstab") }
+    subject { @fstab }
+
+    describe "Parser and access methods" do
+      it "has the expected number of entries" do
+        expect(subject.size).to eq 9
+      end
+
+      it "has the expected devices" do
+        devices =
+          ["/dev/disk/by-label/swap",
+           "/dev/disk/by-label/openSUSE",
+           "/dev/disk/by-label/Ubuntu",
+           "/dev/disk/by-label/work",
+           "/dev/disk/by-label/Win-Boot",
+           "/dev/disk/by-label/Win-App",
+           "nas:/share/sh",
+           "nas:/share/work",
+           "//fritz.box/fritz.nas/"]
+        expect(subject.devices).to eq devices
+      end
+
+      it "has the expected mount points" do
+        mount_points =
+          ["none",
+           "/alternate-root",
+           "/",
+           "/work",
+           "/win/boot",
+           "/win/app",
+           "/nas/sh",
+           "/nas/work",
+           "/fritz.nas"]
+        expect(subject.mount_points).to eq mount_points
+      end
+
+      it "has the expected filesystem types" do
+        fs_types =
+          ["swap",
+           "ext4",
+           "ext4",
+           "ext4",
+           "ntfs",
+           "ntfs",
+           "nfs",
+           "nfs",
+           "cifs"]
+        expect(subject.fs_types).to eq fs_types
+      end
+
+      it "the root filesystem has the correct mount options and fsck pass" do
+        entry = subject.find_mount_point("/")
+        expect(entry).not_to be_nil
+        expect(entry.mount_opts).to eq ["errors=remount-ro"]
+        expect(entry.fsck_pass).to be == 1
+      end
+
+      it "the /work filesystem has no mount options" do
+        entry = subject.find_mount_point("/work")
+        expect(entry).not_to be_nil
+        expect(entry.mount_opts).to eq []
+        expect(entry.mount_opts.empty?).to be true
+      end
+
+      it "the Windows boot partition has the correct mount options" do
+        entry = subject.find_device("/dev/disk/by-label/Win-Boot")
+        expect(entry).not_to be_nil
+        expect(entry.mount_opts).to eq ["umask=007", "gid=46"]
+      end
+
+      it "the /fritz.nas partition's mount options are not cut off" do
+        entry = subject.find_mount_point("/fritz.nas")
+        expect(entry).not_to be_nil
+        opts = entry.mount_opts.dup
+        expect(opts.shift).to end_with("credentials.txt")
+        expect(opts).to eq ["uid=sh", "forceuid", "gid=users", "forcegid"]
+      end
+
+      it "the two Linux non-root partitions have fsck_pass 2" do
+        entries = subject.select { |e| e.fsck_pass == 2 }
+        devices = entries.map(&:device)
+        expected_devices =
+          ["/dev/disk/by-label/openSUSE",
+           "/dev/disk/by-label/work"]
+        expect(devices).to eq expected_devices
+      end
+
+      it "all non-ext4 filesystems have fsck_pass 0" do
+        entries = subject.reject { |e| e.fs_type == "ext4" }
+        nonzero_fsck = entries.reject { |e| e.fsck_pass == 0 }
+        expect(nonzero_fsck).to be_empty
+      end
+
+      it "all dump_pass fields are 0" do
+        dump_pass = subject.map(&:dump_pass)
+        expect(dump_pass.count(0)).to be == 9
+      end
+    end
+
+    describe "#fstab_encode" do
+      it "escapes space characters correctly" do
+        encoded = described_class.fstab_encode("very weird name")
+        expect(encoded).to eq "very\\040weird\\040name"
+      end
+    end
+
+    describe "#fstab_decode" do
+      it "unescapes escaped space characters correctly" do
+        decoded = described_class.fstab_decode("very\\040weird\\040name")
+        expect(decoded).to eq "very weird name"
+      end
+
+      it "unescaping an escaped string with spaces results in the original" do
+        orig = "very weird name"
+        encoded = described_class.fstab_encode(orig)
+        decoded = described_class.fstab_decode(encoded)
+        expect(decoded).to eq orig
+      end
+    end
+
+    describe "#get_mount_by" do
+      it "correctly detects a device mounted by label" do
+        entry = subject.find_mount_point("/work")
+        expect(entry).not_to be_nil
+        expect(entry.get_mount_by).to eq :label
+
+        expect(described_class.get_mount_by("LABEL=work")).to eq :label
+      end
+
+      it "correctly detects a device mounted by UUID" do
+        expect(described_class.get_mount_by("UUID=4711")).to eq :uuid
+        expect(described_class.get_mount_by("/dev/disk/by-uuid/4711")).to eq :uuid
+      end
+
+      it "correctly detects a device mounted by device" do
+        entry = subject.find_mount_point("/nas/work")
+        expect(entry).not_to be_nil
+        expect(entry.get_mount_by).to eq :device
+      end
+
+      it "correctly detects a device mounted by path" do
+        expect(described_class.get_mount_by("/dev/disk/by-path/pci-00:11.4")).to eq :path
+      end
+    end
+
+    describe "#check_mount_order" do
+      it "detects a mount order problem" do
+        expect(subject.check_mount_order).to be false
+      end
+    end
+
+    describe "#next_mount_order_problem" do
+      it "finds the mount order problem" do
+        problem_index = subject.next_mount_order_problem
+        expect(problem_index).to be == 2
+        entry = subject.entries[problem_index]
+        expect(entry).not_to be_nil
+        expect(entry.mount_point).to eq "/"
+      end
+    end
+
+    describe "#find_sort_index" do
+      it "finds the correct place to move the problematic mount point to" do
+        problem_index = 2
+        entry = subject.entries[problem_index]
+        expect(entry).not_to be_nil
+        expect(subject.send(:find_sort_index, entry)).to be == 1
+      end
+    end
+
+    describe "#fix_mount_order" do
+      it "fixes the mount order problem" do
+        new_fstab = subject.dup
+        new_fstab.fix_mount_order
+        mount_points =
+          ["none",
+           "/", # moved one position up
+           "/alternate-root",
+           "/work",
+           "/win/boot",
+           "/win/app",
+           "/nas/sh",
+           "/nas/work",
+           "/fritz.nas"]
+        expect(new_fstab.mount_points).to eq mount_points
+        expect(new_fstab.check_mount_order).to be true
+      end
+    end
+  end
+
+  context "created empty" do
+    subject { described_class.new }
+
+    let(:root) do
+      EtcFstab::Entry.new("/dev/sda1", "/", "ext4")
+    end
+
+    let(:var) do
+      EtcFstab::Entry.new("/dev/sda2", "/var", "xfs")
+    end
+
+    let(:var_lib) do
+      EtcFstab::Entry.new("/dev/sda3", "/var/lib", "jfs")
+    end
+
+    let(:var_lib_myapp) do
+      EtcFstab::Entry.new("/dev/sda4", "/var/lib/myapp", "ext3")
+    end
+
+    let(:var_lib2) do
+      EtcFstab::Entry.new("/dev/sda5", "/var/lib", "ext2")
+    end
+
+    describe "#add_entry" do
+      it "adds entries in the correct sequence" do
+        subject.add_entry(var_lib_myapp)
+        subject.add_entry(var)
+        subject.add_entry(var_lib)
+        subject.add_entry(root)
+        expect(subject.mount_points).to eq ["/", "/var", "/var/lib", "/var/lib/myapp"]
+      end
+    end
+
+    describe "#fix_mount_order" do
+      it "fixes a wrong mount order" do
+        # Intentionally using the wrong superclass method to add items
+        subject.entries << var_lib_myapp << var << var_lib << root
+
+        # Wrong order as expected
+        expect(subject.mount_points).to eq ["/var/lib/myapp", "/var", "/var/lib", "/"]
+        expect(subject.check_mount_order).to be false
+
+        expect(subject.fix_mount_order).to be true
+        expect(subject.mount_points).to eq ["/", "/var", "/var/lib", "/var/lib/myapp"]
+        expect(subject.check_mount_order).to be true
+      end
+
+      it "does not get into an endless loop in the pathological case" do
+        # Intentionally using the wrong superclass method to add items.
+        subject.entries << var_lib << var_lib2 << var << root
+
+        # Wrong order as expected
+        expect(subject.mount_points).to eq ["/var/lib", "/var/lib", "/var", "/"]
+        expect(subject.check_mount_order).to be false
+
+        expect(subject.fix_mount_order).to be false
+        expect(subject.mount_points).to eq ["/", "/var", "/var/lib", "/var/lib"]
+
+        # There still is a problem; we couldn't fix it completely.
+        # This is expected.
+        expect(subject.check_mount_order).to be false
+      end
+    end
+
+    describe "#format_lines" do
+      subject { described_class.new }
+
+      it "formats a simple entry correctly" do
+        entry = subject.create_entry(device: "/dev/sdk3", mount_point: "/work",
+          fs_type: "ext4", mount_opts: ["ro", "foo", "bar"])
+        subject.add_entry(entry)
+        subject.output_delimiter = " "
+
+        expect(subject.size).to eq 1
+        expect(subject.first).to equal(entry)
+        expect(subject.format_lines).to eq ["/dev/sdk3 /work ext4 ro,foo,bar 0 0"]
+      end
+    end
+  end
+
+  context "with demo-fstab" do
+    before(:all) { @fstab = described_class.new("data/fstab/demo-fstab") }
+    subject { @fstab }
+
+    let(:save_as_name) { "data/fstab/demo-fstab-2-generated" }
+    let(:modified_reference_name) { "data/fstab/demo-fstab-2-expected" }
+
+    describe "full-blown read, modify, write cycle" do
+      it "reads the file correctly" do
+        # Notice that constructing an EtcFstab with a filename will read that
+        # file right away
+        expect(subject.size).to eq 9
+        devices =
+          ["/dev/disk/by-label/swap",
+           "/dev/disk/by-label/openSUSE",
+           "/dev/disk/by-label/Ubuntu",
+           "/dev/disk/by-label/work",
+           "/dev/disk/by-label/Win-Boot",
+           "/dev/disk/by-label/Win-App",
+           "nas:/share/sh",
+           "nas:/share/work",
+           "//fritz.box/fritz.nas/"]
+        expect(subject.devices).to eq devices
+      end
+
+      it "has the expected header and footer comments" do
+        expect(subject.header_comments.size).to be == 15
+        expect(subject.footer_comments.size).to be == 1
+      end
+
+      it "has the expected comments before certain entries" do
+        commented = subject.select(&:comment_before?)
+        expect(commented.size).to be == 4
+
+        entry = commented.shift
+        expect(entry.fs_type).to eq "swap"
+        expect(entry.comment_before).to eq ["# Linux disk"]
+
+        entry = commented.shift
+        expect(entry.mount_point).to eq "/win/boot"
+        expect(entry.comment_before).to eq ["", "# Windows disk"]
+
+        entry = commented.shift
+        expect(entry.mount_point).to eq "/nas/sh"
+        expect(entry.comment_before).to eq ["", "# Network"]
+
+        entry = commented.shift
+        expect(entry.mount_point).to eq "/fritz.nas"
+        expect(entry.comment_before).to eq [""]
+      end
+
+      it "can rearrange entries" do
+        win_boot = subject.find_mount_point("/win/boot")
+        win_app = subject.find_mount_point("/win/app")
+
+        # Move both Windows partitions to the end (after the network shares)
+        subject.entries -= [win_boot, win_app]
+        subject.entries << win_boot << win_app
+
+        mount_points =
+          ["none",
+           "/alternate-root",
+           "/",
+           "/work",
+           "/nas/sh",
+           "/nas/work",
+           "/fritz.nas",
+           "/win/boot",
+           "/win/app"]
+        expect(subject.mount_points).to eq mount_points
+      end
+
+      it "can modify existing entries" do
+        nas_shares = subject.select { |s| s.device.start_with?("nas:") }
+        nas_shares.each { |s| s.device.gsub!(/^nas/, "home_nas") }
+
+        devices =
+          ["/dev/disk/by-label/swap",
+           "/dev/disk/by-label/openSUSE",
+           "/dev/disk/by-label/Ubuntu",
+           "/dev/disk/by-label/work",
+           "home_nas:/share/sh",
+           "home_nas:/share/work",
+           "//fritz.box/fritz.nas/",
+           "/dev/disk/by-label/Win-Boot",
+           "/dev/disk/by-label/Win-App"]
+        expect(subject.devices).to eq devices
+      end
+
+      it "can remove entries" do
+        # Removing the longest mount point to test the automatic column sizing
+        # and alignment inherited from ColumnConfigFile
+        subject.delete_if { |e| e.mount_point.include?("alternate") }
+        subject.delete_if { |e| e.device.include?("fritz") }
+
+        devices =
+          ["/dev/disk/by-label/swap",
+           "/dev/disk/by-label/Ubuntu",
+           "/dev/disk/by-label/work",
+           "home_nas:/share/sh",
+           "home_nas:/share/work",
+           "/dev/disk/by-label/Win-Boot",
+           "/dev/disk/by-label/Win-App"]
+        expect(subject.devices).to eq devices
+      end
+
+      it "can add entries in the correct order" do
+        entry = subject.create_entry("LABEL=logs", "/var/log", "xfs")
+        subject.add_entry(entry)
+
+        entry = subject.create_entry("LABEL=var", "/var", "ext2")
+        entry.comment_before = ["", "# Data that keep growing"]
+        # This should go before /var/log; add_entry is expected to move it there.
+        subject.add_entry(entry)
+
+        devices =
+          ["/dev/disk/by-label/swap",
+           "/dev/disk/by-label/Ubuntu",
+           "/dev/disk/by-label/work",
+           "home_nas:/share/sh",
+           "home_nas:/share/work",
+           "/dev/disk/by-label/Win-Boot",
+           "/dev/disk/by-label/Win-App",
+           "LABEL=var",
+           "LABEL=logs"]
+        expect(subject.devices).to eq devices
+      end
+
+      it "correctly escapes blank characters in device names" do
+        win = subject.select { |e| e.device.include?("Win-") }
+        win.each { |e| e.device.gsub!(/Win-/, "Win ") }
+
+        # Using to_s and not Entry.format here to make sure the columns are
+        # updated (populated) from the fields which Entry.to_s enforces, but
+        # Entry.format does not (for efficiency).
+
+        expect(win[0].to_s).to include "/Win\\040Boot"
+        expect(win[1].to_s).to include "/Win\\040App"
+      end
+
+      it "writes the result to file correctly" do
+        subject.write(save_as_name)
+
+        # If this fails:
+        #   diff -u data/fstab/demo-fstab-2-expected data/fstab/demo-fstab-2-generated
+        #
+        expect(FileUtils.cmp(save_as_name, modified_reference_name)).to be true
+
+        # Delete the written file if the test passed
+        File.delete(save_as_name) if File.exist?(save_as_name)
+      end
+    end
+  end
+end

--- a/library/system/test/etc_fstab_test.rb
+++ b/library/system/test/etc_fstab_test.rb
@@ -207,8 +207,6 @@ describe EtcFstab do
   end
 
   context "created empty" do
-    subject { described_class.new }
-
     let(:root) do
       EtcFstab::Entry.new("/dev/sda1", "/", "ext4")
     end
@@ -271,8 +269,6 @@ describe EtcFstab do
     end
 
     describe "#format_lines" do
-      subject { described_class.new }
-
       it "formats a simple entry correctly" do
         entry = subject.create_entry(device: "/dev/sdk3", mount_point: "/work",
           fs_type: "ext4", mount_opts: ["ro", "foo", "bar"])

--- a/library/system/test/etc_fstab_test.rb
+++ b/library/system/test/etc_fstab_test.rb
@@ -16,7 +16,7 @@ require "fileutils"
 
 describe EtcFstab do
   context "with demo-fstab" do
-    before(:all) { @fstab = described_class.new("data/fstab/demo-fstab") }
+    before(:all) { @fstab = described_class.new(TEST_DATA + "fstab/demo-fstab") }
     subject { @fstab }
 
     describe "Parser and access methods" do
@@ -287,11 +287,11 @@ describe EtcFstab do
   end
 
   context "with demo-fstab" do
-    before(:all) { @fstab = described_class.new("data/fstab/demo-fstab") }
+    before(:all) { @fstab = described_class.new(TEST_DATA + "fstab/demo-fstab") }
     subject { @fstab }
 
-    let(:save_as_name) { "data/fstab/demo-fstab-2-generated" }
-    let(:modified_reference_name) { "data/fstab/demo-fstab-2-expected" }
+    let(:save_as_name) { TEST_DATA + "fstab/demo-fstab-2-generated" }
+    let(:modified_reference_name) { TEST_DATA + "fstab/demo-fstab-2-expected" }
 
     describe "full-blown read, modify, write cycle" do
       it "reads the file correctly" do

--- a/library/system/test/test_helper.rb
+++ b/library/system/test/test_helper.rb
@@ -1,1 +1,3 @@
 require_relative "../../../test/test_helper.rb"
+
+TEST_DATA = File.join(File.dirname(__FILE__), "data/")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Dec 11 15:07:33 UTC 2017 - shundhammer@suse.com
+
+- Added infrastructure to preserve existing comments in config
+  files: CommentedConfigFile, ColumnConfigFile, EtcFstab
+  (bsc#1064437)
+- 3.2.40
+
+-------------------------------------------------------------------
 Tue Nov 28 09:50:05 UTC 2017 - mfilka@suse.com
 
 - bnc#956755, bnc#1061306 (mfilka)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.39
+Version:        3.2.40
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Imported classes from my upstream repository:

https://github.com/shundhammer/ruby-commented-config-file

That repo also contains some more examples (and general-purpose diff classes that I didn't import here and now) and of course some introductory comments.

Those classes are now used for the SLE-12-SP3 yast-nfs-client if it runs in standalone mode (i.e. outside the expert partitioner); see also the related PR against yast-nfs-client here: https://github.com/yast/yast-nfs-client/pull/56