### PR TITLE
Update the URL schemes without host name (bsc#1077310)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yastdevel/ruby
+FROM yastdevel/ruby:sle12-sp3
 COPY . /usr/src/app
 # English messages, UTF-8, "C" locale for numeric formatting tests
 ENV LC_ALL= LANG=en_US.UTF-8 LC_NUMERIC=C

--- a/library/types/src/modules/URL.rb
+++ b/library/types/src/modules/URL.rb
@@ -655,9 +655,10 @@ module Yast
 
   private
 
-    # Schemes which should not include a host.
+    # Schemes which should not include a host.Should be kept in sync with libzypp.
+    # @see https://github.com/openSUSE/libzypp/blob/d9c97b883ac1561225c4d728a5f6c8a34498d5b9/zypp/Url.cc#L184-L190
     # @see #merge_host_and_path
-    SCHEMES_WO_HOST = ["cd", "dvd"].freeze
+    SCHEMES_WO_HOST = ["cd", "dvd", "hd", "iso", "dir"].freeze
 
     # Merges host and path tokens
     #

--- a/library/types/test/url_test.rb
+++ b/library/types/test/url_test.rb
@@ -288,7 +288,12 @@ describe Yast::URL do
       "http://user:password@[2001:de8:0:f123::1]:8080/path/to/dir"                               => "http://user:password@[2001:de8:0:f123::1]:8080/path/to/dir",
       "http://name:pass@www.suse.cz:80/path/index.html?question#part"                            => "http://name:pass@www.suse.cz:80/path/index.html?question#part",
       "smb://username:passwd@servername/share/path/on/the/share?mountoptions=ro&workgroup=group" => "smb://username:passwd@servername/share/path/on/the/share?mountoptions=ro&workgroup=group",
-      "slp:/"                                                                                    => "slp://"
+      "slp:/"                                                                                    => "slp://",
+      "dir:/"                                                                                    => "dir:///",
+      "iso:/"                                                                                    => "iso:///",
+      "hd:/"                                                                                     => "hd:///",
+      "cd:/"                                                                                     => "cd:///",
+      "dvd:/"                                                                                    => "dvd:///"
     }.freeze
 
     URLS.each do |url, rebuilt|

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 13 09:34:40 UTC 2018 - lslezak@suse.cz
+
+- Fixed list of the URL schemes without host, fixes processing
+  URLs with the "hd:/" scheme (bsc#1077310)
+- 3.1.219
+
+-------------------------------------------------------------------
 Fri Nov 24 17:55:50 UTC 2017 - mfilka@suse.com
 
 - bnc#956755, bnc#1061306

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.218
+Version:        3.1.219
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- See L3 bug https://bugzilla.suse.com/show_bug.cgi?id=1077310
- The problem has been tracked down to
 `URL.Build(URL.Parse("dvd:/"))` => `"dvd:///"` (OK)
 `URL.Build(URL.Parse("hd:/"))` => `"hd://"` (wrong, rejected by libzypp)
- The expected output is `URL.Build(URL.Parse("hd:/"))` => `"hd:///"`
- Use the [same URL schema list as in libzypp](https://github.com/openSUSE/libzypp/blob/d9c97b883ac1561225c4d728a5f6c8a34498d5b9/zypp/Url.cc#L184-L190), i.e. also added `iso` and `dir` schemes