### PR TITLE
Added missing files to Makefile.am

### DIFF
--- a/library/system/src/Makefile.am
+++ b/library/system/src/Makefile.am
@@ -29,6 +29,9 @@ desktop_DATA = \
 
 ylibdir = @ylibdir@/yast2
 ylib_DATA = \
+  lib/yast2/column_config_file.rb \
+  lib/yast2/commented_config_file.rb \
+  lib/yast2/etc_fstab.rb \
   lib/yast2/execute.rb \
   lib/yast2/hw_detection.rb \
   lib/yast2/fs_snapshot.rb \

--- a/library/system/test/Makefile.am
+++ b/library/system/test/Makefile.am
@@ -1,4 +1,8 @@
 TESTS = \
+  column_config_file_test.rb \
+  commented_config_file_test.rb \
+  etc_fstab_entry_test.rb \
+  etc_fstab_test.rb \
   execute_test.rb \
   kernel_test.rb \
   hw_detection_test.rb \

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 21 16:29:18 UTC 2017 - shundhammer@suse.com
+
+- Added missing files to Makefile.am (bsc#1064437)
+- 3.2.41
+
+-------------------------------------------------------------------
 Mon Dec 11 15:07:33 UTC 2017 - shundhammer@suse.com
 
 - Added infrastructure to preserve existing comments in config

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.40
+Version:        3.2.41
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Debugging the failing tests for yast2-nfs-client showed that the relevant new files were missing in this yast2 package; it turned out that that package is still using the AutoTools, not simply collecting all *.rb files like most of our other Ruby packages.

This commit now collects those files.