### PR TITLE
Use SHA2 instead of MD5

### DIFF
--- a/library/packages/src/lib/y2packager/license.rb
+++ b/library/packages/src/lib/y2packager/license.rb
@@ -110,7 +110,7 @@ module Y2Packager
       return @id if @id
       content = content_for(DEFAULT_LANG)
       return unless content
-      @id = Digest::MD5.hexdigest(content)
+      @id = Digest::SHA1.hexdigest(content)
     end
 
     # Return the license translated content for the given language

--- a/library/packages/src/lib/y2packager/license.rb
+++ b/library/packages/src/lib/y2packager/license.rb
@@ -110,7 +110,7 @@ module Y2Packager
       return @id if @id
       content = content_for(DEFAULT_LANG)
       return unless content
-      @id = Digest::SHA1.hexdigest(content)
+      @id = Digest::SHA2.hexdigest(content)
     end
 
     # Return the license translated content for the given language

--- a/library/packages/test/y2packager/license_test.rb
+++ b/library/packages/test/y2packager/license_test.rb
@@ -72,7 +72,7 @@ describe Y2Packager::License do
     end
 
     it "returns the license unique identifier" do
-      expect(license.id).to eq("040f06fd774092478d450774f5ba30c5da78acc8")
+      expect(license.id).to eq("ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73")
     end
 
     context "when the license is not found" do

--- a/library/packages/test/y2packager/license_test.rb
+++ b/library/packages/test/y2packager/license_test.rb
@@ -72,7 +72,7 @@ describe Y2Packager::License do
     end
 
     it "returns the license unique identifier" do
-      expect(license.id).to eq("9a0364b9e99bb480dd25e1f0284c8555")
+      expect(license.id).to eq("040f06fd774092478d450774f5ba30c5da78acc8")
     end
 
     context "when the license is not found" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Apr  5 17:38:35 UTC 2018 - igonzalezsosa@suse.com
+
+- Use SHA1 instead of MD5 when determining whether a license
+  was already accepted or not (related to fate#325461).
+- 4.0.64
+
+-------------------------------------------------------------------
 Thu Apr  5 12:28:12 UTC 2018 - knut.anderssen@suse.com
 
 - Add a new API to handle product licenses.

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Apr  5 17:38:35 UTC 2018 - igonzalezsosa@suse.com
 
-- Use SHA1 instead of MD5 when determining whether a license
+- Use SHA2 instead of MD5 when determining whether a license
   was already accepted or not (related to fate#325461).
 - 4.0.64
 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.63
+Version:        4.0.64
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Replace MD5 with SHA1 when determining whether a license was accepted or not,
as requested in [fate#325461](https://fate.suse.com/325461).