### PR TITLE
Do not display "download failed" error (bsc#1096027)

### DIFF
--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -329,8 +329,8 @@ module Yast
         return "C" if r == :abort
         return "R" if r == :retry
         if r == :ignore
-          # don't show the warning when a refresh fails
-          if !@autorefreshing
+          # don't show the warning when a refresh fails or for signature errors (error 3)
+          if !@autorefreshing && error != 3
             # TODO: add "Don't show again" checkbox
             # a warning popup displayed after pressing [Ignore] after a download error
             Popup.Warning(
@@ -426,6 +426,11 @@ module Yast
     #   a blank string is returned (so no decision is made).
     def pkg_gpg_check(data)
       log.debug("pkgGpgCheck data: #{data}")
+
+      if data["CheckPackageResult"] && data["CheckPackageResult"] != 0
+        log.warn("Signature check failed: #{data}")
+      end
+
       insecure = Stage.initial && Linuxrc.InstallInf("Insecure") == "1"
       insecure ? "I" : ""
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 31 14:10:06 UTC 2018 - lslezak@suse.cz
+
+- Do not display "download failed" error when using unsigned
+  packages (bsc#1096027)
+- 4.0.81
+
+-------------------------------------------------------------------
 Wed Jul 25 08:13:31 UTC 2018 - jlopez@suse.com
 
 - Services: add class to manage systemd services with associated

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.80
+Version:        4.0.81
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Do not display "download failed" warning when using unsigned packages.
- Just skip the warning dialog when user ignored signature error
- Added extra logging when signature verification fails
- 4.0.81

### Screencasts

##### Original
![unsigned_pkg_orig](https://user-images.githubusercontent.com/907998/43506084-47716972-9569-11e8-9c83-9b24c518d742.gif)

##### Fixed

![unsigned_pkg_fixed](https://user-images.githubusercontent.com/907998/43506094-4f5867e4-9569-11e8-95f5-6cf71d2281ab.gif)
