### PR TITLE
Added firewall interfaces helpers

### DIFF
--- a/library/network/src/Makefile.am
+++ b/library/network/src/Makefile.am
@@ -52,6 +52,11 @@ yfwdapilib_DATA = \
   lib/y2firewall/firewalld/api/services.rb \
   lib/y2firewall/firewalld/api/zones.rb
 
-EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) $(yfwlib_DATA) $(yfwdlib_DATA) $(yfwdapilib_DATA)
+yfwhelperslibdir = @ylibdir@/y2firewall/helpers
+yfwhelperslib_DATA = \
+  lib/y2firewall/helpers/interfaces.rb
+
+EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) \
+						 $(yfwlib_DATA) $(yfwdlib_DATA) $(yfwdapilib_DATA) $(yfwhelperslib_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/library/network/src/Makefile.am
+++ b/library/network/src/Makefile.am
@@ -56,7 +56,8 @@ yfwhelperslibdir = @ylibdir@/y2firewall/helpers
 yfwhelperslib_DATA = \
   lib/y2firewall/helpers/interfaces.rb
 
-EXTRA_DIST = $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) \
-						 $(yfwlib_DATA) $(yfwdlib_DATA) $(yfwdapilib_DATA) $(yfwhelperslib_DATA)
+EXTRA_DIST = \
+  $(module_DATA) $(scrconf_DATA) $(agent_SCRIPTS) $(ylib_DATA) \
+  $(yfwlib_DATA) $(yfwdlib_DATA) $(yfwdapilib_DATA) $(yfwhelperslib_DATA)
 
 include $(top_srcdir)/Makefile.am.common

--- a/library/network/src/lib/y2firewall/helpers/interfaces.rb
+++ b/library/network/src/lib/y2firewall/helpers/interfaces.rb
@@ -1,0 +1,96 @@
+# encoding: utf-8
+#
+# ***************************************************************************
+#
+# Copyright (c) 2018 SUSE LLC.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 or 3 of the GNU General
+# Public License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+# ***************************************************************************
+require "yast"
+require "y2firewall/firewalld"
+
+module Y2Firewall
+  module Helpers
+    # Set of helpers methods for operating with NetworkInterfaces and firewalld
+    # zones.
+    module Interfaces
+      def self.included(_base)
+        Yast.import "NetworkInterfaces"
+      end
+
+      # Return an instance of Y2Firewall::Firewalld
+      #
+      # @return [Y2Firewall::Firewalld] a firewalld instance
+      def firewalld
+        Y2Firewall::Firewalld.instance
+      end
+
+      # Return the name of interfaces which belongs to the default zone
+      #
+      # @return [Array<String>] default zone interface names
+      def default_interfaces
+        known_interfaces.select { |i| i["zone"].to_s.empty? }.map { |i| i["id"] }
+      end
+
+      # Return the zone name for a given interface from the firewalld instance
+      # instead of from the API.
+      #
+      # @param name [String] interface name
+      # @return [String, nil] zone name whether belongs to some or nil if not
+      def interface_zone(name)
+        zone = firewalld.zones.find { |z| z.interfaces.include?(name) }
+
+        zone ? zone.name : nil
+      end
+
+      # Convenience method to return the default zone object
+      #
+      # @return [Y2Firewall::Firewalld::Zone] default zone
+      def default_zone
+        @default_zone ||= firewalld.find_zone(firewalld.default_zone)
+      end
+
+      # Return a hash of all the known interfaces with their "id", "name" and
+      # "zone".
+      #
+      # @example
+      #   CWMFirewallInterfaces.known_interfaces #=>
+      #     [
+      #       { "id" => "eth0", "name" => "Intel Ethernet Connection I217-LM", "zone" => "external"},
+      #       { "id" => "eth1", "name" => "Intel Ethernet Connection I217-LM", "zone" => "public"},
+      #       { "id" => "eth2", "name" => "Intel Ethernet Connection I217-LM", "zone" => nil},
+      #       { "id" => "eth3", "name" => "Intel Ethernet Connection I217-LM", "zone" => nil},
+      #     ]
+      #
+      # @return [Array<Hash<String,String>>] known interfaces "id", "name" and "zone"
+      def known_interfaces
+        return @known_interfaces if @known_interfaces
+
+        interfaces = Yast::NetworkInterfaces.List("").reject { |i| i == "lo" }
+
+        @known_interfaces = interfaces.map do |interface|
+          {
+            "id"   => interface,
+            "name" => Yast::NetworkInterfaces.GetValue(interface, "NAME"),
+            "zone" => interface_zone(interface)
+          }
+        end
+      end
+    end
+  end
+end

--- a/library/network/test/y2firewall/helpers/interfaces_test.rb
+++ b/library/network/test/y2firewall/helpers/interfaces_test.rb
@@ -9,28 +9,45 @@ end
 
 describe Y2Firewall::Helpers::Interfaces do
   subject { DummyClass.new }
+  let(:external) { Y2Firewall::Firewalld::Zone.new(name: "external") }
+  let(:dmz) { Y2Firewall::Firewalld::Zone.new(name: "dmz") }
+  let(:firewalld) { Y2Firewall::Firewalld.instance }
 
   before do
     allow(Yast::NetworkInterfaces).to receive("List").and_return(["eth0", "eth1"])
     allow(Yast::NetworkInterfaces).to receive("GetValue").with("eth0", "NAME").and_return("Intel I217-LM")
     allow(Yast::NetworkInterfaces).to receive("GetValue").with("eth1", "NAME").and_return("Intel I217-LM")
+    allow(subject).to receive(:firewalld).and_return(firewalld)
+    external.interfaces = ["eth0"]
+    dmz.interfaces = []
+    firewalld.zones = [dmz, external]
   end
 
   describe "#interface_zone" do
-    pending
     it "returns the zone name of the given interface" do
+      expect(subject.interface_zone("eth0")).to eql("external")
+    end
+
+    it "returns nil if the interface does not belong to any zone" do
+      expect(subject.interface_zone("eth1")).to eql(nil)
     end
   end
 
   describe "#known_interfaces" do
-    pending
     it "returns a hash with the 'id', 'name' and zone of the current interfaces" do
+      expect(subject.known_interfaces)
+        .to eql(
+          [
+            { "id" => "eth0", "name" => "Intel I217-LM", "zone" => "external" },
+            { "id" => "eth1", "name" => "Intel I217-LM", "zone" => nil }
+          ]
+        )
     end
   end
 
   describe "#default_interfaces" do
-    pending
-    it "returns all the interface names that does not belong to any zone" do
+    it "returns all the interface names that does not belong explicitly to any zone" do
+      expect(subject.default_interfaces).to eql(["eth1"])
     end
   end
 end

--- a/library/network/test/y2firewall/helpers/interfaces_test.rb
+++ b/library/network/test/y2firewall/helpers/interfaces_test.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env rspec
+
+require_relative "../../test_helper"
+require "y2firewall/helpers/interfaces"
+
+class DummyClass
+  include Y2Firewall::Helpers::Interfaces
+end
+
+describe Y2Firewall::Helpers::Interfaces do
+  subject { DummyClass.new }
+
+  before do
+    allow(Yast::NetworkInterfaces).to receive("List").and_return(["eth0", "eth1"])
+    allow(Yast::NetworkInterfaces).to receive("GetValue").with("eth0", "NAME").and_return("Intel I217-LM")
+    allow(Yast::NetworkInterfaces).to receive("GetValue").with("eth1", "NAME").and_return("Intel I217-LM")
+  end
+
+  describe "#interface_zone" do
+    pending
+    it "returns the zone name of the given interface" do
+    end
+  end
+
+  describe "#known_interfaces" do
+    pending
+    it "returns a hash with the 'id', 'name' and zone of the current interfaces" do
+    end
+  end
+
+  describe "#default_interfaces" do
+    pending
+    it "returns all the interface names that does not belong to any zone" do
+    end
+  end
+end

--- a/library/network/test/y2firewall/helpers/interfaces_test.rb
+++ b/library/network/test/y2firewall/helpers/interfaces_test.rb
@@ -21,6 +21,7 @@ describe Y2Firewall::Helpers::Interfaces do
     external.interfaces = ["eth0"]
     dmz.interfaces = []
     firewalld.zones = [dmz, external]
+    firewalld.default_zone = "external"
   end
 
   describe "#interface_zone" do
@@ -48,6 +49,12 @@ describe Y2Firewall::Helpers::Interfaces do
   describe "#default_interfaces" do
     it "returns all the interface names that does not belong explicitly to any zone" do
       expect(subject.default_interfaces).to eql(["eth1"])
+    end
+  end
+
+  describe "#default_zone" do
+    it "returns the Y2Firewall::Firewalld::Zone marked as default in firewalld " do
+      expect(subject.default_zone).to eql(external)
     end
   end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 12 09:23:34 UTC 2018 - knut.anderssen@suse.com
+
+- Firewalld: Added interfaces helpers (fate#323460)
+- 4.0.51
+
+-------------------------------------------------------------------
 Thu Feb  8 12:10:29 UTC 2018 - knut.anderssen@suse.com
 
 - Drop (x)inetd agents

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.50
+Version:        4.0.51
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- Some yast2-modules handle the ports opening directly instead of through the CWMFirewallInterfaces widget. This helpers are for them.

Needed by https://github.com/yast/yast-services-manager/pull/138