### PR TITLE
Auto client packages modified defaults (bsc#1077987)

### DIFF
--- a/library/general/src/lib/installation/auto_client.rb
+++ b/library/general/src/lib/installation/auto_client.rb
@@ -129,14 +129,21 @@ module Installation
       raise NotImplementedError, "Calling abstract method 'write'"
     end
 
-    # Get a list of packages needed for configuration.
+    # Return a hash with packages that need to be installed or removed for
+    # configuration.
     #
-    # The default implementation returns an empty list.
-    # @return [Array<String>] list of required packages
+    # @example
+    #
+    #   def packages
+    #     { "install" => ["package1"], "remove" => ["package2"] }
+    #   end
+    #
+    # The default implementation returns an empty hash.
+    # @return [Hash] of packages to be installed and removed
     def packages
-      log.info "#{self.class}#packages not implemented, returning []."
+      log.info "#{self.class}#packages not implemented, returning {}."
 
-      []
+      {}
     end
 
     # Read settings from the target system.

--- a/library/general/test/auto_client_test.rb
+++ b/library/general/test/auto_client_test.rb
@@ -168,8 +168,8 @@ describe ::Installation::AutoClient do
         expect { ::Installation::AutoClient.run }.to_not raise_error
       end
 
-      it "returns empty array if optional abstract method not defined" do
-        expect(::Installation::AutoClient.run).to eq []
+      it "returns an empty hash if the optional abstract method is not defined" do
+        expect(::Installation::AutoClient.run).to eq({})
       end
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 30 11:06:59 UTC 2018 - knut.anderssen@suse.com
+
+- Installation::AutoClient: modified packages default and improved
+  documentation (fate#323460 bsc#1077987)
+- 4.0.44
+
+-------------------------------------------------------------------
 Tue Jan 30 06:45:17 UTC 2018 - ancor@suse.com
 
 - Fixed a bug causing pages of all CWM::TreePager to be rendered

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.43
+Version:        4.0.44
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- The packages default was an [] but it is expected to be redefined as a hash with "install" and/or remove "remove" creating some confusion specially when you are not used to AutoClients

- This PR tries to clarify it a little.