### PR TITLE
Y2packager integration

### DIFF
--- a/library/packages/src/Makefile.am
+++ b/library/packages/src/Makefile.am
@@ -31,6 +31,12 @@ ylib_DATA = \
   lib/packages/update_message.rb \
   lib/packages/update_messages_view.rb
 
-EXTRA_DIST = $(module_DATA) $(ynclude_DATA) $(ylib_DATA)
+y2packagerdir = "${yast2dir}/lib/y2packager"
+y2packager_DATA = \
+	lib/y2packager/product.rb \
+	lib/y2packager/product_reader.rb \
+	lib/y2packager/product_sorter.rb
+
+EXTRA_DIST = $(module_DATA) $(ynclude_DATA) $(ylib_DATA) $(y2packager_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -1,0 +1,241 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+Yast.import "Pkg"
+Yast.import "Language"
+require "y2packager/product_reader"
+require "y2packager/release_notes_reader"
+
+module Y2Packager
+  # Represent a product which is present in a repository. At this
+  # time this class is responsible for finding out whether two
+  # products instances are the same (for example, coming from different
+  # repositories).
+  class Product
+    include Yast::Logger
+
+    # @return [String] Name
+    attr_reader :name
+    # @return [String] Short name
+    attr_reader :short_name
+    # @return [String] Display name
+    attr_reader :display_name
+    # @return [String] Version
+    attr_reader :version
+    # @return [String] Architecture
+    attr_reader :arch
+    # @return [Symbol] Category
+    attr_reader :category
+    # @return [String] Vendor
+    attr_reader :vendor
+    # @return [Integer] Display order
+    attr_reader :order
+    # @return [String] package including installation.xml for install on top of lean os
+    attr_reader :installation_package
+
+    class << self
+      # Return all known products
+      #
+      # @return [Array<Product>] Known products
+      def all
+        Y2Packager::ProductReader.new.all_products
+      end
+
+      # Return available base products
+      #
+      # @return [Array<Product>] Available base products
+      def available_base_products
+        Y2Packager::ProductReader.new.available_base_products
+      end
+
+      # Returns the selected base product
+      #
+      # It assumes that at most 1 base product can be selected.
+      #
+      # @return [Product] Selected base product
+      def selected_base
+        available_base_products.find(&:selected?)
+      end
+
+      # Return the products with a given status
+      #
+      # @param statuses [Array<Symbol>] Product status (:available, :installed, :selected, etc.)
+      # @return [Array<Product>] Products with the given status
+      def with_status(*statuses)
+        all.select { |p| p.status?(*statuses) }
+      end
+    end
+
+    # Constructor
+    #
+    # @param name                 [String]  Name
+    # @param short_name           [String]  Short name
+    # @param display_name         [String]  Display name
+    # @param version              [String]  Version
+    # @param arch                 [String]  Architecture
+    # @param category             [Symbol]  Category (:base, :addon)
+    # @param vendor               [String]  Vendor
+    # @param order                [Integer] Display order
+    # @param installation_package [String]  Installation package name
+    def initialize(name: nil, short_name: nil, display_name: nil, version: nil, arch: nil,
+      category: nil, vendor: nil, order: nil, installation_package: nil)
+      @name = name
+      @short_name = short_name
+      @display_name = display_name
+      @version = version
+      @arch = arch.to_sym if arch
+      @category = category.to_sym if category
+      @vendor = vendor
+      @order = order
+      @installation_package = installation_package
+    end
+
+    # Compare two different products
+    #
+    # If arch, name, version and vendor match they are considered the
+    # same product.
+    #
+    # @return [Boolean] true if both products are the same; false otherwise
+    def ==(other)
+      result = arch == other.arch && name == other.name &&
+        version == other.version && vendor == other.vendor
+      log.info("Comparing products: '#{arch}' <=> '#{other.arch}', '#{name}' <=> '#{other.name}', "\
+        "'#{version}' <=> '#{other.version}', '#{vendor}' <=> '#{other.vendor}' => "\
+        "result: #{result}")
+      result
+    end
+
+    # is the product selected to install?
+    #
+    # Only the 'name' will be used to find out whether the product is selected,
+    # ignoring the architecture, version, vendor or any other property. libzypp
+    # will take care of finding the proper product.
+    #
+    # @return [Boolean] true if it is selected
+    def selected?
+      status?(:selected)
+    end
+
+    # is the product selected to install?
+    #
+    # Only the 'name' will be used to find out whether the product is installed,
+    # ignoring the architecture, version, vendor or any other property. libzypp
+    # will take care of finding the proper product.
+    #
+    # @see #status?
+    # @return [Boolean] true if it is installed
+    def installed?
+      status?(:installed)
+    end
+
+    # select the product to install
+    #
+    # Only the 'name' will be used to select the product, ignoring the
+    # architecture, version, vendor or any other property. libzypp will take
+    # care of selecting the proper product.
+    #
+    # @return [Boolean] true if the product has been sucessfully selected
+    def select
+      log.info "Selecting product #{name} to install"
+      Yast::Pkg.ResolvableInstall(name, :product, "")
+    end
+
+    # Restore the status of a product
+    #
+    # Only the 'name' will be used to restore the product status, ignoring the
+    # architecture, version, vendor or any other property. libzypp will take
+    # care of modifying the proper product.
+    #
+    def restore
+      log.info "Restoring product #{name} status"
+      Yast::Pkg.ResolvableNeutral(name, :product, true)
+    end
+
+    # Return a package label
+    #
+    # It will use 'display_name', 'short_name' or 'name'.
+    #
+    # @return [String] Package label
+    def label
+      display_name || short_name || name
+    end
+
+    # Return the license to confirm
+    #
+    # It will return the empty string ("") if the license does not exist or if
+    # it was already confirmed.
+    #
+    # @return [String,nil] Product's license; nil if the product was not found.
+    def license(lang = nil)
+      license_lang = lang || Yast::Language.language
+      Yast::Pkg.PrdGetLicenseToConfirm(name, license_lang)
+    end
+
+    # Determines whether the product has a license
+    #
+    # @return [Boolean] true if the product has a license
+    def license?
+      return false unless license
+      license != ""
+    end
+
+    # Determine whether the license should be accepted or not
+    #
+    # @return [Boolean] true if the license acceptance is required
+    def license_confirmation_required?
+      Yast::Pkg.PrdNeedToAcceptLicense(name)
+    end
+
+    # Set license confirmation for the product
+    #
+    # @param confirmed [Boolean] determines whether the license should be accepted or not
+    def license_confirmation=(confirmed)
+      if confirmed
+        Yast::Pkg.PrdMarkLicenseConfirmed(name)
+      else
+        Yast::Pkg.PrdMarkLicenseNotConfirmed(name)
+      end
+    end
+
+    # Determine whether the license is confirmed
+    #
+    # @return [Boolean] true if the license was confirmed (or acceptance was not needed)
+    def license_confirmed?
+      Yast::Pkg.PrdHasLicenseConfirmed(name)
+    end
+
+    # Return product's release notes
+    #
+    # @param format    [Symbol] Release notes format (use :txt as default)
+    # @param user_lang [String] Preferred language (use current language as default)
+    # @return [ReleaseNotes] Release notes for product, language and format
+    # @see ReleaseNotesReader
+    # @see ReleaseNotes
+    def release_notes(format = :txt, user_lang = Yast::Language.language)
+      ReleaseNotesReader.new(self).release_notes(user_lang: user_lang, format: format)
+    end
+
+    # Determine whether a product is in a given status
+    #
+    # Only the 'name' will be used to find out whether the product status,
+    # ignoring the architecture, version, vendor or any other property. libzypp
+    # will take care of finding the proper product.
+    #
+    # @param statuses [Array<Symbol>] Status to compare with.
+    # @return [Boolean] true if it is in the given status
+    def status?(*statuses)
+      Yast::Pkg.ResolvableProperties(name, :product, "").any? do |res|
+        statuses.include?(res["status"])
+      end
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -1,0 +1,127 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2packager/product"
+require "y2packager/product_sorter"
+
+Yast.import "Pkg"
+
+module Y2Packager
+  # Read the product information from libzypp
+  class ProductReader
+    include Yast::Logger
+
+    class << self
+      # Installation packages map
+      #
+      # This map contains the correspondence between products and the
+      # installation package for each product.
+      #
+      # The information is read only once and cached for further queries.
+      #
+      # @return [Hash<String,String>] product name -> installation package name
+      def installation_package_mapping
+        return @installation_package_mapping if @installation_package_mapping
+        installation_packages = Yast::Pkg.PkgQueryProvides("system-installation()")
+        log.info "Installation packages: #{installation_packages.inspect}"
+
+        @installation_package_mapping = {}
+        installation_packages.each do |list|
+          pkg_name = list.first
+          # There can be more instances of same package in different version. We except that one
+          # package provide same product installation. So we just pick the first one.
+          dependencies = Yast::Pkg.ResolvableDependencies(pkg_name, :package, "").first["deps"]
+          install_provide = dependencies.find do |d|
+            d["provides"] && d["provides"].match(/system-installation\(\)/)
+          end
+
+          # parse product name from provides. Format of provide is
+          # `system-installation() = <product_name>`
+          product_name = install_provide["provides"][/system-installation\(\)\s*=\s*(\S+)/, 1]
+          log.info "package #{pkg_name} install product #{product_name}"
+          @installation_package_mapping[product_name] = pkg_name
+        end
+
+        @installation_package_mapping
+      end
+    end
+
+    # Available products
+    #
+    # @return [Array<Product>] Available products
+    def all_products
+      @all_products ||= available_products.map do |prod|
+        prod_pkg = product_package(prod["product_package"], prod["source"])
+
+        if prod_pkg
+          prod_pkg["deps"].find { |dep| dep["provides"] =~ /\Adisplayorder\(\s*([0-9]+)\s*\)\z/ }
+          displayorder = Regexp.last_match[1].to_i if Regexp.last_match
+        end
+
+        Y2Packager::Product.new(
+          name: prod["name"], short_name: prod["short_name"], display_name: prod["display_name"],
+          version: prod["version"], arch: prod["arch"], category: prod["category"],
+          vendor: prod["vendor"], order: displayorder,
+          installation_package: installation_package_mapping[prod["name"]]
+        )
+      end
+    end
+
+    # In installation Read the available libzypp base products for installation
+    # @return [Array<Y2Packager::Product>] the found available base products,
+    #   the products are sorted by the 'displayorder' provides value
+    def available_base_products
+      # If no product contains a 'system-installation()' tag but there is only 1 product,
+      # we assume that it is the base one.
+      if all_products.size == 1 && installation_package_mapping.empty?
+        log.info "Assuming that #{all_products.inspect} is the base product."
+        return all_products
+      end
+
+      # only installable products
+      products = all_products.select(&:installation_package).sort(&::Y2Packager::PRODUCT_SORTER)
+      log.info "available base products #{products}"
+      products
+    end
+
+    def product_package(name, repo_id)
+      return nil unless name
+      Yast::Pkg.ResolvableDependencies(name, :package, "").find do |prod|
+        prod["source"] == repo_id
+      end
+    end
+
+  private
+
+    # read the available products, remove potential duplicates
+    # @return [Array<Hash>] pkg-bindings data structure
+    def available_products
+      products = Yast::Pkg.ResolvableProperties("", :product, "")
+
+      # remove e.g. installed products
+      products.select! { |p| p["status"] == :available || p["status"] == :selected }
+
+      # remove duplicates, there migth be different flavors ("DVD"/"POOL")
+      # or archs (x86_64/i586), when selecting the product to install later
+      # libzypp will select the correct arch automatically
+      products.uniq! { |p| "#{p["name"]}__#{p["version"]}" }
+      log.info "Found products: #{products.map { |p| p["name"] }}"
+
+      products
+    end
+
+    def installation_package_mapping
+      self.class.installation_package_mapping
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/product_sorter.rb
+++ b/library/packages/src/lib/y2packager/product_sorter.rb
@@ -1,0 +1,30 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+module Y2Packager
+  # Sorter for sorting Products in required display order
+  # @param x [Y2Packager::Product] the first item to compare
+  # @param y [Y2Packager::Product] the second item to compare
+  PRODUCT_SORTER = proc do |x, y|
+    # both products have defined order
+    if x.order && y.order
+      x.order <=> y.order
+    # only one product has defined order
+    elsif x.order || y.order
+      # product with defined order first
+      x.order ? -1 : 1
+    else
+      # none product has defined order, sort by label
+      x.label <=> y.label
+    end
+  end
+end

--- a/library/packages/src/modules/Product.rb
+++ b/library/packages/src/modules/Product.rb
@@ -29,6 +29,7 @@
 #
 # $Id$
 require "yast"
+require "y2packager/product_reader"
 
 module Yast
   class ProductClass < Module
@@ -102,16 +103,8 @@ module Yast
       required_status = use_installed_products? ? :installed : :selected
       fill_up_relnotes(products.select { |p| p["status"] == required_status })
 
-      # FIXME: move the code from yast2-packager here, we cannot depend on
-      # yast2-packager as it would result in a circular dependency
-      begin
-        require "y2packager/product_reader"
-        # list of products defined by the "system-installation()" provides
-        system_products = Y2Packager::ProductReader.installation_package_mapping.keys
-      rescue LoadError
-        log.warn "yast2-packager is missing, cannot read system-installation products"
-      end
-
+      # list of products defined by the "system-installation()" provides
+      system_products = Y2Packager::ProductReader.installation_package_mapping.keys
       selected = Pkg.IsAnyResolvable(:product, :to_install)
 
       # Use only base products

--- a/library/packages/test/Makefile.am
+++ b/library/packages/test/Makefile.am
@@ -3,10 +3,12 @@ TESTS = \
   dummy_callbacks_test.rb \
   file_conflict_callbacks_test.rb \
   package_callbacks_test.rb \
-  lib/package_downloader_test.rb \
-  lib/package_extractor_test.rb \
 	lib/product_test.rb \
 	lib/repository_test.rb \
+  lib/package_downloader_test.rb \
+  lib/package_extractor_test.rb \
+  lib/product_reader_test.rb \
+  lib/product_sorter_test.rb \
   packages_ui_test.rb \
   product_test.rb \
   signature_check_callbacks_test.rb \

--- a/library/packages/test/data/products-sles15.yml
+++ b/library/packages/test/data/products-sles15.yml
@@ -1,0 +1,42 @@
+---
+- arch: x86_64
+  category: addon
+  description: |-
+    SUSE Linux Enterprise offers a comprehensive
+            suite of products built on a single code base.
+            The platform addresses business needs from
+            the smallest thin-client devices to the world's
+            most powerful high-performance computing
+            and mainframe servers. SUSE Linux Enterprise
+            offers common management tools and technology
+            certifications across the platform, and
+            each product is enterprise-class.
+  display_name: SUSE Linux Enterprise Server 15 Alpha1
+  download_size: 0
+  flags: []
+  flavor: ''
+  inst_size: 0
+  locked: false
+  medium_nr: 0
+  name: SLES
+  on_system_by_user: false
+  product_file: SLES.prod
+  product_line: ''
+  product_package: sles-release
+  register_release: ''
+  register_target: sle-15-x86_64
+  relnotes_url: https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/release-notes-sles.rpm
+  relnotes_urls:
+  - https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/release-notes-sles.rpm
+  short_name: SLES15
+  source: 0
+  status: :selected
+  summary: SUSE Linux Enterprise Server 15 Alpha1
+  transact_by: :app_high
+  type: addon
+  update_urls: []
+  vendor: SUSE LINUX Products GmbH, Nuernberg, Germany
+  version: 15-0
+  version_epoch: 
+  version_release: '0'
+  version_version: '15'

--- a/library/packages/test/lib/product_reader_test.rb
+++ b/library/packages/test/lib/product_reader_test.rb
@@ -1,0 +1,102 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yaml"
+require_relative "../test_helper"
+
+require "y2packager/product_reader"
+
+describe Y2Packager::ProductReader do
+  subject { Y2Packager::ProductReader.new }
+  let(:products) { YAML.load(File.read(FIXTURES_PATH.join("products-sles15.yml"))) }
+  let(:installation_package_map) { { "SLES" => "skelcd-SLES" } }
+
+  describe "#available_base_products" do
+    before do
+      # TODO: proper mocking of pkg methods
+      allow(subject).to receive(:installation_package_mapping).and_return(installation_package_map)
+    end
+
+    it "returns empty list if there is no product" do
+      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        .and_return([])
+      expect(subject.available_base_products).to eq([])
+    end
+
+    it "returns Installation::Product objects" do
+      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        .and_return(products)
+      expect(subject.available_base_products.first).to be_a(Y2Packager::Product)
+    end
+
+    it "returns the correct product properties" do
+      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        .and_return(products)
+      ret = subject.available_base_products.first
+      expect(ret.name).to eq("SLES")
+      expect(ret.label).to eq("SUSE Linux Enterprise Server 15 Alpha1")
+    end
+
+    it "returns only the products from the initial repository" do
+      sp3 = products.first
+      addon1 = sp3.dup
+      addon1["source"] = 1
+      addon2 = sp3.dup
+      addon2["source"] = 2
+
+      expect(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        .and_return([addon2, addon1, sp3])
+
+      expect(subject.available_base_products.size).to eq(1)
+    end
+
+    context "when no product with system-installation() tag exists" do
+      let(:installation_package_map) { {} }
+      let(:prod1) { { "name" => "SLES", "status" => :available } }
+      let(:prod2) { { "name" => "SLED", "status" => :available } }
+
+      before do
+        allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+          .and_return(products)
+      end
+
+      context "and only 1 product exists" do
+        let(:products) { [prod1] }
+
+        it "returns the found product" do
+          expect(subject.available_base_products.size).to eq(1)
+        end
+      end
+
+      context "and more than 1 product exsits" do
+        let(:products) { [prod1, prod2] }
+
+        it "returns an empty array" do
+          expect(subject.available_base_products).to be_empty
+        end
+      end
+    end
+  end
+
+  describe "#products" do
+    before do
+      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        .and_return(products)
+      allow(Yast::Pkg).to receive(:PkgQueryProvides).with("system-installation()")
+        .and_return([])
+    end
+
+    it "returns available products" do
+      expect(subject.all_products.size).to eq(1)
+    end
+  end
+end

--- a/library/packages/test/lib/product_reader_test.rb
+++ b/library/packages/test/lib/product_reader_test.rb
@@ -15,9 +15,11 @@ require_relative "../test_helper"
 
 require "y2packager/product_reader"
 
+FIXTURES_PATH = File.join(File.dirname(__FILE__), "../data")
+
 describe Y2Packager::ProductReader do
   subject { Y2Packager::ProductReader.new }
-  let(:products) { YAML.load(File.read(FIXTURES_PATH.join("products-sles15.yml"))) }
+  let(:products) { YAML.load(File.read(File.join(FIXTURES_PATH, "products-sles15.yml"))) }
   let(:installation_package_map) { { "SLES" => "skelcd-SLES" } }
 
   describe "#available_base_products" do

--- a/library/packages/test/lib/product_sorter_test.rb
+++ b/library/packages/test/lib/product_sorter_test.rb
@@ -1,0 +1,60 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../test_helper"
+
+require "y2packager/product"
+require "y2packager/product_sorter"
+
+describe Y2Packager::PRODUCT_SORTER do
+
+  # testing products with defined ordering
+  let(:p1) do
+    Y2Packager::Product.new(name: "p10", display_name: "Product with order 10", order: 10)
+  end
+
+  let(:p2) do
+    Y2Packager::Product.new(name: "p20", display_name: "Product with order 20", order: 20)
+  end
+
+  let(:p3) do
+    Y2Packager::Product.new(name: "p30", display_name: "Product with order 30", order: 30)
+  end
+
+  # testing products with undefined (nil) ordering
+  let(:pnil1) { Y2Packager::Product.new(name: "p1", display_name: "Product 1 without order") }
+  let(:pnil2) { Y2Packager::Product.new(name: "p2", display_name: "Product 2 without order") }
+
+  it "keeps an already sorted list unchanged" do
+    products = [p1, p2, p3]
+    products.sort!(&::Y2Packager::PRODUCT_SORTER)
+    expect(products).to eq([p1, p2, p3])
+  end
+
+  it "sorts the products by the ordering number" do
+    products = [p3, p2, p1]
+    products.sort!(&::Y2Packager::PRODUCT_SORTER)
+    expect(products).to eq([p1, p2, p3])
+  end
+
+  it "sorts by label if ordering is missing" do
+    products = [pnil2, pnil1]
+    products.sort!(&::Y2Packager::PRODUCT_SORTER)
+    expect(products).to eq([pnil1, pnil2])
+  end
+
+  it "puts the products with undefined order at the end" do
+    products = [pnil2, p3, pnil1, p1]
+    products.sort!(&::Y2Packager::PRODUCT_SORTER)
+    expect(products).to eq([p1, p3, pnil1, pnil2])
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,7 +2,7 @@
 Thu Feb  1 08:09:28 UTC 2018 - lslezak@suse.cz
 
 - Move some Y2Packager classes from yast2-packager here to avoid
-  circular dependency (related to fate#1076513)
+  circular dependency (related to fate#323163)
 - 4.0.46
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 31 15:50:51 UTC 2018 - lslezak@suse.cz
+
+- Move some classes from yast2-packager to avoid circular dependency
+ (related to fate#1076513)
+- 4.0.46
+
+-------------------------------------------------------------------
 Wed Jan 31 13:54:12 UTC 2018 - knut.anderssen@suse.com
 
 - Firewalld API: Cache whether the configuration has been read

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,8 +1,8 @@
 -------------------------------------------------------------------
-Wed Jan 31 15:50:51 UTC 2018 - lslezak@suse.cz
+Thu Feb  1 08:09:28 UTC 2018 - lslezak@suse.cz
 
-- Move some classes from yast2-packager to avoid circular dependency
- (related to fate#1076513)
+- Move some Y2Packager classes from yast2-packager here to avoid
+  circular dependency (related to fate#1076513)
 - 4.0.46
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.45
+Version:        4.0.46
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0
@@ -93,7 +93,7 @@ Conflicts:      yast2-installation < 2.18.5
 # moved cfg_mail.scr
 Conflicts:      yast2-mail < 3.1.7
 # Older packager use removed API
-Conflicts:      yast2-packager < 3.1.34
+Conflicts:      yast2-packager < 4.0.33
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 # for Punycode.rb (bnc#651893) - the idnconv tool is located in
 # different packages (SLE12/Leap-42.1: bind-utils, TW/Factory: idnkit)


### PR DESCRIPTION
- Move some code from `yast2-packager` to `yast2` - it is required in `Product.rb` module
- It cannot depend on `yast2-packager` because it would create `yast2` <-> `yast2-packager` circular dependency
- Note: I'm keeping the `Y2Packager` namespace as the `Product` class is currently defined  in `Packages::Product` and `Y2Packager::Product`. These should be unified/merged later.