### PR TITLE
Add product license locales

### DIFF
--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -221,7 +221,12 @@ module Y2Packager
     #
     # @return [Array<String>] Language codes ("de_DE", "en_US", etc.)
     def license_locales
-      locales = Yast::Pkg.PrdLicenseLocales(name) || []
+      locales = Yast::Pkg.PrdLicenseLocales(name)
+      if locales.nil?
+        log.error "Error getting the list of available license translations for '#{name}'"
+        return []
+      end
+
       empty_idx = locales.index("")
       locales[empty_idx] = DEFAULT_LICENSE_LANG if empty_idx
       locales

--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -214,6 +214,19 @@ module Y2Packager
       Yast::Pkg.PrdHasLicenseConfirmed(name)
     end
 
+    # [String] Default license language.
+    DEFAULT_LICENSE_LANG = "en_US".freeze
+
+    # Return available locales for product's license
+    #
+    # @return [Array<String>] Language codes ("de_DE", "en_US", etc.)
+    def license_locales
+      locales = Yast::Pkg.PrdLicenseLocales(name) || []
+      empty_idx = locales.index("")
+      locales[empty_idx] = DEFAULT_LICENSE_LANG if empty_idx
+      locales
+    end
+
     # Return product's release notes
     #
     # @param format    [Symbol] Release notes format (use :txt as default)

--- a/library/packages/test/y2packager/product_test.rb
+++ b/library/packages/test/y2packager/product_test.rb
@@ -269,6 +269,16 @@ describe Y2Packager::Product do
         expect(product.license_locales).to eq(["en_US"])
       end
     end
+
+    context "when the product is not found" do
+      before do
+        allow(Yast::Pkg).to receive(:PrdLicenseLocales).and_return(nil)
+      end
+
+      it "returns an empty array" do
+        expect(product.license_locales).to eq([])
+      end
+    end
   end
 
   describe "#license_confirmation_required?" do

--- a/library/packages/test/y2packager/product_test.rb
+++ b/library/packages/test/y2packager/product_test.rb
@@ -252,6 +252,25 @@ describe Y2Packager::Product do
     end
   end
 
+  describe "#license_locales" do
+    it "returns license locales from libzypp" do
+      expect(Yast::Pkg).to receive(:PrdLicenseLocales).with(product.name)
+        .and_return(["en_US", "de_DE"])
+      expect(product.license_locales).to eq(["en_US", "de_DE"])
+    end
+
+    context "when the empty locale is reported by libzypp" do
+      before do
+        allow(Yast::Pkg).to receive(:PrdLicenseLocales).with(product.name)
+          .and_return([""])
+      end
+
+      it "converts it to the default one (en_US)" do
+        expect(product.license_locales).to eq(["en_US"])
+      end
+    end
+  end
+
   describe "#license_confirmation_required?" do
     before do
       allow(Yast::Pkg).to receive(:PrdNeedToAcceptLicense).with(product.name).and_return(needed)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 14 12:48:54 UTC 2018 - igonzalezsosa@suse.com
+
+- Add a method to get the list of available license translations
+  for a given product (related to FATE#322276).
+- 4.0.52
+
+-------------------------------------------------------------------
 Mon Feb 12 09:23:34 UTC 2018 - knut.anderssen@suse.com
 
 - Firewalld: Added interfaces helpers (fate#323460)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.51
+Version:        4.0.52
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Extend `Y2Packager::Product` to get the list of available translations from libzypp.

PBI: https://trello.com/c/VjEpcE8x/