### PR TITLE
Pass absolute paths to "yard"

### DIFF
--- a/doc/autodocs/Makefile.am
+++ b/doc/autodocs/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_PM = $(wildcard $(srcdir)/../../library/general/src/modules/*.pm)
-AUTODOCS_RB = $(wildcard $(srcdir)/../../library/general/src/modules/*.rb)
+AUTODOCS_RB = $(wildcard $(abs_top_srcdir)/library/general/src/modules/*.rb)
 
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/commandline/doc/autodocs/Makefile.am
+++ b/library/commandline/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=commandline
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/commandline/src/modules/*.rb \
+  $(abs_top_srcdir)/library/commandline/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/control/doc/autodocs/Makefile.am
+++ b/library/control/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=control
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/control/src/modules/*.rb \
+  $(abs_top_srcdir)/library/control/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/cron/doc/autodocs/Makefile.am
+++ b/library/cron/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=cron
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/cron/src/modules/*.rb \
+  $(abs_top_srcdir)/library/cron/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/cwm/doc/autodocs/Makefile.am
+++ b/library/cwm/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=cwm
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/cwm/src/modules/*.rb \
+  $(abs_top_srcdir)/library/cwm/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/desktop/doc/autodocs/Makefile.am
+++ b/library/desktop/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=desktop
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/desktop/src/modules/*.rb \
+  $(abs_top_srcdir)/library/desktop/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/gpg/doc/autodocs/Makefile.am
+++ b/library/gpg/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=gpg
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/gpg/src/modules/*.rb \
+  $(abs_top_srcdir)/library/gpg/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/log/doc/autodocs/Makefile.am
+++ b/library/log/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=log
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/log/src/modules/*.rb \
+  $(abs_top_srcdir)/library/log/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/network/doc/autodocs/Makefile.am
+++ b/library/network/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=network
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/network/src/modules/*.rb \
+  $(abs_top_srcdir)/library/network/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/packages/doc/autodocs/Makefile.am
+++ b/library/packages/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=packages
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/packages/src/modules/*.rb \
+  $(abs_top_srcdir)/library/packages/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/runlevel/doc/autodocs/Makefile.am
+++ b/library/runlevel/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=runlevel
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/runlevel/src/modules/*.rb \
+  $(abs_top_srcdir)/runlevel/desktop/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/sequencer/doc/autodocs/Makefile.am
+++ b/library/sequencer/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=sequencer
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/sequencer/src/modules/*.rb \
+  $(abs_top_srcdir)/library/sequencer/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/system/doc/autodocs/Makefile.am
+++ b/library/system/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=system
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/system/src/modules/*.rb \
+  $(abs_top_srcdir)/library/system/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/types/doc/autodocs/Makefile.am
+++ b/library/types/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=types
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/types/src/modules/*.rb \
+  $(abs_top_srcdir)/library/types/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/wizard/doc/autodocs/Makefile.am
+++ b/library/wizard/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=wizard
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/wizard/src/modules/*.rb \
+  $(abs_top_srcdir)/library/wizard/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/library/xml/doc/autodocs/Makefile.am
+++ b/library/xml/doc/autodocs/Makefile.am
@@ -1,4 +1,7 @@
 # Makefile.am for YCP module .../doc/autodocs
 
 AUTODOCS_SUBDIR=xml
+AUTODOCS_RB ?= $(wildcard $(abs_top_srcdir)/library/xml/src/modules/*.rb \
+  $(abs_top_srcdir)/library/xml/src/include/*/*.rb)
+
 include $(top_srcdir)/autodocs-ycp.ami

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Jul 25 06:52:19 UTC 2018 - lslezak@suse.cz
+
+- Pass absolute paths to "yard", relative paths do not work anymore
+  because of a security update (bsc#1070263, CVE-2017-17042)
+- This is a yast2.rpm specific fix because it uses a different
+  directory layout than the other YaST packages.
+- 3.1.155.10
+
+-------------------------------------------------------------------
 Fri Feb 16 12:30:38 UTC 2018 - knut.anderssen@suse.com
 
 - Fixed interface type detection when read (bsc#1080805)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.1.155.9
+Version:        3.1.155.10
 Release:        0
 Url:            https://github.com/yast/yast-yast2
 


### PR DESCRIPTION
- Similar fix to https://github.com/yast/yast-country/pull/177, this is an `yast2` specific fix for the updated `yard`.
- Tested manually with the `osc build SLE-12-SP1_Update` (to build agains SP1-Updates), builds fine now.