### PR TITLE
Added missing textdomain to zone class for translations (bsc#1082246)

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/zone.rb
+++ b/library/network/src/lib/y2firewall/firewalld/zone.rb
@@ -31,6 +31,8 @@ module Y2Firewall
       include Yast::I18n
       extend Yast::I18n
 
+      textdomain "base"
+
       # Map of known zone names and description
       KNOWN_ZONES = {
         "block"    => N_("Block Zone"),

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 23 10:50:59 UTC 2018 - knut.anderssen@suse.com
+
+- Added missing textdomain to firewalld zone class for translations
+  (bsc#1082246).
+- 4.0.54
+
+-------------------------------------------------------------------
 Thu Feb 15 17:34:40 UTC 2018 - lslezak@suse.cz
 
 - Fixed list of the URL schemes without host, fixes processing

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.53
+Version:        4.0.54
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1082246