### PR TITLE
save_y2logs: save kernel messages and udev log (bsc#1089647, bsc#1085212)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 16 14:48:27 CEST 2018 - snwint@suse.de
+
+- save_y2logs: save kernel messages and udev log (bsc#1089647,
+  bsc#1085212)
+- 4.0.70
+
+-------------------------------------------------------------------
 Thu Apr 12 13:38:26 UTC 2018 - igonzalezsosa@suse.com
 
 - Handle input/output errors in the DoneProvide package callback

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.69
+Version:        4.0.70
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0

--- a/scripts/save_y2logs
+++ b/scripts/save_y2logs
@@ -118,6 +118,7 @@ VAR_LOG_FILES='\
   zypper.log zypp/history* pk_backend_zypp \
   pbl.log linuxrc.log wickedd.log \
   evms-engine.* \
+  boot.msg messages udev.log \
 '
 cd /var/log
 for i in $VAR_LOG_FILES ; do


### PR DESCRIPTION
Kernel messages can show up in /var/log/boot.msg (linuxrc redirects there) and
/var/log/messages (syslog).

Since bsc#1085212 linuxrc can run udev in debug mode. In this case udev logs
into /var/log/udev.log.