### PR TITLE
Checking if firewalld has been installed before calling it

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/api/services.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/services.rb
@@ -31,12 +31,15 @@ module Y2Firewall
         # @param service [String] The firewall service
         # @param permanent [Boolean] if true it adds the --permanent option the
         # command to be executed
+        # @return true for success
         def new_service(service, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           query_command("--new-service=#{service}", permanent: permanent)
         end
 
         # @return [Array<String>] List of firewall services
         def services
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--get-services").split(" ")
         end
 
@@ -45,6 +48,7 @@ module Y2Firewall
         # command to be executed
         # @return [Array<String>] list of all information for the given service
         def info_service(service, permanent: permanent?)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--info-service", service.to_s, permanent: permanent).split("\n")
         end
 
@@ -54,6 +58,7 @@ module Y2Firewall
         # @return [String] Short description for service
         def service_short(service, permanent: permanent?)
           # these may not exist on early firewalld releases
+          return "" unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--get-short", permanent: permanent)
         end
 
@@ -62,12 +67,14 @@ module Y2Firewall
         # command to be executed
         # @return [String] Description for service
         def service_description(service, permanent: permanent?)
+          return "" unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--get-description", permanent: permanent)
         end
 
         # @param service [String] The firewall service
         # @return [Boolean] True if service definition exists
         def service_supported?(service)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           services.include?(service)
         end
 
@@ -76,6 +83,7 @@ module Y2Firewall
         # command to be executed
         # @return [Array<String>] The firewall service ports
         def service_ports(service, permanent: permanent?)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--get-ports", permanent: permanent).split(" ")
         end
 
@@ -84,6 +92,7 @@ module Y2Firewall
         # command to be executed
         # @return [Array<String>] The firewall service protocols
         def service_protocols(service, permanent: permanent?)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--get-protocols", permanent: permanent).split(" ")
         end
 
@@ -92,6 +101,7 @@ module Y2Firewall
         # command to be executed
         # @return [Array<String>] The firewall service modules
         def service_modules(service, permanent: permanent?)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--get-modules", permanent: permanent).split(" ")
         end
 
@@ -101,6 +111,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if port was removed from service
         def remove_service_port(service, port, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--remove-port=#{port}", permanent: permanent)
         end
 
@@ -110,6 +121,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if port was removed from service
         def add_service_port(service, port, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           string_command("--service=#{service}", "--add-port=#{port}", permanent: permanent)
         end
       end

--- a/library/network/src/lib/y2firewall/firewalld/api/zones.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/zones.rb
@@ -30,47 +30,55 @@ module Y2Firewall
       module Zones
         # @return [Array<String>] List of firewall zones
         def zones
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--get-zones").split(" ")
         end
 
         # @param zone [String] The firewall zone
         # @return [Array<String>] list of zone's interfaces
         def list_interfaces(zone)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--zone=#{zone}", "--list-interfaces").split(" ")
         end
 
         # @param zone [String] The firewall zone
         # @return [Arrray<String>] list of zone's services
         def list_services(zone)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--zone=#{zone}", "--list-services").split(" ")
         end
 
         # @param zone [String] The firewall zone
         # @return [Array<String>] list of zone's ports
         def list_ports(zone)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--zone=#{zone}", "--list-ports").split(" ")
         end
 
         # @param zone [String] The firewall zone
         # @return [Array<String>] list of zone's protocols
         def list_protocols(zone)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--zone=#{zone}", "--list-protocols").split(" ")
         end
 
         # @param zone [String] The firewall zone
         # @return [Array<String>] list of zone's sources
         def list_sources(zone)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--zone=#{zone}", "--list-sources").split(" ")
         end
 
         # @param zone [String] The firewall zone
         # @return [Array<String>] list of all information for given zone
         def list_all(zone)
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--zone=#{zone}", "--list-all").split(" ")
         end
 
         # @return [Array<String>] list of all information for all firewall zones
         def list_all_zones
+          return [] unless Y2Firewall::Firewalld.instance.installed?
           string_command("--list-all-zones").split("\n")
         end
 
@@ -81,6 +89,7 @@ module Y2Firewall
         # @param interface [String] interface name
         # @return [String, nil] the interface zone or nil
         def interface_zone(interface)
+          return nil unless Y2Firewall::Firewalld.instance.installed?
           string_command("--get-zone-of-interface=#{interface}")
         end
 
@@ -88,6 +97,7 @@ module Y2Firewall
         # @param interface [String] The network interface
         # @return [Boolean] True if interface is assigned to zone
         def interface_enabled?(zone, interface)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           query_command("--zone=#{zone} --query-interface=#{interface}")
         end
 
@@ -96,6 +106,7 @@ module Y2Firewall
         # @param permanent [Boolean] if true it adds the --permanent option the
         # @return [Boolean] True if interface was added to zone
         def add_interface(zone, interface, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--add-interface=#{interface}", permanent: permanent)
         end
 
@@ -105,6 +116,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if interface was removed from zone
         def remove_interface(zone, interface, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--remove-interface=#{interface}", permanent: permanent)
         end
 
@@ -114,6 +126,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if interface was changed
         def change_interface(zone, interface, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--change-interface=#{interface}", permanent: permanent)
         end
 
@@ -123,6 +136,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if source was added
         def add_source(zone, source, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--add-source=#{source}", permanent: permanent)
         end
 
@@ -132,6 +146,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if source was removed
         def remove_source(zone, source, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--remove-source=#{source}", permanent: permanent)
         end
 
@@ -141,6 +156,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if source was changed
         def change_source(zone, source, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--change-source=#{source}", permanent: permanent)
         end
 
@@ -148,6 +164,7 @@ module Y2Firewall
         # @param service [String] The firewall service
         # @return [Boolean] True if service is enabled in zone
         def service_enabled?(zone, service)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           query_command("--zone=#{zone}", "--query-service=#{service}")
         end
 
@@ -155,6 +172,7 @@ module Y2Firewall
         # @param port [String] The firewall port
         # @return [Boolean] True if port is enabled in zone
         def port_enabled?(zone, port)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           query_command("--zone=#{zone}", "--query-port=#{port}")
         end
 
@@ -162,6 +180,7 @@ module Y2Firewall
         # @param protocol [String] The zone protocol
         # @return [Boolean] True if protocol is enabled in zone
         def protocol_enabled?(zone, protocol)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           query_command("--zone=#{zone}", "--query-protocol=#{protocol}")
         end
 
@@ -171,6 +190,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if service was added to zone
         def add_service(zone, service, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--add-service=#{service}", permanent: permanent)
         end
 
@@ -180,6 +200,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if port was added to zone
         def add_port(zone, port, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--add-port=#{port}", permanent: permanent)
         end
 
@@ -189,6 +210,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if protocol was added to zone
         def add_protocol(zone, protocol, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--add-protocol=#{protocol}", permanent: permanent)
         end
 
@@ -198,6 +220,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if service was removed from zone
         def remove_service(zone, service, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           if offline?
             run_command("--zone=#{zone}", "--remove-service-from-zone=#{service}")
           else
@@ -211,6 +234,7 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if port was removed from zone
         def remove_port(zone, port, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--remove-port=#{port}", permanent: permanent)
         end
 
@@ -220,18 +244,21 @@ module Y2Firewall
         # command to be executed
         # @return [Boolean] True if protocol was removed from zone
         def remove_protocol(zone, protocol, permanent: permanent?)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           run_command("--zone=#{zone}", "--remove-protocol=#{protocol}", permanent: permanent)
         end
 
         # @param zone [String] The firewall zone
         # @return [Boolean] True if masquerade is enabled in zone
         def masquerade_enabled?(zone)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           query_command("--zone=#{zone}", "--query-masquerade")
         end
 
         # @param zone [String] The firewall zone
         # @return [Boolean] True if masquerade was enabled in zone
         def add_masquerade(zone)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           return true if masquerade_enabled?(zone)
 
           run_command("--zone=#{zone}", "--add-masquerade")
@@ -240,6 +267,7 @@ module Y2Firewall
         # @param zone [String] The firewall zone
         # @return [Boolean] True if masquerade was removed in zone
         def remove_masquerade(zone)
+          return false unless Y2Firewall::Firewalld.instance.installed?
           return true if !masquerade_enabled?(zone)
 
           run_command("--zone=#{zone}", "--remove-masquerade")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 25 13:38:38 CET 2018 - schubi@suse.de
+
+- Firewalld: Checking if firewalld is available bofore calling
+  it.
+  (fate#323460)
+- 4.0.39
+
+-------------------------------------------------------------------
 Wed Jan 24 13:23:14 UTC 2018 - jreidinger@suse.com
 
 - CWM: Add possibility to define abort handler for CWM.show

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.38
+Version:        4.0.39
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
The problem is that many modules are using CWMFirewallInterfaces. This will be often already done
by including it by starting the different module. At that point it could be that the package has not been installed at all.

e.g.: 

 https://github.com/yast/yast-ftp-server/blob/master/src/clients/ftp-server_auto.rb#L30

Please review the following changes:
  * 2d3b25c9 checking if the package is available
