### PR TITLE
Improve on-demand handling during 1st stage

### DIFF
--- a/library/systemd/src/lib/yast2/system_service.rb
+++ b/library/systemd/src/lib/yast2/system_service.rb
@@ -173,6 +173,13 @@ module Yast2
       @errors = {}
     end
 
+    # Determines whether the service exists in the underlying system
+    #
+    # @return [Boolean] true if it exists; false otherwise.
+    def found?
+      !service.not_found?
+    end
+
     # State of the service
     #
     # In case the service is not active but socket is, the socket state is considered
@@ -228,8 +235,13 @@ module Yast2
     # * :on_demand: The service will be started on demand.
     # * :manual:    The service is disabled and it will be started manually.
     #
+    # @note When the service does not exist in the underlying system (for instance,
+    # during 1st stage) all possible start modes are returned, as there is no way
+    # to find out which of them are supported.
+    #
     # @return [Array<Symbol>] List of supported modes.
     def start_modes
+      @start_modes = [:on_boot, :manual, :on_demand] unless found?
       return @start_modes if @start_modes
       @start_modes = [:on_boot, :manual]
       @start_modes << :on_demand if socket

--- a/library/systemd/src/lib/yast2/system_service.rb
+++ b/library/systemd/src/lib/yast2/system_service.rb
@@ -437,7 +437,7 @@ module Yast2
         when :on_boot
           service.enable && (socket ? socket.disable : true)
         when :on_demand
-          service.disable && (socket ? socket.enable : true)
+          service.disable && (socket ? socket.enable : false)
         when :manual
           service.disable && (socket ? socket.disable : true)
         end

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -81,7 +81,8 @@ module Yast
       :loaded?,
       :active_state,
       :sub_state,
-      :can_reload?
+      :can_reload?,
+      :not_found?
     ].freeze
 
     private_constant :FORWARDED_METHODS

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -194,7 +194,7 @@ module Yast
       # 'Triggers' property of each socket would be a better way. However, it won't work
       # during installation as 'systemctl show' is not available.
       #
-      # @return [Yast::SystemdSocketClass::Socket]
+      # @return [Yast::SystemdSocketClass::Socket,nil]
       def socket
         @socket ||= Yast::SystemdSocket.find(name)
       end

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -190,19 +190,13 @@ module Yast
 
       # Returns socket associated with service or nil if there is no such socket
       #
+      # @note The current implementation is too simplistic. At this point, checking the
+      # 'Triggers' property of each socket would be a better way. However, it won't work
+      # during installation as 'systemctl show' is not available.
+      #
       # @return [Yast::SystemdSocketClass::Socket]
       def socket
-        return @socket if @socket
-
-        # not triggered
-        socket_name = properties.triggered_by
-        return unless socket_name
-
-        # this may be a space separated list
-        socket_name = socket_name[/\S+\.socket/]
-        return unless socket_name # triggered by non-socket
-
-        @socket = Yast::SystemdSocket.find(socket_name)
+        @socket ||= Yast::SystemdSocket.find(name)
       end
 
       # Determines whether the service has an associated socket

--- a/library/systemd/test/systemd_service_test.rb
+++ b/library/systemd/test/systemd_service_test.rb
@@ -179,20 +179,22 @@ module Yast
 
     describe "#socket" do
       subject(:service) { SystemdService.find(service_name) }
+      let(:service_name) { "sshd" }
 
-      before { stub_services(service: service_name) }
+      before do
+        allow(SystemdSocket).to receive(:find).with(service_name).and_return(socket)
+      end
 
-      context "when the service is triggered by a socket" do
-        let(:service_name) { "cups" }
+      context "when a socket named after the service exists" do
+        let(:socket) { instance_double(SystemdSocketClass::Socket) }
 
         it "returns the socket" do
-          expect(service.socket).to be_a(Yast::SystemdSocketClass::Socket)
-          expect(service.socket.unit_name).to eq("iscsid")
+          expect(service.socket).to eq(socket)
         end
       end
 
-      context "when the service is not triggered by a socket" do
-        let(:service_name) { "sshd" }
+      context "when no socket named after the service exists" do
+        let(:socket) { nil }
 
         it "returns nil" do
           expect(service.socket).to be_nil
@@ -201,12 +203,14 @@ module Yast
     end
 
     describe "#socket?" do
-      subject(:service) { SystemdService.find(service_name) }
+      subject(:service) { SystemdService.find("sshd") }
 
-      before { stub_services(service: service_name) }
+      before do
+        allow(service).to receive(:socket).and_return(socket)
+      end
 
       context "when there is an associated socket" do
-        let(:service_name) { "cups" }
+        let(:socket) { instance_double(SystemdSocketClass::Socket) }
 
         it "returns true" do
           expect(service.socket?).to eq(true)
@@ -214,7 +218,7 @@ module Yast
       end
 
       context "when there is no associated socket" do
-        let(:service_name) { "sshd" }
+        let(:socket) { nil }
 
         it "returns false" do
           expect(service.socket?).to eq(false)

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -620,6 +620,17 @@ describe Yast2::SystemService do
 
           system_service.save
         end
+
+        context "but there is not associated socket (possible during 1st stage)" do
+          before do
+            allow(system_service).to receive(:socket).and_return(nil)
+          end
+
+          it "registers an error" do
+            system_service.save
+            expect(system_service.errors).to include(start_mode: :on_demand)
+          end
+        end
       end
 
       context "and the new start mode is :manual" do

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -1116,7 +1116,7 @@ describe Yast2::SystemService do
     end
   end
 
-  describe "#found" do
+  describe "#found?" do
     context "when the service is found" do
       let(:service_found) { true }
 

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -28,14 +28,16 @@ describe Yast2::SystemService do
 
   let(:service) do
     instance_double(Yast::SystemdServiceClass::Service,
-      name:     "cups",
-      enabled?: service_enabled,
-      active?:  service_active,
-      refresh!: true)
+      name:       "cups",
+      enabled?:   service_enabled,
+      active?:    service_active,
+      not_found?: !service_found,
+      refresh!:   true)
   end
 
   let(:service_enabled) { true }
   let(:service_active) { true }
+  let(:service_found) { true }
 
   let(:service_socket) do
     instance_double(Yast::SystemdSocketClass::Socket,
@@ -309,6 +311,15 @@ describe Yast2::SystemService do
 
       it "returns :on_boot and :manual" do
         expect(system_service.start_modes).to contain_exactly(:on_boot, :manual)
+      end
+    end
+
+    context "when the service is not found" do
+      let(:socket) { nil }
+      let(:service_found) { false }
+
+      it "returns all available start modes" do
+        expect(system_service.start_modes).to contain_exactly(:on_boot, :manual, :on_demand)
       end
     end
   end
@@ -1090,6 +1101,24 @@ describe Yast2::SystemService do
     context "when no changes were made" do
       it "returns false" do
         expect(system_service.changed?).to eq(false)
+      end
+    end
+  end
+
+  describe "#found" do
+    context "when the service is found" do
+      let(:service_found) { true }
+
+      it "returns true" do
+        expect(system_service.found?).to eq(true)
+      end
+    end
+
+    context "when the service is not found" do
+      let(:service_found) { false }
+
+      it "returns false" do
+        expect(system_service.found?).to eq(false)
       end
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Aug  8 10:09:55 UTC 2018 - igonzalezsosa@suse.com
+
+- Add a method to detect whether a systemd service exists in
+  the underlying system or not (related to fate#319428).
+- Fix systemd socket detection.
+- 4.0.83
+
+-------------------------------------------------------------------
 Wed Aug  1 10:48:04 UTC 2018 - igonzalezsosa@suse.com
 
 - Fix support to handle services during early 1st stage

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.82
+Version:        4.0.83
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
`Yast2::SystemService#start_modes`:
* `Yast2::SystemService#start_modes` returns all known modes as there is not enough information
  in order to find out which modes are supported.
* When trying to save the start mode, an error is registered if the socket is not found.

Additionally, the socket detection is not done using `TriggeredBy` anymore, as it won't work when the socket is stopped. Currently we are using a *name based* approach that might be not 100% reliable in the future. Some research is needed in order to find a better mechanism which, ideally, works during 1st stage too. This fix should be backported to `SLE-15-GA`.