### PR TITLE
Firewalld API: reload & complete_reload return true in offline mode

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -130,16 +130,21 @@ module Y2Firewall
         run_command("--set-default-zone=#{zone}")
       end
 
+      # Do a reload of the firewall if running. In offline mode just return
+      # true as a reload is not needed to apply the changes.
+      #
       # @return [Boolean] The firewalld reload result (exit code)
       def reload
-        return false if offline?
+        return true if offline?
         run_command("--reload")
       end
 
+      # Do a complete reload of the firewall if running. In offline mode just
+      # return true as a reload is not needed to apply the changes
+      #
       # @return [Boolean] The firewalld complete-reload result (exit code)
       def complete_reload
-        return false if offline?
-
+        return true if offline?
         run_command("--complete-reload")
       end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 29 17:11:19 UTC 2018 - knut.anderssen@suse.com
+
+- Firewalld API: reload and complete reload return true in offline
+  mode (fate#323460)
+- 4.0.42
+
+-------------------------------------------------------------------
 Mon Jan 29 14:11:59 UTC 2018 - knut.anderssen@suse.com
 
 - Fixed logging typo (fate#1076513)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.41
+Version:        4.0.42
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- [Trello Card](https://trello.com/c/99OkErr6/1093-8-firewall-firewalld-is-the-new-susefirewall-cwm)

If the firewall is not running it does not need to be reloaded at all so makes more sense to return true instead of false.