### PR TITLE
Replace SuSEFirewall2 by firewalld in CWMFirewallInterfaces

### DIFF
--- a/library/network/src/Makefile.am
+++ b/library/network/src/Makefile.am
@@ -39,18 +39,18 @@ yfwlibdir = @ylibdir@/y2firewall
 yfwlib_DATA = \
   lib/y2firewall/firewalld.rb
 
-yfwdlibdir = @yfwdlibdir@/firewalld
+yfwdlibdir = @ylibdir@/y2firewall/firewalld
 yfwdlib_DATA = \
   lib/y2firewall/firewalld/api.rb \
   lib/y2firewall/firewalld/relations.rb \
   lib/y2firewall/firewalld/zone.rb \
   lib/y2firewall/firewalld/zone_parser.rb
 
-yfwdapilibdir = @yfwdlibdir@/api/
+yfwdapilibdir = @ylibdir@/y2firewall/firewalld/api/
 yfwdapilib_DATA = \
   lib/y2firewall/firewalld/api/services.rb \
   lib/y2firewall/firewalld/api/zones.rb
 
-EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) $(yfwlib_DATA) $(yfwdapilib_DATA)
+EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) $(yfwlib_DATA) $(yfwdlib_DATA) $(yfwdapilib_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/library/network/src/Makefile.am
+++ b/library/network/src/Makefile.am
@@ -38,13 +38,18 @@ yfwlibdir = @ylibdir@/y2firewall
 yfwlib_DATA = \
   lib/y2firewall/firewalld.rb
 
-yfwdlibdir = @ylibdir@/y2firewall/firewalld
+yfwdlibdir = @yfwdlibdir@/firewalld
 yfwdlib_DATA = \
   lib/y2firewall/firewalld/api.rb \
   lib/y2firewall/firewalld/relations.rb \
   lib/y2firewall/firewalld/zone.rb \
   lib/y2firewall/firewalld/zone_parser.rb
 
-EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) $(yfwlib_DATA) $(yfwdlibdir_DATA)
+yfwdapilibdir = @yfwdlibdir@/api/
+yfwdapilib_DATA = \
+  lib/y2firewall/firewalld/api/services.rb \
+  lib/y2firewall/firewalld/api/zones.rb
+
+EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) $(yfwlib_DATA) $(yfwdapilib_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/library/network/src/Makefile.am
+++ b/library/network/src/Makefile.am
@@ -14,7 +14,8 @@ module_DATA = \
   modules/SuSEFirewallExpertRules.rb \
   modules/SuSEFirewallServices.rb \
   modules/SLPAPI.pm \
-  modules/DnsServerAPI.pm
+  modules/DnsServerAPI.pm \
+  modules/firewalld_wrapper.rb
 
 scrconf_DATA = \
   scrconf/sysconfig_SuSEfirewall2.scr \

--- a/library/network/src/lib/y2firewall/firewalld.rb
+++ b/library/network/src/lib/y2firewall/firewalld.rb
@@ -60,6 +60,8 @@ module Y2Firewall
     # Constructor
     def initialize
       @api = Api.new
+      @zones = []
+      @services = []
     end
 
     # Read the current firewalld configuration initializing the zones and other
@@ -73,7 +75,6 @@ module Y2Firewall
       @default_zone       = api.default_zone
       # The list of services is not read or initialized because takes time and
       # affects to the performance and also the services are rarely touched.
-      @services           = []
       true
     end
 

--- a/library/network/src/lib/y2firewall/firewalld.rb
+++ b/library/network/src/lib/y2firewall/firewalld.rb
@@ -121,12 +121,12 @@ module Y2Firewall
 
     # Apply the changes to the modified zones and sets the logging option
     def write
-      only_write
+      write_only
       reload
     end
 
     # Apply the changes to the modified zones and sets the logging option
-    def only_write
+    def write_only
       zones.map { |z| z.apply_changes! if z.modified? }
       api.log_denied_packets = log_denied_packets
       api.default_zone       = default_zone

--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -173,6 +173,12 @@ module Y2Firewall
       end
 
       # @param zone [String] The firewall zone
+      # @return [Array<String>] list of zone's sources
+      def list_sources(zone)
+        string_command("--zone=#{zone}", "--list-sources").split(" ")
+      end
+
+      # @param zone [String] The firewall zone
       # @return [Array<String>] list of all information for given zone
       def list_all(zone)
         string_command("--zone=#{zone}", "--list-all").split(" ")
@@ -219,6 +225,27 @@ module Y2Firewall
       # @return [Boolean] True if interface was changed
       def change_interface(zone, interface, permanent: permanent?)
         run_command("--zone=#{zone}", "--change-interface=#{interface}", permanent: permanent)
+      end
+
+      # @param zone [String] The firewall zone
+      # @param source [String] The network source
+      # @return [Boolean] True if source was added
+      def add_source(zone, source, permanent: permanent?)
+        run_command("--zone=#{zone}", "--add-source=#{source}", permanent: permanent)
+      end
+
+      # @param zone [String] The firewall zone
+      # @param source [String] The network source
+      # @return [Boolean] True if source was removed
+      def remove_source(zone, source, permanent: permanent?)
+        run_command("--zone=#{zone}", "--remove-source=#{source}", permanent: permanent)
+      end
+
+      # @param zone [String] The firewall zone
+      # @param source [String] The network source
+      # @return [Boolean] True if source was changed
+      def change_source(zone, source, permanent: permanent?)
+        run_command("--zone=#{zone}", "--change-source=#{source}", permanent: permanent)
       end
 
       # @param zone [String] The firewall zone

--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -179,6 +179,7 @@ module Y2Firewall
       # @see Yast::Execute
       # @param args [Array<String>] list of command optional arguments
       # @param permanent [Boolean] if true it adds the --permanent option the
+      # command to be executed
       # @param allowed_exitstatus [Fixnum, .include?, nil] allowed exit codes
       # which do not cause an exception.
       # command to be executed

--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -25,6 +25,7 @@
 require "yast"
 require "yast2/execute"
 require "y2firewall/firewalld/api/services"
+require "y2firewall/firewalld/api/zones"
 
 Yast.import "Stage"
 Yast.import "Service"
@@ -44,6 +45,7 @@ module Y2Firewall
       include Yast::Logger
       include Yast::I18n
       include Services
+      include Zones
       extend Forwardable
 
       # Map firewalld modes with their command line tools
@@ -139,202 +141,6 @@ module Y2Firewall
         return false if offline?
 
         run_command("--complete-reload")
-      end
-
-      ### Zones ####
-
-      # @return [Array<String>] List of firewall zones
-      def zones
-        string_command("--get-zones").split(" ")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Array<String>] list of zone's interfaces
-      def list_interfaces(zone)
-        string_command("--zone=#{zone}", "--list-interfaces").split(" ")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Arrray<String>] list of zone's services
-      def list_services(zone)
-        string_command("--zone=#{zone}", "--list-services").split(" ")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Array<String>] list of zone's ports
-      def list_ports(zone)
-        string_command("--zone=#{zone}", "--list-ports").split(" ")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Array<String>] list of zone's protocols
-      def list_protocols(zone)
-        string_command("--zone=#{zone}", "--list-protocols").split(" ")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Array<String>] list of zone's sources
-      def list_sources(zone)
-        string_command("--zone=#{zone}", "--list-sources").split(" ")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Array<String>] list of all information for given zone
-      def list_all(zone)
-        string_command("--zone=#{zone}", "--list-all").split(" ")
-      end
-
-      # @return [Array<String>] list of all information for all firewall zones
-      def list_all_zones
-        string_command("--list-all-zones").split("\n")
-      end
-
-      ### Interfaces ###
-
-      # Return the name of the zone the interface belongs to or nil.
-      #
-      # @param interface [String] interface name
-      # @return [String, nil] the interface zone or nil
-      def interface_zone(interface)
-        string_command("--get-zone-of-interface=#{interface}")
-      end
-
-      # @param zone [String] The firewall zone
-      # @param interface [String] The network interface
-      # @return [Boolean] True if interface is assigned to zone
-      def interface_enabled?(zone, interface)
-        query_command("--zone=#{zone} --query-interface=#{interface}")
-      end
-
-      # @param zone [String] The firewall zone
-      # @param interface [String] The network interface
-      # @return [Boolean] True if interface was added to zone
-      def add_interface(zone, interface, permanent: permanent?)
-        run_command("--zone=#{zone}", "--add-interface=#{interface}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param interface [String] The network interface
-      # @return [Boolean] True if interface was removed from zone
-      def remove_interface(zone, interface, permanent: permanent?)
-        run_command("--zone=#{zone}", "--remove-interface=#{interface}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param interface [String] The network interface
-      # @return [Boolean] True if interface was changed
-      def change_interface(zone, interface, permanent: permanent?)
-        run_command("--zone=#{zone}", "--change-interface=#{interface}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param source [String] The network source
-      # @return [Boolean] True if source was added
-      def add_source(zone, source, permanent: permanent?)
-        run_command("--zone=#{zone}", "--add-source=#{source}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param source [String] The network source
-      # @return [Boolean] True if source was removed
-      def remove_source(zone, source, permanent: permanent?)
-        run_command("--zone=#{zone}", "--remove-source=#{source}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param source [String] The network source
-      # @return [Boolean] True if source was changed
-      def change_source(zone, source, permanent: permanent?)
-        run_command("--zone=#{zone}", "--change-source=#{source}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param service [String] The firewall service
-      # @return [Boolean] True if service is enabled in zone
-      def service_enabled?(zone, service)
-        query_command("--zone=#{zone}", "--query-service=#{service}")
-      end
-
-      # @param zone [String] The firewall zone
-      # @param port [String] The firewall port
-      # @return [Boolean] True if port is enabled in zone
-      def port_enabled?(zone, port)
-        query_command("--zone=#{zone}", "--query-port=#{port}")
-      end
-
-      # @param zone [String] The firewall zone
-      # @param protocol [String] The zone protocol
-      # @return [Boolean] True if protocol is enabled in zone
-      def protocol_enabled?(zone, protocol)
-        query_command("--zone=#{zone}", "--query-protocol=#{protocol}")
-      end
-
-      # @param zone [String] The firewall zone
-      # @param service [String] The firewall service
-      # @return [Boolean] True if service was added to zone
-      def add_service(zone, service, permanent: permanent?)
-        run_command("--zone=#{zone}", "--add-service=#{service}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param port [String] The firewall port
-      # @return [Boolean] True if port was added to zone
-      def add_port(zone, port, permanent: permanent?)
-        run_command("--zone=#{zone}", "--add-port=#{port}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param protocol [String] The firewall protocol
-      # @return [Boolean] True if protocol was added to zone
-      def add_protocol(zone, protocol, permanent: permanent?)
-        run_command("--zone=#{zone}", "--add-protocol=#{protocol}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param service [String] The firewall service
-      # @return [Boolean] True if service was removed from zone
-      def remove_service(zone, service, permanent: permanent?)
-        if offline?
-          run_command("--zone=#{zone}", "--remove-service-from-zone=#{service}")
-        else
-          run_command("--zone=#{zone}", "--remove-service=#{service}", permanent: permanent)
-        end
-      end
-
-      # @param zone [String] The firewall zone
-      # @param port [String] The firewall port
-      # @return [Boolean] True if port was removed from zone
-      def remove_port(zone, port, permanent: permanent?)
-        run_command("--zone=#{zone}", "--remove-port=#{port}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @param protocol [String] The firewall protocol
-      # @return [Boolean] True if protocol was removed from zone
-      def remove_protocol(zone, protocol, permanent: permanent?)
-        run_command("--zone=#{zone}", "--remove-protocol=#{protocol}", permanent: permanent)
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Boolean] True if masquerade is enabled in zone
-      def masquerade_enabled?(zone)
-        query_command("--zone=#{zone}", "--query-masquerade")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Boolean] True if masquerade was enabled in zone
-      def add_masquerade(zone)
-        return true if masquerade_enabled?(zone)
-
-        run_command("--zone=#{zone}", "--add-masquerade")
-      end
-
-      # @param zone [String] The firewall zone
-      # @return [Boolean] True if masquerade was removed in zone
-      def remove_masquerade(zone)
-        return true if !masquerade_enabled?(zone)
-
-        run_command("--zone=#{zone}", "--remove-masquerade")
       end
 
       ### Logging ###

--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -24,6 +24,7 @@
 
 require "yast"
 require "yast2/execute"
+require "y2firewall/firewalld/api/services"
 
 Yast.import "Stage"
 Yast.import "Service"
@@ -42,6 +43,7 @@ module Y2Firewall
     class Api
       include Yast::Logger
       include Yast::I18n
+      include Services
       extend Forwardable
 
       # Map firewalld modes with their command line tools
@@ -219,61 +221,11 @@ module Y2Firewall
         run_command("--zone=#{zone}", "--change-interface=#{interface}", permanent: permanent)
       end
 
-      ### Services ###
-
-      # @return [Array<String>] List of firewall services
-      def services
-        string_command("--get-services").split(" ")
-      end
-
-      # @param service [String] The firewall service
-      # @return [Array<String>] list of all information for the given service
-      def info_service(service)
-        string_command("--info-service", service.to_s).split("\n")
-      end
-
-      # @param service [String] The firewall service
-      # @return [String] Short description for service
-      def service_short(service)
-        # these may not exist on early firewalld releases
-        string_command("--service=#{service}", "--get-short").rstrip
-      end
-
-      # @param service [String] the firewall service
-      # @return [String] Description for service
-      def service_description(service)
-        string_command("--service=#{service}", "--get-description").rstrip
-      end
-
-      # @param service [String] The firewall service
-      # @return [Boolean] True if service definition exists
-      def service_supported?(service)
-        services.include?(service)
-      end
-
       # @param zone [String] The firewall zone
       # @param service [String] The firewall service
       # @return [Boolean] True if service is enabled in zone
       def service_enabled?(zone, service)
         query_command("--zone=#{zone}", "--query-service=#{service}")
-      end
-
-      # @param service [String] The firewall service
-      # @return [Array<String>] The firewall service ports
-      def service_ports(service)
-        string_command("--service=#{service}", "--get-ports").strip
-      end
-
-      # @param service [String] The firewall service
-      # @return [Array<String>] The firewall service protocols
-      def service_protocols(service)
-        string_command("--service=#{service}", "--get-protocols").strip
-      end
-
-      # @param service [String] The firewall service
-      # @return [Array<String>] The firewall service modules
-      def service_modules(service)
-        string_command("--service=#{service}", "--get-modules").strip
       end
 
       # @param zone [String] The firewall zone

--- a/library/network/src/lib/y2firewall/firewalld/api/services.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/services.rb
@@ -25,6 +25,8 @@
 module Y2Firewall
   class Firewalld
     class Api
+      # This module contains specific api methods for handling with services
+      # definition and configuration.
       module Services
         # @param service [String] The firewall service
         def new_service(service, permanent: permanent?)

--- a/library/network/src/lib/y2firewall/firewalld/api/services.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/services.rb
@@ -25,7 +25,7 @@
 module Y2Firewall
   class Firewalld
     class Api
-      # This module contains specific api methods for handling with services
+      # This module contains specific api methods for handling services
       # definition and configuration.
       module Services
         # @param service [String] The firewall service

--- a/library/network/src/lib/y2firewall/firewalld/api/services.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/services.rb
@@ -29,7 +29,6 @@ module Y2Firewall
       # definition and configuration.
       module Services
         # @param service [String] The firewall service
-        # @param permanent [
         # @param permanent [Boolean] if true it adds the --permanent option the
         # command to be executed
         def new_service(service, permanent: permanent?)

--- a/library/network/src/lib/y2firewall/firewalld/api/services.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/services.rb
@@ -1,0 +1,98 @@
+# encoding: utf-8
+#
+# ***************************************************************************
+#
+# Copyright (c) 2017 SUSE LLC.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 or 3 of the GNU General
+# Public License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+# ***************************************************************************
+
+module Y2Firewall
+  class Firewalld
+    class Api
+      module Services
+        # @param service [String] The firewall service
+        def new_service(service, permanent: permanent?)
+          query_command("--new-service=#{service}", permanent: permanent)
+        end
+
+        # @return [Array<String>] List of firewall services
+        def services
+          string_command("--get-services").split(" ")
+        end
+
+        # @param service [String] The firewall service
+        # @return [Array<String>] list of all information for the given service
+        def info_service(service, permanent: permanent?)
+          string_command("--info-service", service.to_s, permanent: permanent).split("\n")
+        end
+
+        # @param service [String] The firewall service
+        # @return [String] Short description for service
+        def service_short(service, permanent: permanent?)
+          # these may not exist on early firewalld releases
+          string_command("--service=#{service}", "--get-short", permanent: permanent)
+        end
+
+        # @param service [String] the firewall service
+        # @return [String] Description for service
+        def service_description(service, permanent: permanent?)
+          string_command("--service=#{service}", "--get-description", permanent: permanent)
+        end
+
+        # @param service [String] The firewall service
+        # @return [Boolean] True if service definition exists
+        def service_supported?(service)
+          services.include?(service)
+        end
+
+        # @param service [String] The firewall service
+        # @return [Array<String>] The firewall service ports
+        def service_ports(service, permanent: permanent?)
+          string_command("--service=#{service}", "--get-ports", permanent: permanent).split(" ")
+        end
+
+        # @param service [String] The firewall service
+        # @return [Array<String>] The firewall service protocols
+        def service_protocols(service, permanent: permanent?)
+          string_command("--service=#{service}", "--get-protocols", permanent: permanent).split(" ")
+        end
+
+        # @param service [String] The firewall service
+        # @return [Array<String>] The firewall service modules
+        def service_modules(service, permanent: permanent?)
+          string_command("--service=#{service}", "--get-modules", permanent: permanent).split(" ")
+        end
+
+        # @param service [String] The firewall service
+        # @param port [String] The firewall port
+        # @return [Boolean] True if port was removed from service
+        def remove_service_port(service, port, permanent: permanent?)
+          string_command("--service=#{service}", "--remove-port=#{port}", permanent: permanent)
+        end
+
+        # @param service [String] The firewall firewall
+        # @param port [String] The firewall port
+        # @return [Boolean] True if port was removed from service
+        def add_service_port(service, port, permanent: permanent?)
+          string_command("--service=#{service}", "--add-port=#{port}", permanent: permanent)
+        end
+      end
+    end
+  end
+end

--- a/library/network/src/lib/y2firewall/firewalld/api/services.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/services.rb
@@ -2,7 +2,7 @@
 #
 # ***************************************************************************
 #
-# Copyright (c) 2017 SUSE LLC.
+# Copyright (c) 2018 SUSE LLC.
 # All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or
@@ -29,6 +29,9 @@ module Y2Firewall
       # definition and configuration.
       module Services
         # @param service [String] The firewall service
+        # @param permanent [
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         def new_service(service, permanent: permanent?)
           query_command("--new-service=#{service}", permanent: permanent)
         end
@@ -39,12 +42,16 @@ module Y2Firewall
         end
 
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Array<String>] list of all information for the given service
         def info_service(service, permanent: permanent?)
           string_command("--info-service", service.to_s, permanent: permanent).split("\n")
         end
 
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [String] Short description for service
         def service_short(service, permanent: permanent?)
           # these may not exist on early firewalld releases
@@ -52,6 +59,8 @@ module Y2Firewall
         end
 
         # @param service [String] the firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [String] Description for service
         def service_description(service, permanent: permanent?)
           string_command("--service=#{service}", "--get-description", permanent: permanent)
@@ -64,18 +73,24 @@ module Y2Firewall
         end
 
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Array<String>] The firewall service ports
         def service_ports(service, permanent: permanent?)
           string_command("--service=#{service}", "--get-ports", permanent: permanent).split(" ")
         end
 
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Array<String>] The firewall service protocols
         def service_protocols(service, permanent: permanent?)
           string_command("--service=#{service}", "--get-protocols", permanent: permanent).split(" ")
         end
 
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Array<String>] The firewall service modules
         def service_modules(service, permanent: permanent?)
           string_command("--service=#{service}", "--get-modules", permanent: permanent).split(" ")
@@ -83,6 +98,8 @@ module Y2Firewall
 
         # @param service [String] The firewall service
         # @param port [String] The firewall port
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if port was removed from service
         def remove_service_port(service, port, permanent: permanent?)
           string_command("--service=#{service}", "--remove-port=#{port}", permanent: permanent)
@@ -90,6 +107,8 @@ module Y2Firewall
 
         # @param service [String] The firewall firewall
         # @param port [String] The firewall port
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if port was removed from service
         def add_service_port(service, port, permanent: permanent?)
           string_command("--service=#{service}", "--add-port=#{port}", permanent: permanent)

--- a/library/network/src/lib/y2firewall/firewalld/api/zones.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/zones.rb
@@ -93,6 +93,7 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param interface [String] The network interface
+        # @param permanent [Boolean] if true it adds the --permanent option the
         # @return [Boolean] True if interface was added to zone
         def add_interface(zone, interface, permanent: permanent?)
           run_command("--zone=#{zone}", "--add-interface=#{interface}", permanent: permanent)

--- a/library/network/src/lib/y2firewall/firewalld/api/zones.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/zones.rb
@@ -101,6 +101,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param interface [String] The network interface
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if interface was removed from zone
         def remove_interface(zone, interface, permanent: permanent?)
           run_command("--zone=#{zone}", "--remove-interface=#{interface}", permanent: permanent)
@@ -108,6 +110,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param interface [String] The network interface
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if interface was changed
         def change_interface(zone, interface, permanent: permanent?)
           run_command("--zone=#{zone}", "--change-interface=#{interface}", permanent: permanent)
@@ -115,6 +119,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param source [String] The network source
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if source was added
         def add_source(zone, source, permanent: permanent?)
           run_command("--zone=#{zone}", "--add-source=#{source}", permanent: permanent)
@@ -122,6 +128,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param source [String] The network source
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if source was removed
         def remove_source(zone, source, permanent: permanent?)
           run_command("--zone=#{zone}", "--remove-source=#{source}", permanent: permanent)
@@ -129,6 +137,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param source [String] The network source
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if source was changed
         def change_source(zone, source, permanent: permanent?)
           run_command("--zone=#{zone}", "--change-source=#{source}", permanent: permanent)
@@ -157,6 +167,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if service was added to zone
         def add_service(zone, service, permanent: permanent?)
           run_command("--zone=#{zone}", "--add-service=#{service}", permanent: permanent)
@@ -164,6 +176,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param port [String] The firewall port
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if port was added to zone
         def add_port(zone, port, permanent: permanent?)
           run_command("--zone=#{zone}", "--add-port=#{port}", permanent: permanent)
@@ -171,6 +185,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param protocol [String] The firewall protocol
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if protocol was added to zone
         def add_protocol(zone, protocol, permanent: permanent?)
           run_command("--zone=#{zone}", "--add-protocol=#{protocol}", permanent: permanent)
@@ -178,6 +194,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param service [String] The firewall service
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if service was removed from zone
         def remove_service(zone, service, permanent: permanent?)
           if offline?
@@ -189,6 +207,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param port [String] The firewall port
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if port was removed from zone
         def remove_port(zone, port, permanent: permanent?)
           run_command("--zone=#{zone}", "--remove-port=#{port}", permanent: permanent)
@@ -196,6 +216,8 @@ module Y2Firewall
 
         # @param zone [String] The firewall zone
         # @param protocol [String] The firewall protocol
+        # @param permanent [Boolean] if true it adds the --permanent option the
+        # command to be executed
         # @return [Boolean] True if protocol was removed from zone
         def remove_protocol(zone, protocol, permanent: permanent?)
           run_command("--zone=#{zone}", "--remove-protocol=#{protocol}", permanent: permanent)

--- a/library/network/src/lib/y2firewall/firewalld/api/zones.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/zones.rb
@@ -1,0 +1,227 @@
+# encoding: utf-8
+#
+# ***************************************************************************
+#
+# Copyright (c) 2018 SUSE LLC.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 or 3 of the GNU General
+# Public License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+# ***************************************************************************
+
+module Y2Firewall
+  class Firewalld
+    class Api
+      # This module contains specific api methods for handling zones
+      # configuration.
+      module Zones
+        # @return [Array<String>] List of firewall zones
+        def zones
+          string_command("--get-zones").split(" ")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Array<String>] list of zone's interfaces
+        def list_interfaces(zone)
+          string_command("--zone=#{zone}", "--list-interfaces").split(" ")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Arrray<String>] list of zone's services
+        def list_services(zone)
+          string_command("--zone=#{zone}", "--list-services").split(" ")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Array<String>] list of zone's ports
+        def list_ports(zone)
+          string_command("--zone=#{zone}", "--list-ports").split(" ")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Array<String>] list of zone's protocols
+        def list_protocols(zone)
+          string_command("--zone=#{zone}", "--list-protocols").split(" ")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Array<String>] list of zone's sources
+        def list_sources(zone)
+          string_command("--zone=#{zone}", "--list-sources").split(" ")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Array<String>] list of all information for given zone
+        def list_all(zone)
+          string_command("--zone=#{zone}", "--list-all").split(" ")
+        end
+
+        # @return [Array<String>] list of all information for all firewall zones
+        def list_all_zones
+          string_command("--list-all-zones").split("\n")
+        end
+
+        ### Interfaces ###
+
+        # Return the name of the zone the interface belongs to or nil.
+        #
+        # @param interface [String] interface name
+        # @return [String, nil] the interface zone or nil
+        def interface_zone(interface)
+          string_command("--get-zone-of-interface=#{interface}")
+        end
+
+        # @param zone [String] The firewall zone
+        # @param interface [String] The network interface
+        # @return [Boolean] True if interface is assigned to zone
+        def interface_enabled?(zone, interface)
+          query_command("--zone=#{zone} --query-interface=#{interface}")
+        end
+
+        # @param zone [String] The firewall zone
+        # @param interface [String] The network interface
+        # @return [Boolean] True if interface was added to zone
+        def add_interface(zone, interface, permanent: permanent?)
+          run_command("--zone=#{zone}", "--add-interface=#{interface}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param interface [String] The network interface
+        # @return [Boolean] True if interface was removed from zone
+        def remove_interface(zone, interface, permanent: permanent?)
+          run_command("--zone=#{zone}", "--remove-interface=#{interface}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param interface [String] The network interface
+        # @return [Boolean] True if interface was changed
+        def change_interface(zone, interface, permanent: permanent?)
+          run_command("--zone=#{zone}", "--change-interface=#{interface}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param source [String] The network source
+        # @return [Boolean] True if source was added
+        def add_source(zone, source, permanent: permanent?)
+          run_command("--zone=#{zone}", "--add-source=#{source}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param source [String] The network source
+        # @return [Boolean] True if source was removed
+        def remove_source(zone, source, permanent: permanent?)
+          run_command("--zone=#{zone}", "--remove-source=#{source}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param source [String] The network source
+        # @return [Boolean] True if source was changed
+        def change_source(zone, source, permanent: permanent?)
+          run_command("--zone=#{zone}", "--change-source=#{source}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param service [String] The firewall service
+        # @return [Boolean] True if service is enabled in zone
+        def service_enabled?(zone, service)
+          query_command("--zone=#{zone}", "--query-service=#{service}")
+        end
+
+        # @param zone [String] The firewall zone
+        # @param port [String] The firewall port
+        # @return [Boolean] True if port is enabled in zone
+        def port_enabled?(zone, port)
+          query_command("--zone=#{zone}", "--query-port=#{port}")
+        end
+
+        # @param zone [String] The firewall zone
+        # @param protocol [String] The zone protocol
+        # @return [Boolean] True if protocol is enabled in zone
+        def protocol_enabled?(zone, protocol)
+          query_command("--zone=#{zone}", "--query-protocol=#{protocol}")
+        end
+
+        # @param zone [String] The firewall zone
+        # @param service [String] The firewall service
+        # @return [Boolean] True if service was added to zone
+        def add_service(zone, service, permanent: permanent?)
+          run_command("--zone=#{zone}", "--add-service=#{service}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param port [String] The firewall port
+        # @return [Boolean] True if port was added to zone
+        def add_port(zone, port, permanent: permanent?)
+          run_command("--zone=#{zone}", "--add-port=#{port}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param protocol [String] The firewall protocol
+        # @return [Boolean] True if protocol was added to zone
+        def add_protocol(zone, protocol, permanent: permanent?)
+          run_command("--zone=#{zone}", "--add-protocol=#{protocol}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param service [String] The firewall service
+        # @return [Boolean] True if service was removed from zone
+        def remove_service(zone, service, permanent: permanent?)
+          if offline?
+            run_command("--zone=#{zone}", "--remove-service-from-zone=#{service}")
+          else
+            run_command("--zone=#{zone}", "--remove-service=#{service}", permanent: permanent)
+          end
+        end
+
+        # @param zone [String] The firewall zone
+        # @param port [String] The firewall port
+        # @return [Boolean] True if port was removed from zone
+        def remove_port(zone, port, permanent: permanent?)
+          run_command("--zone=#{zone}", "--remove-port=#{port}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @param protocol [String] The firewall protocol
+        # @return [Boolean] True if protocol was removed from zone
+        def remove_protocol(zone, protocol, permanent: permanent?)
+          run_command("--zone=#{zone}", "--remove-protocol=#{protocol}", permanent: permanent)
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Boolean] True if masquerade is enabled in zone
+        def masquerade_enabled?(zone)
+          query_command("--zone=#{zone}", "--query-masquerade")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Boolean] True if masquerade was enabled in zone
+        def add_masquerade(zone)
+          return true if masquerade_enabled?(zone)
+
+          run_command("--zone=#{zone}", "--add-masquerade")
+        end
+
+        # @param zone [String] The firewall zone
+        # @return [Boolean] True if masquerade was removed in zone
+        def remove_masquerade(zone)
+          return true if !masquerade_enabled?(zone)
+
+          run_command("--zone=#{zone}", "--remove-masquerade")
+        end
+      end
+    end
+  end
+end

--- a/library/network/src/lib/y2firewall/firewalld/relations.rb
+++ b/library/network/src/lib/y2firewall/firewalld/relations.rb
@@ -42,7 +42,8 @@ module  Y2Firewall
       #   zone.apply_services_changes!
       #
       # @param args [Array<Symbol] relation or attribute names
-      def has_many(*relations) # rubocop:disable Style/PredicateName
+      def has_many(*relations, scope: nil) # rubocop:disable Style/PredicateName
+        scope = "#{scope}_" if scope
         relations.each do |relation|
           relation_singularized = relation.to_s.sub(/s$/, "")
           class_eval("attr_accessor :#{relation}")
@@ -60,15 +61,19 @@ module  Y2Firewall
           end
 
           define_method "current_#{relation}" do
-            api.public_send("list_#{relation}", name)
+            if scope
+              api.public_send("#{scope}#{relation}", name)
+            else
+              api.public_send("list_#{relation}", name)
+            end
           end
 
           define_method "add_#{relation_singularized}!" do |item|
-            api.public_send("add_#{relation_singularized}", name, item)
+            api.public_send("add_#{scope}#{relation_singularized}", name, item)
           end
 
           define_method "remove_#{relation_singularized}!" do |item|
-            api.public_send("remove_#{relation_singularized}", name, item)
+            api.public_send("remove_#{scope}#{relation_singularized}", name, item)
           end
 
           define_method "add_#{relation}!" do

--- a/library/network/src/lib/y2firewall/firewalld/service.rb
+++ b/library/network/src/lib/y2firewall/firewalld/service.rb
@@ -71,7 +71,7 @@ module Y2Firewall
       end
 
       def apply_changes!
-        create! unless supported?
+        return false unless supported?
 
         apply_protocols_changes!
         apply_ports_changes!

--- a/library/network/src/lib/y2firewall/firewalld/service.rb
+++ b/library/network/src/lib/y2firewall/firewalld/service.rb
@@ -35,7 +35,7 @@ module Y2Firewall
       attr_accessor :short
       attr_accessor :description
 
-      has_many :ports, :protocols, :scope => "service"
+      has_many :ports, :protocols, scope: "service"
 
       # Constructor
       #

--- a/library/network/src/lib/y2firewall/firewalld/service.rb
+++ b/library/network/src/lib/y2firewall/firewalld/service.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 # ------------------------------------------------------------------------------
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2018 SUSE LLC
 #
 #
 # This program is free software; you can redistribute it and/or modify it under
@@ -27,6 +27,13 @@ module Y2Firewall
   class Firewalld
     # Class to work with Firewalld services
     class Service
+      # Service was not found
+      class NotFound < StandardError
+        def initialize(name)
+          super "Service '#{name}' not found"
+        end
+      end
+
       extend Relations
       include Yast::I18n
       extend Yast::I18n

--- a/library/network/src/lib/y2firewall/firewalld/service.rb
+++ b/library/network/src/lib/y2firewall/firewalld/service.rb
@@ -38,27 +38,37 @@ module Y2Firewall
       include Yast::I18n
       extend Yast::I18n
 
-      attr_accessor :name
-      attr_accessor :short
-      attr_accessor :description
+      # @return name [String] service name
+      attr_reader :name
+      # @return short [String] service short description
+      attr_reader :short
+      # @return description [String] service long description
+      attr_reader :description
 
       has_many :ports, :protocols, scope: "service"
 
       # Constructor
       #
       # @param name [String] zone name
-      def initialize(name: nil)
+      def initialize(name:)
         @name = name
       end
 
+      # Create the service in firewalld
       def create!
         api.add_service(name)
       end
 
+      # Return whether the service is available in firewalld or not
+      #
+      # @return [Boolean] true if defined; false otherwise
       def supported?
         api.service_supported?(name)
       end
 
+      # Read the firewalld configuration initializing the object accordingly
+      #
+      # @return [Boolean] true if read
       def read
         return false unless supported?
 
@@ -70,6 +80,9 @@ module Y2Firewall
         true
       end
 
+      # Apply the changes done since read in firewalld
+      #
+      # @return [Boolean] true if applied; false otherwise
       def apply_changes!
         return false unless supported?
 

--- a/library/network/src/lib/y2firewall/firewalld/service.rb
+++ b/library/network/src/lib/y2firewall/firewalld/service.rb
@@ -1,0 +1,92 @@
+# encoding: utf-8
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC
+#
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2firewall/firewalld/api"
+require "y2firewall/firewalld/relations"
+
+module Y2Firewall
+  class Firewalld
+    # Class to work with Firewalld services
+    class Service
+      extend Relations
+      include Yast::I18n
+      extend Yast::I18n
+
+      attr_accessor :name
+      attr_accessor :short
+      attr_accessor :description
+
+      has_many :ports, :protocols, :scope => "service"
+
+      # Constructor
+      #
+      # @param name [String] zone name
+      def initialize(name: nil)
+        @name = name
+      end
+
+      def create!
+        api.add_service(name)
+      end
+
+      def supported?
+        api.service_supported?(name)
+      end
+
+      def read
+        return false unless supported?
+
+        @short        = api.service_short(name)
+        @description  = api.service_description(name)
+        @protocols    = current_protocols
+        @ports        = current_ports
+
+        true
+      end
+
+      def apply_changes!
+        create! unless supported?
+
+        apply_protocols_changes!
+        apply_ports_changes!
+
+        true
+      end
+
+    private
+
+      # Convenience method which return an instance of Y2Firewall::Firewalld
+      #
+      # @return [Y2Firewall::Firewalld] a firewalld instance
+      def firewalld
+        Y2Firewall::Firewalld.instance
+      end
+
+      # Convenience method which return an instance of the firewalld API
+      #
+      # @return [Y2Firewall::Firewalld::API] a firewalld api instance
+      def api
+        @api ||= firewalld.api
+      end
+    end
+  end
+end

--- a/library/network/src/lib/y2firewall/firewalld/zone.rb
+++ b/library/network/src/lib/y2firewall/firewalld/zone.rb
@@ -69,6 +69,10 @@ module Y2Firewall
         KNOWN_ZONES
       end
 
+      def full_name
+        self.class.known_zones[name]
+      end
+
       # Whether the zone have been modified or not since read
       #
       # @return [Boolean] true if it was modified; false otherwise

--- a/library/network/src/lib/y2firewall/firewalld/zone.rb
+++ b/library/network/src/lib/y2firewall/firewalld/zone.rb
@@ -48,7 +48,7 @@ module Y2Firewall
       attr_reader :name
 
       # @see Y2Firewall::Firewalld::Relations
-      has_many :services, :interfaces, :protocols, :ports
+      has_many :services, :interfaces, :protocols, :ports, :sources
 
       # [Boolean] Whether masquerade is enabled or not
       attr_accessor :masquerade
@@ -81,6 +81,7 @@ module Y2Firewall
         return true if current_services.sort   != services.sort
         return true if current_protocols.sort  != protocols.sort
         return true if current_ports.sort      != ports.sort
+        return true if current_sources.sort    != sources.sort
 
         masquerade? != api.masquerade_enabled?(name)
       end
@@ -91,6 +92,7 @@ module Y2Firewall
         apply_services_changes!
         apply_ports_changes!
         apply_protocols_changes!
+        apply_sources_changes!
 
         masquerade? ? api.add_masquerade(name) : api.remove_masquerade(name)
       end
@@ -109,6 +111,7 @@ module Y2Firewall
         @services   = api.list_services(name)
         @ports      = api.list_ports(name)
         @protocols  = api.list_protocols(name)
+        @sources    = api.list_sources(name)
         @masquerade = api.masquerade_enabled?(name)
 
         true
@@ -132,6 +135,7 @@ module Y2Firewall
           "services"   => services,
           "ports"      => ports,
           "protocols"  => protocols,
+          "sources"    => sources,
           "masquerade" => masquerade
         }
       end

--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -1062,7 +1062,7 @@ module Yast
     def services_not_defined_widget(services)
       services_list =
         services.map do |service|
-          if firewalld.api.service_supported?(service)
+          if !firewalld.api.service_supported?(service)
             HBox(HSpacing(2), Left(Label(_("* %{service} (Not available)") % { service: service })))
           else
             HBox(HSpacing(2), Left(Label(_("* %{service}") % { service: service })))

--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -841,7 +841,9 @@ module Yast
     # </pre>
     # @return [Hash] the widget description map
     def CreateOpenFirewallWidget(settings)
-      services = settings.fetch("services", []) || []
+      settings = deep_copy(settings)
+
+      services = adapt_settings_services!(settings)
 
       if services.empty?
         log.error("Firewall services not specified")
@@ -1102,6 +1104,25 @@ module Yast
           )
         )
       )
+    end
+
+    # Modify the services of a given widget settings definition removing old
+    # "services:" prepend from them.
+    #
+    # @example
+    #
+    #  settings = { "services" => ["service:apache2", "service:apache2-ssl"] }
+    #  adapt_settings_services!(settings) #=> ["apache2", "apache2-ssl"]
+    #  settings #=> { "services" => ["apache2", "apache2-ssl"] }
+    #
+    # @param settings[Hash{String => Object}] settings a map of all parameters needed
+    # to create the widget properly
+    # @return [Array<String>] converted widget settings services names
+    def adapt_settings_services!(settings)
+      services = settings.fetch("services", []) || []
+      return [] if services.empty?
+
+      settings["services"] = services.map { |s| s.sub!(/service:/, "") }
     end
   end
 

--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -42,6 +42,29 @@ require "yast"
 require "y2firewall/firewalld"
 
 module Yast
+  # This class provide a set of methods to define a widget for handling with
+  # firewall interfaces configuration.
+  #
+  # @example Open a service in the firewall
+  #
+  #   # Obtain the firewalld widget description (a widget with the firewalld
+  #   # status, a checkbox for opening the service in all the interfaces and
+  #   # a details button to decide per interface where should be opened.
+  #
+  #   CWMFireallInterfaces.CreateOpenFirewallWidget(["smtp"])
+  #
+  #   # Require the new firewalld library
+  #   require 'y2firewall/firewalld'
+  #
+  #   # In your Read method call firewalld.read to initializate the firewalld
+  #   # object and all of its zones.
+  #
+  #   Y2Firewall::Firewalld.instance.read
+  #
+  #   # And finally call firewalld.write to apply the changes done through the
+  #   # widget.
+  #
+  #   Y2Firewall::Firewalld.instance.write
   class CWMFirewallInterfacesClass < Module
     include Yast::Logger
 

--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -1122,7 +1122,9 @@ module Yast
       services = settings.fetch("services", []) || []
       return [] if services.empty?
 
-      settings["services"] = services.map { |s| s.sub!(/service:/, "") }
+      services.each { |s| s.sub!(/service:/, "") }
+
+      settings["services"] = services.select { |s| s && !s.empty? }
     end
   end
 

--- a/library/network/src/modules/firewalld_wrapper.rb
+++ b/library/network/src/modules/firewalld_wrapper.rb
@@ -1,0 +1,57 @@
+# encoding: utf-8
+#
+# ***************************************************************************
+#
+# Copyright (c) 2017 SUSE LLC.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 or 3 of the GNU General
+# Public License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+# ***************************************************************************
+
+require "yast"
+require "y2firewall/firewalld"
+
+module Yast
+  # This module add support for handling firewalld configuration and it is
+  # mainly a firewalld wrapper. It is inteded to be used mostly by YaST
+  # modules written in Perl like yast-dns-server.
+  class FirewalldWrapperClass < Module
+    def read
+      firewalld.read
+    end
+
+    def write
+      firewalld.write
+    end
+
+    def write_only
+      firewalld.write_only
+    end
+
+    publish function: :read, type: "boolean (string)"
+    publish function: :write, type: "boolean (string)"
+    publish function: :write_only, type: "boolean (string)"
+
+  private
+
+    def firewalld
+      Y2Firewall::Firewalld.instance
+    end
+  end
+
+  FirewalldWrapper = FirewalldWrapperClass.new
+end

--- a/library/network/test/cwm_firewall_interfaces_test.rb
+++ b/library/network/test/cwm_firewall_interfaces_test.rb
@@ -1,0 +1,191 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+Yast.import "CWMFirewallInterfaces"
+Yast.import "NetworkInterfaces"
+Yast.import "Mode"
+Yast.import "UI"
+
+describe Yast::CWMFirewallInterfaces do
+
+  subject { Yast::CWMFirewallInterfaces }
+
+  describe "#CreateOpenFirewallWidget" do
+    let(:widget_settings) { { "services" => ["apache"] } }
+  end
+
+  describe "#OpenFirewallInit" do
+    let(:open_firewall_widget) { false }
+    let(:widget_settings) { { "services" => ["apache"] } }
+    let(:allowed_interfaces) { ["eth0"] }
+    let(:all_interfaces) { ["eth0", "eth1"] }
+    let(:firewalld_enabled?) { true }
+
+    before do
+      allow(Yast::UI).to receive(:WidgetExists).with(Id("_cwm_open_firewall"))
+        .and_return(open_firewall_widget)
+      allow(subject).to receive(:InitAllInterfacesList)
+      allow(subject).to receive(:InitAllowedInterfaces)
+      allow(subject).to receive(:UpdateFirewallStatus)
+      allow(subject).to receive(:EnableOrDisableFirewallDetails)
+      allow(subject).to receive(:allowed_interfaces).and_return(allowed_interfaces)
+      allow(subject).to receive(:all_interfaces).and_return(all_interfaces)
+      allow(Yast::UI).to receive(:ChangeWidget)
+      allow_any_instance_of(Y2Firewall::Firewalld)
+        .to receive(:enabled?).and_return(firewalld_enabled?)
+    end
+
+    context "when the open firewall widget does not exist" do
+      it "return nil" do
+        subject.OpenFirewallInit(widget_settings, "")
+      end
+    end
+
+    context "when the open firewall widget exist" do
+      let(:open_firewall_widget) { true }
+
+      it "initializes the list of network interfaces" do
+        expect(subject).to receive(:InitAllInterfacesList)
+        subject.OpenFirewallInit(widget_settings, "")
+      end
+
+      it "initializes the list of allowed interfaces" do
+        expect(subject).to receive(:InitAllowedInterfaces)
+        subject.OpenFirewallInit(widget_settings, "")
+      end
+
+      it "updates the firewalld status label" do
+        expect(subject).to receive(:UpdateFirewallStatus)
+        subject.OpenFirewallInit(widget_settings, "")
+      end
+
+      it "enables or disables the firewall details button according to the settings" do
+        expect(subject).to receive(:EnableOrDisableFirewallDetails)
+        subject.OpenFirewallInit(widget_settings, "")
+      end
+
+      context "and firewalld is enabled" do
+        context "but there are no network interfaces in the system" do
+          let(:all_interfaces) { [] }
+
+          it "disables the open port checkbox" do
+            expect(Yast::UI).to receive(:ChangeWidget)
+              .with(Id("_cwm_open_firewall"), :Enabled, false)
+
+            subject.OpenFirewallInit(widget_settings, "")
+          end
+
+          it "sets the open port checkbox as unchecked" do
+            expect(Yast::UI).to receive(:ChangeWidget)
+              .with(Id("_cwm_open_firewall"), :Value, false)
+
+            subject.OpenFirewallInit(widget_settings, "")
+          end
+        end
+      end
+
+      context "and firewalld is disabled" do
+        let(:firewalld_enabled?) { false }
+
+        it "disables the open port checkbox" do
+          expect(Yast::UI).to receive(:ChangeWidget)
+            .with(Id("_cwm_open_firewall"), :Enabled, false)
+
+          subject.OpenFirewallInit(widget_settings, "")
+        end
+
+        it "sets the open port checkbox as unchecked" do
+          expect(Yast::UI).to receive(:ChangeWidget)
+            .with(Id("_cwm_open_firewall"), :Value, false)
+
+          subject.OpenFirewallInit(widget_settings, "")
+        end
+      end
+    end
+
+  end
+
+  describe "#InitAllInterfacesList" do
+    let(:mode) { "normal" }
+
+    before do
+      allow(Yast::Mode).to receive(:mode).and_return(mode)
+    end
+    context "when called in :installation, :update or :config Mode" do
+      let(:mode) { "update" }
+
+      it "does not read network interfaces config" do
+        allow(Yast::Mode).to receive(:config).and_return(true)
+        expect(Yast::NetworkInterfaces).to_not receive(:Read)
+
+        subject.InitAllInterfacesList
+      end
+    end
+
+    context "in other modes" do
+      it "reads the network interfaces configuration" do
+        expect(Yast::NetworkInterfaces).to receive(:Read)
+
+        subject.InitAllInterfacesList
+      end
+    end
+  end
+
+  describe "#Selected2Opened" do
+    context "given a list of selected interfaces" do
+      let(:zone) do
+        instance_double("Y2Firewall::Firewalld::Zone", interfaces: ["eth0", "eth1"], name: "public")
+      end
+
+      before do
+        allow(subject).to receive(:interface_zone).with("eth0").and_return("public")
+        allow_any_instance_of(Y2Firewall::Firewalld).to receive(:find_zone).and_return(zone)
+      end
+
+      it "returns all the interfaces that belongs to same zone of the given interfaces" do
+        expect(subject.Selected2Opened(["eth0"], false)).to eq(["eth0", "eth1"])
+      end
+    end
+  end
+
+  describe "#StoreAllowedInterfaces" do
+    let(:known_interfaces) do
+      [
+        { "id" => "eth0", "name" => "Ethernet 1", "zone" => "external" },
+        { "id" => "eth1", "name" => "Ethernet 2", "zone" => "public" },
+        { "id" => "eth2", "name" => "Ethernet 3", "zone" => nil }
+      ]
+    end
+    let(:external_zone) do
+      instance_double("Y2Firewall::Firewalld::Zone", name: "external",
+                      interfaces: ["eth0"], services: [])
+    end
+    let(:public_zone) do
+      instance_double("Y2Firewall::Firewalld::Zone", name: "public",
+                      interfaces: ["eth1"], services: ["dns"])
+    end
+
+    let(:zones) { [external_zone, public_zone] }
+
+    before do
+      allow(subject).to receive(:known_interfaces).and_return(known_interfaces)
+      allow_any_instance_of(Y2Firewall::Firewalld).to receive(:zones).and_return(zones)
+      allow(subject).to receive(:default_zone).and_return(public_zone)
+      allow(subject).to receive(:configuration_changed).and_return(true)
+      allow(subject).to receive(:allowed_interfaces).and_return(["eth0", "eth1", "eth2"])
+    end
+
+    context "given a list of services" do
+      context "and having set the list of allowed interfaces" do
+        it "enables each service in the zones with allowed interfaces" do
+          expect(public_zone).to_not receive(:add_service)
+          expect(public_zone).to_not receive(:remove_service)
+          expect(external_zone).to receive(:add_service).with("dns")
+
+          subject.StoreAllowedInterfaces(["dns"])
+        end
+      end
+    end
+  end
+end

--- a/library/network/test/y2firewall/firewalld/zone_test.rb
+++ b/library/network/test/y2firewall/firewalld/zone_test.rb
@@ -65,7 +65,9 @@ describe Y2Firewall::Firewalld::Zone do
       allow(subject).to receive(:current_ports).and_return(["80/tcp", "443/tcp"])
       allow(subject).to receive(:ports).and_return(["80/tcp", "443/tcp"])
       allow(subject).to receive(:current_protocols).and_return([])
+      allow(subject).to receive(:current_sources).and_return([])
       allow(subject).to receive(:protocols).and_return([])
+      allow(subject).to receive(:sources).and_return([])
       allow(subject).to receive(:masquerade?).and_return(true)
     end
 
@@ -93,6 +95,7 @@ describe Y2Firewall::Firewalld::Zone do
       allow(subject).to receive(:services).and_return(["ssh", "samba"])
       allow(subject).to receive(:ports).and_return(["80/tcp", "443/tcp"])
       allow(subject).to receive(:protocols).and_return(["esp"])
+      allow(subject).to receive(:sources).and_return([])
       allow(subject).to receive(:masquerade).and_return(true)
     end
 
@@ -104,6 +107,7 @@ describe Y2Firewall::Firewalld::Zone do
       expect(config["services"]).to eql(["ssh", "samba"])
       expect(config["ports"]).to eql(["80/tcp", "443/tcp"])
       expect(config["protocols"]).to eql(["esp"])
+      expect(config["sources"]).to eql([])
       expect(config["masquerade"]).to eql(true)
     end
   end

--- a/library/network/test/y2firewall/firewalld_test.rb
+++ b/library/network/test/y2firewall/firewalld_test.rb
@@ -330,7 +330,7 @@ describe Y2Firewall::Firewalld do
     end
 
     it "reloads firewalld" do
-      allow(firewalld).to receive(:write_only)
+      allow(firewalld).to receive(:write_only).and_return(true)
       expect(firewalld).to receive(:reload)
 
       firewalld.write

--- a/library/network/test/y2firewall/firewalld_test.rb
+++ b/library/network/test/y2firewall/firewalld_test.rb
@@ -280,7 +280,6 @@ describe Y2Firewall::Firewalld do
     end
   end
 
-
   describe "#write_only" do
     let(:api) do
       Y2Firewall::Firewalld::Api.new

--- a/library/network/test/y2firewall/firewalld_test.rb
+++ b/library/network/test/y2firewall/firewalld_test.rb
@@ -189,13 +189,15 @@ describe Y2Firewall::Firewalld do
        "  interfaces: ",
        "  ports: ",
        "  protocols:",
+       "  sources:",
        "",
        "external (active)",
        "  target: default",
        "  interfaces: eth0",
        "  services: ssh samba",
        "  ports: 5901/tcp 5901/udp",
-       "  protocols: "]
+       "  protocols:",
+       "  sources:"]
     end
 
     let(:api) do
@@ -278,7 +280,8 @@ describe Y2Firewall::Firewalld do
     end
   end
 
-  describe "#write" do
+
+  describe "#write_only" do
     let(:api) do
       Y2Firewall::Firewalld::Api.new
     end
@@ -301,7 +304,7 @@ describe Y2Firewall::Firewalld do
       expect(api).to receive(:default_zone=).with("drop")
       expect(api).to receive(:log_denied_packets=).with(false)
 
-      firewalld.write
+      firewalld.write_only
     end
 
     it "only apply changes to the modified zones" do
@@ -311,11 +314,27 @@ describe Y2Firewall::Firewalld do
       external = firewalld.find_zone("external")
       expect(external).to_not receive(:apply_changes!)
 
-      firewalld.write
+      firewalld.write_only
     end
 
     it "returns true" do
-      expect(firewalld.write).to eq(true)
+      expect(firewalld.write_only).to eq(true)
+    end
+  end
+
+  describe "#write" do
+    it "writes the configuration" do
+      allow(firewalld).to receive(:reload)
+      expect(firewalld).to receive(:write_only)
+
+      firewalld.write
+    end
+
+    it "reloads firewalld" do
+      allow(firewalld).to receive(:write_only)
+      expect(firewalld).to receive(:reload)
+
+      firewalld.write
     end
   end
 
@@ -326,13 +345,15 @@ describe Y2Firewall::Firewalld do
        "  interfaces: ",
        "  ports: ",
        "  protocols:",
+       "  sources:",
        "",
        "external (active)",
        "  target: default",
        "  interfaces: eth0",
        "  services: ssh samba",
        "  ports: 5901/tcp 5901/udp",
-       "  protocols: esp"]
+       "  protocols: esp",
+       "  sources:"]
     end
 
     let(:api) do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 23 07:31:21 UTC 2018 - knut.anderssen@suse.com
+
+- CWMFirewallInterfaces: Replaced SuSEFirewall2 by firewalld.
+  (fate#323460)
+- 4.0.36
+
+-------------------------------------------------------------------
 Tue Jan 16 14:43:14 UTC 2018 - jreidinger@suse.com
 
 - fix having some roles without description when choosing

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.35
+Version:        4.0.36
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)

The CWMFirewallInterfaces have been maintained and just adapted to work with firewalld, the only big dfiference is that CWMFirewallInterfaces.CreateOpenFirewallWidget will return a empty VBox() if some service is not supported preventing modifications:

![notsupportedservices](https://user-images.githubusercontent.com/7056681/35213240-d6919588-ff54-11e7-90db-c54943cb9df9.png)
