### PR TITLE
Base product selection fix

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 26 14:25:07 UTC 2018 - lslezak@suse.cz
+
+- Improved base product detection at upgrade (fate#1076513)
+- 4.0.40
+
+-------------------------------------------------------------------
 Wed Jan 24 14:13:13 UTC 2018 - knut.anderssen@suse.com
 
 - Firewalld: Added methods to the wrapper class for opening ports

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.39
+Version:        4.0.40
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- This is a workaround for reading the base product in offline migration via SCC, we need to use the `system-installation()` provides for correctly detecting the base products
- We need some functionality from the `yast2-packager` but as we cannot depend on that package (it would introduce a circular dependency) there is a simple `LoadError` check, the `yast2-packager` is included in the inst-sys anyway
- Because the package submission deadline is today we need to merge it ASAP
- The fix up can be done later, we need this feature for the testers (added `FIXME` at least)
- Tested manually in the SLES12-SP3 -> SLES15 offline migration