### PR TITLE
Do not use the solver for finding the best product upgrade (bsc#1086734)

### DIFF
--- a/library/packages/src/lib/y2packager/product_upgrade.rb
+++ b/library/packages/src/lib/y2packager/product_upgrade.rb
@@ -21,7 +21,7 @@ module Y2Packager
     Yast.import "Pkg"
 
     # mapping with upgraded products to handle some corner cases,
-    # maps installed products to a new base product
+    # maps installed products to a new available base product
     MAPPING = {
       # SLES12 + HPC module => SLESHPC15
       # (a bit tricky, the module became a new base product!)
@@ -34,7 +34,10 @@ module Y2Packager
       ["SUSE_SLED"]              => "SLED",
       # SLES4SAP11 => SLES4SAP15
       ["SUSE_SLES_SAP"]          => "SLES_SAP",
-      # openSUSE => SLES
+      # (installed) openSUSE => (available) SLES,
+      # this one is used when openSUSE is not available, e.g. booting SLE medium
+      # (moreover the openSUSE medium should contain only one product so that
+      # product should be used unconditionally)
       ["openSUSE"]               => "SLES"
     }.freeze
 

--- a/library/packages/test/y2packager/product_upgrade_test.rb
+++ b/library/packages/test/y2packager/product_upgrade_test.rb
@@ -6,12 +6,6 @@ require "y2packager/product_upgrade"
 require "y2packager/product"
 
 describe Y2Packager::ProductUpgrade do
-  before do
-    allow(Yast::Pkg).to receive(:SaveState)
-    allow(Yast::Pkg).to receive(:RestoreState)
-    allow(Yast::Pkg).to receive(:CreateSolverTestCase)
-  end
-
   let(:product1) { Y2Packager::Product.new(name: "testing_product1") }
   let(:product2) { Y2Packager::Product.new(name: "testing_product2") }
   let(:product3) { Y2Packager::Product.new(name: "testing_product3") }
@@ -25,11 +19,6 @@ describe Y2Packager::ProductUpgrade do
       it "returns nil" do
         expect(described_class.new_base_product).to be_nil
       end
-
-      it "does not run the solver" do
-        expect(Yast::Pkg).to_not receive(:PkgUpdateAll)
-        described_class.new_base_product
-      end
     end
 
     context "only one base product is available" do
@@ -41,76 +30,44 @@ describe Y2Packager::ProductUpgrade do
       it "returns that product" do
         expect(described_class.new_base_product).to be(product1)
       end
-
-      it "does not run the solver" do
-        expect(Yast::Pkg).to_not receive(:PkgUpdateAll)
-        described_class.new_base_product
-      end
     end
 
     context "several base products are available" do
+      let(:sles) { Y2Packager::Product.new(name: "SLES") }
+      let(:sles_hpc) { Y2Packager::Product.new(name: "SLES_HPC") }
+      let(:hpc_module) { Y2Packager::Product.new(name: "sle-module-hpc") }
+      let(:sles11) { Y2Packager::Product.new(name: "SUSE_SLES") }
+
       before do
-        allow(Yast::Pkg).to receive(:PkgUpdateAll)
+        expect(Y2Packager::Product).to receive(:available_base_products)
+          .and_return([product1, product2, sles, sles_hpc]).at_least(:once)
       end
 
-      context "solver selects a product" do
-        before do
-          expect(Y2Packager::Product).to receive(:available_base_products)
-            .and_return([product1, product2, product3]).at_least(:once)
-          allow(Yast::Pkg).to receive(:ResolvableProperties)
-            .and_return(["name" => product1.name, "status" => :selected]).at_least(:once)
+      context "the new base product is found in the fallback mapping" do
+        it "returns SLES for SLES11" do
+          expect(Y2Packager::Product).to receive(:installed_products).and_return([sles11])
+          expect(described_class.new_base_product).to be(sles)
         end
 
-        it "runs the solver" do
-          expect(Yast::Pkg).to receive(:PkgUpdateAll)
-          described_class.new_base_product
-        end
-
-        it "returns the selected product" do
-          expect(Yast::Pkg).to receive(:ResolvableProperties)
-            .and_return(["name" => product1.name, "status" => :selected]).at_least(:once)
-          expect(described_class.new_base_product).to be(product1)
+        it "returns SLES_HPC for SLES and HPC module installed" do
+          expect(Y2Packager::Product).to receive(:installed_products)
+            .and_return([sles, hpc_module])
+          expect(described_class.new_base_product).to be(sles_hpc)
         end
       end
 
-      # the solver might fail because of some dependency issues
-      context "the solver does not select any base product to install" do
-        let(:sles) { Y2Packager::Product.new(name: "SLES") }
-        let(:sles_hpc) { Y2Packager::Product.new(name: "SLES_HPC") }
-        let(:hpc_module) { Y2Packager::Product.new(name: "sle-module-hpc") }
-        let(:sles11) { Y2Packager::Product.new(name: "SUSE_SLES") }
-
-        before do
-          expect(Y2Packager::Product).to receive(:available_base_products)
-            .and_return([product1, product2, sles, sles_hpc]).at_least(:once)
-        end
-
-        context "the new base product is found in the fallback mapping" do
-          it "returns SLES for SLES11" do
-            expect(Y2Packager::Product).to receive(:installed_products).and_return([sles11])
-            expect(described_class.new_base_product).to be(sles)
-          end
-
-          it "returns SLES_HPC for SLES and HPC module installed" do
-            expect(Y2Packager::Product).to receive(:installed_products)
-              .and_return([sles, hpc_module])
-            expect(described_class.new_base_product).to be(sles_hpc)
-          end
-        end
-
-        context "the base product if found by name" do
-          it "returns SLES for installed SLES" do
-            expect(Y2Packager::Product).to receive(:installed_base_product)
-              .and_return(sles)
-            expect(described_class.new_base_product).to be(sles)
-          end
-        end
-
-        it "returns nil if no upgrade product is found" do
+      context "the base product if found by name" do
+        it "returns SLES for installed SLES" do
           expect(Y2Packager::Product).to receive(:installed_base_product)
-            .and_return(product3)
-          expect(described_class.new_base_product).to be_nil
+            .and_return(sles)
+          expect(described_class.new_base_product).to be(sles)
         end
+      end
+
+      it "returns nil if no upgrade product is found" do
+        expect(Y2Packager::Product).to receive(:installed_base_product)
+          .and_return(product3)
+        expect(described_class.new_base_product).to be_nil
       end
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Apr 10 11:38:23 UTC 2018 - lslezak@suse.cz
+
+- Do not use the solver for finding the best product upgrade
+  candidate, it does not work correctly in the SLES + sle-module-hpc
+  => SLES_HPC case (bsc#1086734)
+- 4.0.67
+
+-------------------------------------------------------------------
 Tue Apr 10 07:25:08 UTC 2018 - jreidinger@suse.com
 
 - Fix early exit of installation when initial install url is

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.66
+Version:        4.0.67
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- Do not use the solver for finding the best product upgrade
- It does not work correctly in the SLES + sle-module-hpc => SLES_HPC case as the solver finds the new SLES and selects the SLES => SLES upgrade.
- Use the only product available or search from the hardcoded list
- This is a quick fix for SLE15-GA, for SLE15-SP1 we should find a better solution (avoid hardcoding)
- See https://bugzilla.suse.com/show_bug.cgi?id=1086734
- Tested manually in a SLES12-SP3 + sle-module-hpc upgrade to SLE15, see the screenshots below
- Additionally I have added also the openSUSE => SLES upgrade support (not tested)
- 4.0.67

## Screenshots

### Original Behavior

Originally the standard SLES product was selected for upgrade as you can see in the license agreement dialog:

![sles_hpc_upgrade_license_agreement_broken](https://user-images.githubusercontent.com/907998/38558437-6d644c18-3cd0-11e8-81fc-1596036fab04.png)

### After Applying the Fix

With the fix the SLES_HPC product is displayed:

![sles_hpc_upgrade_license_agreement](https://user-images.githubusercontent.com/907998/38558438-6d8d7142-3cd0-11e8-9136-6b01faa2bc0a.png)

And later the migration to SLES_HPC is offered:

![sles_hpc_upgrade_migration_selection](https://user-images.githubusercontent.com/907998/38558439-6da94188-3cd0-11e8-81b6-17219d5219f2.png)

(For some reason two same migrations are offered, but that's an unrelated issue and probably on  the SCC side, I'll check later...)
