### PR TITLE
Fix overlay

### DIFF
--- a/library/control/src/modules/ProductFeatures.rb
+++ b/library/control/src/modules/ProductFeatures.rb
@@ -324,7 +324,9 @@ module Yast
     # @param features [Hash{String => Hash{String => Object}}] in the same
     #   format as `@features` or `@defaults`
     # @return void
+    # @raise RuntimeError if called twice without {ClearOverlay}
     def SetOverlay(features)
+      raise "SetOverlay called when old overlay was not cleared" if @backup_features
       @backup_features = deep_copy(@features)
 
       features.each do |section_name, section|

--- a/library/control/src/modules/ProductFeatures.rb
+++ b/library/control/src/modules/ProductFeatures.rb
@@ -340,6 +340,9 @@ module Yast
     def ClearOverlay
       return if @backup_features.nil?
       @features = deep_copy(@backup_features)
+      # when overlay is cleared, remove backup as it can become invalid over-time
+      # when new extensions is applied
+      @backup_features = nil
     end
 
     publish function: :GetStringFeature, type: "string (string, string)"

--- a/library/control/test/ProductFeatures_test.rb
+++ b/library/control/test/ProductFeatures_test.rb
@@ -61,6 +61,15 @@ describe Yast::ProductFeatures do
       expect(subject.Export).to eq(original_features)
     end
 
+    it "does nothing in second consequent call" do
+      subject.Import(original_features)
+      subject.SetOverlay(overlay_features)
+      subject.ClearOverlay
+      subject.SetFeature("globals", "keyboard", "test")
+      subject.ClearOverlay
+      expect(subject.Export).to_not eq(original_features)
+    end
+
     it "keeps the original state if nothing was overlaid" do
       subject.Import(original_features)
       subject.ClearOverlay

--- a/library/control/test/ProductFeatures_test.rb
+++ b/library/control/test/ProductFeatures_test.rb
@@ -7,6 +7,11 @@ Yast.import "ProductFeatures"
 describe Yast::ProductFeatures do
   subject { Yast::ProductFeatures }
 
+  before do
+    # ensure no overlay is active
+    subject.ClearOverlay
+  end
+
   let(:original_features) do
     {
       "globals"      => {
@@ -50,6 +55,12 @@ describe Yast::ProductFeatures do
       subject.Import(original_features)
       subject.SetOverlay(overlay_features)
       expect(subject.Export).to eq(resulting_features)
+    end
+
+    it "raises RuntimeError if called twice without ClearOverlay meanwhile" do
+      subject.Import(original_features)
+      subject.SetOverlay(overlay_features)
+      expect{subject.SetOverlay(overlay_features)}.to raise_error(RuntimeError)
     end
   end
 

--- a/library/control/test/ProductFeatures_test.rb
+++ b/library/control/test/ProductFeatures_test.rb
@@ -60,7 +60,7 @@ describe Yast::ProductFeatures do
     it "raises RuntimeError if called twice without ClearOverlay meanwhile" do
       subject.Import(original_features)
       subject.SetOverlay(overlay_features)
-      expect{subject.SetOverlay(overlay_features)}.to raise_error(RuntimeError)
+      expect { subject.SetOverlay(overlay_features) }.to raise_error(RuntimeError)
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 16 14:43:14 UTC 2018 - jreidinger@suse.com
+
+- fix having some roles without description when choosing
+  different extensions during installation (bsc#1070726)
+- 4.0.35
+
+-------------------------------------------------------------------
 Fri Jan 12 14:13:38 CET 2018 - schubi@suse.de
 
 - Firewalld export: Return empty hash if the package has not

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.34
+Version:        4.0.35
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
quoting first commit message:

### Fix applying too old backup for overlays (bsc#1070726)

In general problem is that system role selection clears overlay before
creating dialog, but it does it when going back and also when going
forward. So result is that when going back it is properly cleared and
then when going forward when different extensions is chosen, it is again
cleared, but with invalid backup. So this change in the end apply backup
only when going back.