### PR TITLE
Make possible to use Yast2::Popup from Report

### DIFF
--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -40,6 +40,8 @@ module Yast
   # @TODO not all methods respect all environment, feel free to open issue with
   #   method that doesn't respect it.
   class ReportClass < Module
+    include Yast::Logger
+
     def main
       textdomain "base"
 
@@ -436,6 +438,8 @@ module Yast
     #   - The argument :timeout will be ignored, the timeout fixed in the Report
     #   module will always be used instead (again, see {#DisplayYesNoMessages}).
     #   - The button ids must be :yes and :no, to honor the Report API.
+    #   - Due to the previous point, if no :buttons argument is provided, the
+    #   value :yes_no will be used for it.
     #
     # Like any other method used to present yesno_messages, false is always
     # returned if the system is configured to not display messages, no matter
@@ -449,9 +453,15 @@ module Yast
       # Use exactly the same y2milestone call than other yesno methods
       Builtins.y2milestone(1, "%1", message) if @log_yesno_messages
 
+      if extra_args.key?(:timeout)
+        log.warn "Report.yesno_popup will ignore the :timeout argument"
+      end
+
       ret =
         if @display_yesno_messages
-          answer = Yast2::Popup.show(message, extra_args.merge(timeout: @timeout_yesno_messages))
+          args = { buttons: :yes_no }.merge(extra_args)
+          args[:timeout] = @timeout_yesno_messages
+          answer = Yast2::Popup.show(message, args)
           answer == :yes
         else
           false

--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -31,6 +31,7 @@
 #
 #
 require "yast"
+require "yast2/popup"
 
 module Yast
   # Report module is universal reporting module. It properly display messages
@@ -419,6 +420,44 @@ module Yast
       end
 
       @yesno_messages = Builtins.add(@yesno_messages, message)
+      ret
+    end
+
+    # Question presented via the Yast2::Popup class
+    #
+    # It works like any other method used to present yesno_messages, but it
+    # delegates drawing the pop-up to {Yast2::Popup.show}, in case the message
+    # must be presented to the user (which can be configured via
+    # {#DisplayYesNoMessages}).
+    #
+    # All the arguments are forwarded to #{Yast2::Popup.show} almost as-is, but
+    # some aspects must be observed:
+    #
+    #   - The argument :timeout will be ignored, the timeout fixed in the Report
+    #   module will always be used instead (again, see {#DisplayYesNoMessages}).
+    #   - The button ids must be :yes and :no, to honor the Report API.
+    #
+    # Like any other method used to present yesno_messages, false is always
+    # returned if the system is configured to not display messages, no matter
+    # what was selected as the focused default answer.
+    #
+    # @param [String] message Popup message, forwarded to {Yast2::Popup.show}
+    # @param [Hash] extra_args Extra options to be forwarded to {Yast2::Popup.show},
+    #   see description for some considerations
+    # @return [Boolean] True if :yes is pressed, otherwise false
+    def yesno_popup(message, extra_args = {})
+      # Use exactly the same y2milestone call than other yesno methods
+      Builtins.y2milestone(1, "%1", message) if @log_yesno_messages
+
+      ret =
+        if @display_yesno_messages
+          answer = Yast2::Popup.show(message, extra_args.merge(timeout: @timeout_yesno_messages))
+          answer == :yes
+        else
+          false
+        end
+
+      @yesno_messages << message
       ret
     end
 

--- a/library/general/test/report_test.rb
+++ b/library/general/test/report_test.rb
@@ -13,9 +13,16 @@ describe Yast::Report do
   # Shared examples
   #
   shared_examples "logging" do |meth, level|
+    before do
+      if meth == :yesno_popup
+        allow(Yast2::Popup).to receive(:show)
+      else
+        allow(Yast::Popup).to receive(meth)
+      end
+    end
+
     context "when logging is enabled" do
       it "logs the message" do
-        allow(Yast::Popup).to receive(meth)
         expect(Yast::Builtins).to receive("y2#{level}")
           .with(1, "%1", "Message")
         subject.send(meth, "Message")
@@ -26,7 +33,6 @@ describe Yast::Report do
       let(:log) { false }
 
       it "does not log the message" do
-        allow(Yast::Popup).to receive(meth)
         expect(Yast::Builtins).to_not receive("y2#{level}")
         subject.send(meth, "Message")
       end
@@ -265,6 +271,54 @@ describe Yast::Report do
       it "shows a timed popup" do
         expect(Yast::Popup).to receive(:TimedError).with(/#{message}/, timeout)
         subject.Error(message)
+      end
+    end
+  end
+
+  describe ".yesno_popup" do
+    let(:show) { true }
+    let(:timeout) { 0 }
+    let(:log) { true }
+
+    before do
+      subject.DisplayYesNoMessages(show, timeout)
+      subject.LogYesNoMessages(log)
+    end
+
+    include_examples "logging", :yesno_popup, "milestone"
+
+    it "stores the message" do
+      allow(Yast2::Popup).to receive(:show)
+      subject.yesno_popup("Message")
+      expect(subject.GetMessages(0, 1, 0, 0)).to match(/Message/)
+    end
+
+    context "when display of messages is disabled" do
+      let(:show) { false }
+
+      it "does not show a popup" do
+        expect(Yast2::Popup).to_not receive(:show)
+        subject.yesno_popup("Message")
+      end
+
+      it "returns false" do
+        expect(subject.yesno_popup("Message")).to eq false
+      end
+    end
+
+    context "when display of messages is enabled" do
+      it "shows a popup" do
+        expect(Yast2::Popup).to receive(:show).with("Message", hash_including(timeout: 0))
+        subject.yesno_popup("Message")
+      end
+
+      context "when timeouts are enabled" do
+        let(:timeout) { 12 }
+
+        it "shows a timed popup" do
+          expect(Yast2::Popup).to receive(:show).with("Message", hash_including(timeout: 12))
+          subject.yesno_popup("Message")
+        end
       end
     end
   end

--- a/library/general/test/report_test.rb
+++ b/library/general/test/report_test.rb
@@ -307,17 +307,42 @@ describe Yast::Report do
     end
 
     context "when display of messages is enabled" do
-      it "shows a popup" do
+      it "shows a popup ignoring any :timeout argument" do
         expect(Yast2::Popup).to receive(:show).with("Message", hash_including(timeout: 0))
         subject.yesno_popup("Message")
+
+        expect(Yast2::Popup).to receive(:show).with("Message", hash_including(timeout: 0))
+        subject.yesno_popup("Message", timeout: 22)
+      end
+
+      it "uses :yes_no buttons for the popup by default" do
+        expect(Yast2::Popup).to receive(:show).with("Message", hash_including(buttons: :yes_no))
+        subject.yesno_popup("Message")
+
+        expect(Yast2::Popup).to receive(:show)
+          .with("Message", hash_including(buttons: { yes: "Sir" }))
+        subject.yesno_popup("Message", buttons: { yes: "Sir" })
+      end
+
+      it "returns true if :yes is pressed" do
+        allow(Yast2::Popup).to receive(:show).and_return :yes
+        expect(subject.yesno_popup("Message")).to eq true
+      end
+
+      it "returns false if another button is pressed" do
+        allow(Yast2::Popup).to receive(:show).and_return :no
+        expect(subject.yesno_popup("Message")).to eq false
       end
 
       context "when timeouts are enabled" do
         let(:timeout) { 12 }
 
-        it "shows a timed popup" do
+        it "shows a timed popup based on the Report timeout" do
           expect(Yast2::Popup).to receive(:show).with("Message", hash_including(timeout: 12))
           subject.yesno_popup("Message")
+
+          expect(Yast2::Popup).to receive(:show).with("Message", hash_including(timeout: 12))
+          subject.yesno_popup("Message", timeout: 22)
         end
       end
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 27 15:00:20 UTC 2018 - ancor@suse.com
+
+- Make possible to use the Yast2::Popup class from the Report
+  module (part of bsc#1082542).
+- 4.0.61
+
+-------------------------------------------------------------------
 Fri Mar 23 09:17:01 UTC 2018 - jreidinger@suse.com
 
 - fix behavior of showing timed error popup (found during

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.60
+Version:        4.0.61
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Part of https://trello.com/c/T5rxuHfg/300-2-sles15-p1-1082542-build4731storage-ng-delete-lvmlv-failed-when-reinstall-on-encrypted-lvm

See it in action in a yast-storage-ng callback:
![report_yesno](https://user-images.githubusercontent.com/3638289/37976344-97393f34-31e1-11e8-91ec-bc0bfc5b83fd.png)

The same popup using the timeout from `Report`
![report_yesno_timeout](https://user-images.githubusercontent.com/3638289/37980969-b5e55e12-31ec-11e8-9998-c1bf8d0ed239.png)

