### PR TITLE
Fix running GNOME center SLE 12 SP3

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 15 16:35:08 UTC 2018 - jreidinger@suse.com
+
+- fix starting gnome control center (bsc#1058376 and bsc#1075535)
+- 3.2.42
+
+-------------------------------------------------------------------
 Thu Dec 21 16:29:18 UTC 2017 - shundhammer@suse.com
 
 - Added missing files to Makefile.am (bsc#1064437)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.41
+Version:        3.2.42
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -136,6 +136,8 @@ select_control_center()
     y2ccbin=""
     case "$WANTED_SHELL" in
 	gtk)
+            # gnome control center use different format of arguments (bsc#1058376)
+            Y2UI_ARGS="--gtk-name=YaST2 --class=yast"
 	    y2ccbin="$GNOME_SHELL"
 	    ;;
 	*)


### PR DESCRIPTION
Backport [bsc#1075535](https://bugzilla.suse.com/show_bug.cgi?id=1075535).