### PR TITLE
Support multiple "system-installation()" provides (bsc#1092965)

### DIFF
--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -43,15 +43,18 @@ module Y2Packager
           # There can be more instances of same package in different version. We except that one
           # package provide same product installation. So we just pick the first one.
           dependencies = Yast::Pkg.ResolvableDependencies(pkg_name, :package, "").first["deps"]
-          install_provide = dependencies.find do |d|
+          install_provides = dependencies.find_all do |d|
             d["provides"] && d["provides"].match(/system-installation\(\)/)
           end
 
           # parse product name from provides. Format of provide is
           # `system-installation() = <product_name>`
-          product_name = install_provide["provides"][/system-installation\(\)\s*=\s*(\S+)/, 1]
-          log.info "package #{pkg_name} install product #{product_name}"
-          installation_package_mapping[product_name] = pkg_name
+          install_provides.each do |install_provide|
+            product_name = install_provide["provides"][/system-installation\(\)\s*=\s*(\S+)/, 1]
+            log.info "package #{pkg_name} install product #{product_name}"
+            installation_package_mapping[product_name] = pkg_name
+          end
+
         end
 
         installation_package_mapping

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 14 09:00:43 UTC 2018 - lslezak@suse.cz
+
+- Support multiple "system-installation()" provides in one
+  package (bsc#1092965)
+- 4.0.74
+
+-------------------------------------------------------------------
 Tue May  8 10:21:07 UTC 2018 - jlopez@suse.com
 
 - CWM: allow to define back handler for CWM#show.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2
-Version:        4.0.73
+Version:        4.0.74
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
- Evaluate *all* `system-installation()` provides, not only the first one
- This allows sharing one installation package between multiple products, eg. have a single `skelcd-foo` providing `system-installation() = foo1` and  `system-installation() = foo2` instead of the duplicated `skelcd-foo1` and `skelcd-foo2` just with different `system-installation()` values.
- Use case: `SLE-HPC` and `SLES_HPC` can share the `skelcd-control-SLES4HPC` package, see
https://bugzilla.suse.com/show_bug.cgi?id=1092965 for the details
- 4.0.74
- Tested manually by Egbert, see https://bugzilla.suse.com/show_bug.cgi?id=1092965#c2
