### PR TITLE
Improve systemd socket detection

### DIFF
--- a/library/systemd/src/Makefile.am
+++ b/library/systemd/src/Makefile.am
@@ -6,8 +6,9 @@ module_DATA = \
 ylibdir = @ylibdir@/yast2
 ylib_DATA = \
   lib/yast2/systemctl.rb \
+  lib/yast2/system_service.rb \
   lib/yast2/systemd_unit.rb \
-  lib/yast2/system_service.rb
+  lib/yast2/systemd_socket_finder.rb
 
 EXTRA_DIST = $(module_DATA) $(ylib_DATA)
 

--- a/library/systemd/src/lib/yast2/system_service.rb
+++ b/library/systemd/src/lib/yast2/system_service.rb
@@ -154,13 +154,9 @@ module Yast2
       #
       # @param names [Array<String>] service names to find
       #
-      # @raise [NotFoundError] if any service is not found
       # @return [Array<SystemService>]
       def find_many(names)
-        systemd_services = Yast::SystemdService.find_many(names)
-        raise NotFoundError if systemd_services.any?(&:nil?)
-
-        systemd_services.map { |s| new(s) }
+        Yast::SystemdService.find_many(names).map { |s| new(s) }
       end
     end
 

--- a/library/systemd/src/lib/yast2/systemd_socket_finder.rb
+++ b/library/systemd/src/lib/yast2/systemd_socket_finder.rb
@@ -39,6 +39,7 @@ module Yast2
   class SystemdSocketFinder
     # Returns the socket for a given service
     #
+    # @param service_name [String] Service name (without the `.service` extension)
     # @return [Yast2::SystemdSocketClass::Socket,nil]
     def for_service(service_name)
       socket_name = socket_name_for(service_name)
@@ -60,6 +61,8 @@ module Yast2
 
     # Builds a map between services and sockets
     #
+    # @note When more than one socket triggers the service, the last one will be used.
+    #
     # @return [Hash<String,String>] Sockets indexed by the name of the service they trigger
     def sockets_map
       return @sockets_map if @sockets_map
@@ -78,9 +81,11 @@ module Yast2
 
     # Returns the systemctl show command to get sockets details
     #
+    # @note The list is alphabetically ordered.
+    #
     # @return [String] systemctl show command
     def show_triggers_cmd
-      format(SHOW_TRIGGERS_CMD, unit_names: unit_names.join(" "))
+      format(SHOW_TRIGGERS_CMD, unit_names: unit_names.sort.join(" "))
     end
 
     # Returns the names of the socket units

--- a/library/systemd/src/lib/yast2/systemd_socket_finder.rb
+++ b/library/systemd/src/lib/yast2/systemd_socket_finder.rb
@@ -1,0 +1,100 @@
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/execute"
+
+Yast.import "Systemctl"
+Yast.import "Stage"
+
+module Yast2
+  # This class is responsible for finding out which sockets trigger a given service.
+  #
+  # When systemd is working properly, the relationship between services and sockets is cached in
+  # order to reduce the amount of calls to `systemctl show`. However, during the installation, where
+  # systemd is not fully operational, this class just tries to find a socket named after the
+  # service.
+  #
+  # @example Finding a socket
+  #   finder = Yast2::SystemdSocketFinder.new
+  #   finder.for_service("cups").class # => Yast::SystemdSocketClass::Socket
+  class SystemdSocketFinder
+    # Returns the socket for a given service
+    #
+    # @return [Yast2::SystemdSocketClass::Socket,nil]
+    def for_service(service_name)
+      socket_name = socket_name_for(service_name)
+      return nil unless socket_name
+      Yast::SystemdSocket.find(socket_name)
+    end
+
+  private
+
+    # Return the socket's name for a given service
+    #
+    # @note On 1st stage it returns just the same name.
+    #
+    # @return [String,nil]
+    def socket_name_for(service_name)
+      return service_name if Yast::Stage.initial
+      sockets_map[service_name]
+    end
+
+    # Builds a map between services and sockets
+    #
+    # @return [Hash<String,String>] Sockets indexed by the name of the service they trigger
+    def sockets_map
+      return @sockets_map if @sockets_map
+      result = Yast::Systemctl.execute(show_triggers_cmd)
+      return {} unless result.exit.zero?
+      lines = result.stdout.lines.map(&:chomp)
+      @sockets_map = lines.each_slice(3).each_with_object({}) do |(id_str, triggers_str, _), memo|
+        id = id_str[/Id=(\w+).socket/, 1]
+        triggers = triggers_str[/Triggers=(\w+).service/, 1]
+        memo[triggers] = id if triggers && id
+      end
+    end
+
+    # @return [String] systemctl command to get services and their triggers
+    SHOW_TRIGGERS_CMD = "show --property Id,Triggers %<unit_names>s".freeze
+
+    # Returns the systemctl show command to get sockets details
+    #
+    # @return [String] systemctl show command
+    def show_triggers_cmd
+      format(SHOW_TRIGGERS_CMD, unit_names: unit_names.join(" "))
+    end
+
+    # Returns the names of the socket units
+    #
+    # @return [Array<String>] Socket unit names
+    def unit_names
+      output = Yast::Execute.on_target(
+        "/usr/bin/systemctl", "list-unit-files", "--type", "socket",
+        stdout: :capture
+      )
+      output.lines.each_with_object([]) do |name, memo|
+        socket_name = name[/\A(\w+.socket)/, 1]
+        memo << socket_name if socket_name
+      end
+    end
+  end
+end

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -110,10 +110,9 @@ module Yast
       property_texts = out.stdout.split("\n\n")
       return [] unless snames.size == property_texts.size
 
-      snames.zip(property_texts).map do |service_name, property_text|
-        service = Service.new(service_name, service_propmap, property_text)
-        next nil if service.properties.not_found?
-        service
+      snames.zip(property_texts).each_with_object([]) do |(name, property_text), memo|
+        service = Service.new(name, service_propmap, property_text)
+        memo << service unless service.not_found?
       end
     end
 

--- a/library/systemd/src/modules/systemd_service.rb
+++ b/library/systemd/src/modules/systemd_service.rb
@@ -189,13 +189,10 @@ module Yast
 
       # Returns socket associated with service or nil if there is no such socket
       #
-      # @note The current implementation is too simplistic. At this point, checking the
-      # 'Triggers' property of each socket would be a better way. However, it won't work
-      # during installation as 'systemctl show' is not available.
-      #
       # @return [Yast::SystemdSocketClass::Socket,nil]
+      # @see SystemdSocket.for_service
       def socket
-        @socket ||= Yast::SystemdSocket.find(name)
+        @socket ||= Yast::SystemdSocket.for_service(name)
       end
 
       # Determines whether the service has an associated socket

--- a/library/systemd/src/modules/systemd_socket.rb
+++ b/library/systemd/src/modules/systemd_socket.rb
@@ -92,6 +92,7 @@ module Yast
 
     # Returns the socket for a given service
     #
+    # @param service_name [String] Service name (without the `.service` extension)
     # @return [Yast::SystemdSocketClass::Socket,nil]
     def for_service(service_name)
       @socket_finder ||= Yast2::SystemdSocketFinder.new

--- a/library/systemd/src/modules/systemd_socket.rb
+++ b/library/systemd/src/modules/systemd_socket.rb
@@ -1,4 +1,5 @@
 require "yast2/systemd_unit"
+require "yast2/systemd_socket_finder"
 
 module Yast
   ###
@@ -87,6 +88,14 @@ module Yast
         Socket.new(socket_unit, propmap)
       end
       sockets.select { |s| s.properties.supported? }
+    end
+
+    # Returns the socket for a given service
+    #
+    # @return [Yast::SystemdSocketClass::Socket,nil]
+    def for_service(service_name)
+      @socket_finder ||= Yast2::SystemdSocketFinder.new
+      @socket_finder.for_service(service_name)
     end
 
     class Socket < SystemdUnit

--- a/library/systemd/test/Makefile.am
+++ b/library/systemd/test/Makefile.am
@@ -4,7 +4,8 @@ TESTS = \
   systemd_socket_test.rb \
   systemd_target_test.rb \
   systemd_service_test.rb \
-  yast2/system_service_test.rb
+  yast2/system_service_test.rb \
+  yast2/systemd_socket_finder_test.rb
 
 TEST_EXTENSIONS = .rb
 RB_LOG_COMPILER = rspec

--- a/library/systemd/test/data/apparmor_and_cups_properties
+++ b/library/systemd/test/data/apparmor_and_cups_properties
@@ -1,6 +1,5 @@
 MainPID=0
 Id=apparmor.service
-TriggeredBy=
 Description=Load AppArmor profiles
 LoadState=loaded
 ActiveState=active
@@ -10,7 +9,6 @@ UnitFileState=enabled
 
 MainPID=25772
 Id=cups.service
-TriggeredBy=cups.path cups.socket
 Description=CUPS Scheduler
 LoadState=loaded
 ActiveState=active

--- a/library/systemd/test/data/cups_service_properties
+++ b/library/systemd/test/data/cups_service_properties
@@ -141,7 +141,6 @@ Requires=system.slice sysinit.target
 Conflicts=shutdown.target
 Before=shutdown.target
 After=system.slice cups.socket sysinit.target basic.target cups.path systemd-journald.socket
-TriggeredBy=iscsid.socket cups.path
 Documentation=man:cupsd(8)
 Description=CUPS Scheduler
 LoadState=loaded

--- a/library/systemd/test/systemd_service_test.rb
+++ b/library/systemd/test/systemd_service_test.rb
@@ -95,6 +95,22 @@ module Yast
         )
       end
 
+      context "when a service is not found" do
+        let(:not_found_double) { double("Service", name: "cups", not_found?: true) }
+
+        before do
+          allow(Yast::SystemdServiceClass::Service).to receive(:new).and_call_original
+          allow(Yast::SystemdServiceClass::Service).to receive(:new)
+            .with("cups.service", anything, anything)
+            .and_return(not_found_double)
+        end
+
+        it "does not include the not found service" do
+          services = SystemdService.find_many(["apparmor", "cups"])
+          expect(services.map(&:name)).to eq(["apparmor"])
+        end
+      end
+
       context "when 'systemctl show' fails to provide services information" do
         let(:systemctl_show) { OpenStruct.new(stdout: "", stderr: "", exit: 1) }
 

--- a/library/systemd/test/systemd_service_test.rb
+++ b/library/systemd/test/systemd_service_test.rb
@@ -95,11 +95,6 @@ module Yast
         )
       end
 
-      it "includes 'TriggeredBy' property" do
-        cups = SystemdService.find_many(["apparmor", "cups"]).last
-        expect(cups.properties.triggered_by).to eq("cups.path cups.socket")
-      end
-
       context "when 'systemctl show' fails to provide services information" do
         let(:systemctl_show) { OpenStruct.new(stdout: "", stderr: "", exit: 1) }
 

--- a/library/systemd/test/systemd_service_test.rb
+++ b/library/systemd/test/systemd_service_test.rb
@@ -81,7 +81,7 @@ module Yast
       before do
         allow(Yast::Systemctl).to receive(:execute).with(
           "show  --property=Id,MainPID,Description,LoadState,ActiveState,SubState,UnitFileState," \
-          "FragmentPath,CanReload,TriggeredBy apparmor.service cups.service"
+          "FragmentPath,CanReload apparmor.service cups.service"
         ).and_return(systemctl_show)
         allow(SystemdService).to receive(:find).with("apparmor", {}).and_return(apparmor_double)
         allow(SystemdService).to receive(:find).with("cups", {}).and_return(cups_double)

--- a/library/systemd/test/systemd_service_test.rb
+++ b/library/systemd/test/systemd_service_test.rb
@@ -180,21 +180,26 @@ module Yast
     describe "#socket" do
       subject(:service) { SystemdService.find(service_name) }
       let(:service_name) { "sshd" }
+      let(:socket) { instance_double(SystemdSocketClass::Socket) }
 
-      before do
-        allow(SystemdSocket).to receive(:find).with(service_name).and_return(socket)
+      it "returns the socket for the service" do
+        expect(SystemdSocket).to receive(:for_service).with(service_name)
+          .and_return(socket)
+        expect(service.socket).to eq(socket)
       end
 
-      context "when a socket named after the service exists" do
-        let(:socket) { instance_double(SystemdSocketClass::Socket) }
+      it "asks for the socket only once" do
+        expect(SystemdSocket).to receive(:for_service).with(service_name)
+          .and_return(socket).once
+        expect(service.socket).to eq(socket)
+        expect(service.socket).to eq(socket)
+      end
 
-        it "returns the socket" do
-          expect(service.socket).to eq(socket)
+      context "when no associated socket is found" do
+        before do
+          allow(SystemdSocket).to receive(:for_service).with(service_name)
+            .and_return(nil)
         end
-      end
-
-      context "when no socket named after the service exists" do
-        let(:socket) { nil }
 
         it "returns nil" do
           expect(service.socket).to be_nil

--- a/library/systemd/test/systemd_socket_test.rb
+++ b/library/systemd/test/systemd_socket_test.rb
@@ -1,12 +1,13 @@
 #!/usr/bin/env rspec
-require "yast"
+
 require_relative "test_helper"
-require "yast2/systemd_unit"
 
 module Yast
   import "SystemdSocket"
 
   describe SystemdSocket do
+    subject(:systemd_socket) { SystemdSocketClass.new }
+
     include SystemdSocketStubs
 
     before do
@@ -42,6 +43,27 @@ module Yast
         expect(sockets).to be_a(Array)
         expect(sockets).not_to be_empty
         sockets.each { |s| expect(s.unit_type).to eq("socket") }
+      end
+
+      describe ".for_service" do
+        let(:finder) { instance_double(Yast2::SystemdSocketFinder, for_service: socket) }
+        let(:socket) { instance_double(SystemdSocketClass::Socket) }
+
+        before do
+          allow(Yast2::SystemdSocketFinder).to receive(:new).and_return(finder)
+        end
+
+        it "returns the socket for the given service" do
+          expect(subject.for_service("cups")).to eq(socket)
+        end
+
+        context "when there is not associated socket" do
+          let(:socket) { nil }
+
+          it "returns nil" do
+            expect(subject.for_service("cups")).to be_nil
+          end
+        end
       end
     end
 

--- a/library/systemd/test/systemd_socket_test.rb
+++ b/library/systemd/test/systemd_socket_test.rb
@@ -57,7 +57,7 @@ module Yast
           expect(subject.for_service("cups")).to eq(socket)
         end
 
-        context "when there is not associated socket" do
+        context "when there is no associated socket" do
           let(:socket) { nil }
 
           it "returns nil" do

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -94,6 +94,14 @@ describe Yast2::SystemService do
         expect(system_service.service).to eq(systemd_service)
       end
     end
+
+    context "when the service is not found" do
+      let(:systemd_service) { nil }
+
+      it "raises an exception" do
+        expect { described_class.find!("cups") }.to raise_error(Yast2::SystemService::NotFoundError)
+      end
+    end
   end
 
   describe ".build" do

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -94,14 +94,6 @@ describe Yast2::SystemService do
         expect(system_service.service).to eq(systemd_service)
       end
     end
-
-    context "when the service is not found" do
-      let(:systemd_service) { nil }
-
-      it "raises an exception" do
-        expect { described_class.find!("cups") }.to raise_error(Yast2::SystemService::NotFoundError)
-      end
-    end
   end
 
   describe ".build" do
@@ -128,18 +120,6 @@ describe Yast2::SystemService do
       system_services = described_class.find_many(["apparmor", "cups"])
       expect(system_services).to be_all(Yast2::SystemService)
       expect(system_services.map(&:service)).to eq([apparmor, cups])
-    end
-
-    context "when some service is not found" do
-      before do
-        allow(Yast::SystemdService).to receive(:find_many).with(["apparmor", "cups"])
-          .and_return([nil, cups])
-      end
-
-      it "raises an exception" do
-        expect { described_class.find_many(["apparmor", "cups"]) }
-          .to raise_error(Yast2::SystemService::NotFoundError)
-      end
     end
   end
 

--- a/library/systemd/test/yast2/systemd_socket_finder_test.rb
+++ b/library/systemd/test/yast2/systemd_socket_finder_test.rb
@@ -1,0 +1,87 @@
+#!/usr/bin/env rspec
+# encoding: utf-8
+
+# Copyright (c) [2018] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "yast2/systemd_socket_finder"
+
+describe Yast2::SystemdSocketFinder do
+  subject(:finder) { described_class.new }
+
+  let(:systemctl_result) do
+    OpenStruct.new(
+      exit:   0,
+      stdout: "Id=cups.socket\nTriggers=cups.service\n\nId=sckt1.socket\nTriggers=srvc1.service\n"
+    )
+  end
+
+  before do
+    allow(Yast::Systemctl).to receive(:execute)
+      .with("show --property Id,Triggers cups.socket sckt1.socket")
+      .and_return(systemctl_result)
+    allow(Yast::Execute).to receive(:on_target).and_return(
+      "UNIT FILE                       STATE   \n" \
+      "cups.socket                     enabled \n" \
+      "sckt1.socket                    disabled\n"
+    )
+  end
+
+  describe "#for_service" do
+    let(:socket) { double("socket") }
+
+    it "returns the related socket" do
+      expect(Yast::SystemdSocket).to receive(:find).with("sckt1").and_return(socket)
+      expect(finder.for_service("srvc1")).to eq(socket)
+    end
+
+    context "when there is no related socket" do
+      it "returns nil" do
+        expect(finder.for_service("httpd")).to be_nil
+      end
+
+      it "does not try to read the socket" do
+        expect(Yast::SystemdSocket).to_not receive(:find)
+        expect(finder.for_service("httpd")).to be_nil
+      end
+    end
+
+    context "on 1st stage" do
+      before do
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+      end
+
+      it "returns a socket named after the service" do
+        expect(Yast::SystemdSocket).to receive(:find).with("cups").and_return(socket)
+        expect(finder.for_service("cups")).to eq(socket)
+      end
+
+      context "when there is no related socket" do
+        before do
+          allow(Yast::SystemdSocket).to receive(:find).with("httpd").and_return(nil)
+        end
+
+        it "returns nil" do
+          expect(finder.for_service("httpd")).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug  9 13:02:38 UTC 2018 - imo@localhost
+
+- Improve systemd socket detection (related to fate#319428).
+- SystemService#find_many does not raise an exception anymore.
+- 4.0.84
+
+-------------------------------------------------------------------
 Wed Aug  8 10:09:55 UTC 2018 - igonzalezsosa@suse.com
 
 - Add a method to detect whether a systemd service exists in

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.83
+Version:        4.0.84
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
* Introduce a new `SystemdSocketFinder` which speeds up the detection of
  service sockets.
* Does not fetch TriggeredBy anymore as it was not reliable.
* SystemdService.find_many_at_once does not return nil values