### PR TITLE
Turned Relation#relations into class method

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/relations.rb
+++ b/library/network/src/lib/y2firewall/firewalld/relations.rb
@@ -88,7 +88,7 @@ module  Y2Firewall
         scope = "#{scope}_" if scope
         enable_modifications_cache if cache
 
-        define_method "relations" do
+        define_singleton_method "relations" do
           relations
         end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  8 09:21:19 UTC 2018 - mfilka@suse.com
+
+- fate#323460
+  - slightly improved consistency of new Y2Firewall API
+- 4.0.50 
+
+-------------------------------------------------------------------
 Fri Feb  2 11:25:21 UTC 2018 - igonzalezsosa@suse.com
 
 - Y2Packager::Product does not depend on Yast::Language module

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.49
+Version:        4.0.50
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
bcs #has_many is used as class method (e.g.) in Zone it makes sense to have possibility to query defined relations at the same level

For an example see https://github.com/yast/yast-firewall/pull/48