### PR TITLE
[RFC] Add exception to distinguish a `systemctl show` fail from others

### DIFF
--- a/library/systemd/src/lib/yast2/system_service.rb
+++ b/library/systemd/src/lib/yast2/system_service.rb
@@ -354,9 +354,15 @@ module Yast2
 
       result = errors.none?
 
-      result && reset && refresh
+      if result
+        reset && refresh
+      end
 
       result
+    rescue Yast::SystemctlError
+      register_error(:active)
+
+      false
     end
 
     # Reverts cached changes
@@ -456,9 +462,8 @@ module Yast2
       result = send("perform_#{action}")
       register_error(:active) if result == false
       result
-    rescue => e
-      register_error(:active) if e.kind_of?(Yast::SystemctlError)
-      false
+    rescue Yast::CouldNotRefreshUnitError
+      true
     end
 
     # Starts the service in the underlying system

--- a/library/systemd/src/lib/yast2/system_service.rb
+++ b/library/systemd/src/lib/yast2/system_service.rb
@@ -342,10 +342,8 @@ module Yast2
 
     # Saves changes into the underlying system
     #
-    # @note All cached changes are reset and the underlying service is refreshed
-    #   when the changes are correctly applied.
-    #
-    # @raise [Yast::SystemctlError] if the service cannot be refreshed
+    # @note All cached changes are reset and the underlying service will be refreshed when the changes
+    #   are correctly applied.
     #
     # @param keep_state [Boolean] Do not change service status. Useful when running on 1st stage.
     # @return [Boolean] true if the service was saved correctly; false otherwise.
@@ -354,7 +352,11 @@ module Yast2
       save_start_mode
       perform_action unless keep_state
 
-      errors.none? && reset && refresh!
+      result = errors.none?
+
+      result && reset && refresh
+
+      result
     end
 
     # Reverts cached changes

--- a/library/systemd/src/lib/yast2/system_service.rb
+++ b/library/systemd/src/lib/yast2/system_service.rb
@@ -375,7 +375,7 @@ module Yast2
     # @return [Boolean] true if the service was refreshed correctly; false otherwise.
     def refresh
       refresh!
-    rescue Yast::SystemctlError
+    rescue Yast::CouldNotRefreshUnitError
       false
     end
 
@@ -453,14 +453,9 @@ module Yast2
 
       result = send("perform_#{action}")
       register_error(:active) if result == false
-
       result
-
-      # FIXME: SystemdService#{start, stop, etc} calls to refresh! internally, so when
-      # this exception is raised we cannot distinguish if the action is failing or
-      # refresh! is failing. For SP1, refresh! should raise a new kind of exception.
-    rescue Yast::SystemctlError
-      register_error(:active)
+    rescue => e
+      register_error(:active) if e.kind_of?(Yast::SystemctlError)
       false
     end
 

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -3,6 +3,14 @@ require "yast2/systemctl"
 require "ostruct"
 
 module Yast
+  # Represent a fail when systemctl command tries to refresh the service
+  class CouldNotRefreshUnitError < StandardError
+    # @param unit [Yast::SystemdUnit]
+    def initialize(unit)
+      super "Could not refresh #{unit.name}"
+    end
+  end
+
   ###
   #  Use this class always as a parent class for implementing various systemd units.
   #  Do not use it directly for ad-hoc implementation of systemd units.
@@ -121,11 +129,13 @@ module Yast
       @name = id.to_s.split(".").first || unit_name
     end
 
-    # @raise [Yast::SystemctlError] if 'systemctl show' cannot be executed
+    # @raise [Yast::CouldNotRefreshUnitError] if 'systemctl show' cannot be executed
     def refresh!
       @properties = show
       @error = properties.error
       properties
+    rescue Yast::SystemctlError
+      raise Yast::CouldNotRefreshUnitError, self
     end
 
     # Run 'systemctl show' and parse the unit properties

--- a/library/systemd/src/lib/yast2/systemd_unit.rb
+++ b/library/systemd/src/lib/yast2/systemd_unit.rb
@@ -4,7 +4,7 @@ require "ostruct"
 
 module Yast
   # Represent a fail when systemctl command tries to refresh the service
-  class CouldNotRefreshUnitError < StandardError
+  class CouldNotRefreshUnitError < SystemctlError
     # @param unit [Yast::SystemdUnit]
     def initialize(unit)
       super "Could not refresh #{unit.name}"
@@ -135,6 +135,8 @@ module Yast
       @error = properties.error
       properties
     rescue Yast::SystemctlError
+      @error = "Fails to refresh unit"
+
       raise Yast::CouldNotRefreshUnitError, self
     end
 

--- a/library/systemd/test/systemd_unit_test.rb
+++ b/library/systemd/test/systemd_unit_test.rb
@@ -214,8 +214,19 @@ module Yast
     end
 
     describe "#refresh!" do
+      let(:unit) { SystemdUnit.new("your.socket") }
+
+      context "when `show` command cannot be executed" do
+        before do
+          allow_any_instance_of(Yast::SystemdUnit).to receive(:show).and_raise(Yast::SystemctlError, unit)
+        end
+
+        it "raises a `CouldNotRefreshUnitError`" do
+          expect { unit.refresh! }.to raise_error(Yast::CouldNotRefreshUnitError)
+        end
+      end
+
       it "rewrites and returns the properties instance variable" do
-        unit = SystemdUnit.new("your.socket")
         properties = unit.properties
         expect(unit.refresh!).not_to equal(properties)
       end

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -531,7 +531,7 @@ describe Yast2::SystemService do
     end
   end
 
-  describe "#save=" do
+  describe "#save" do
     before do
       allow(service).to receive(:enable).and_return(true)
       allow(service).to receive(:disable).and_return(true)
@@ -979,6 +979,19 @@ describe Yast2::SystemService do
         it "returns true" do
           expect(system_service.save).to eq(true)
         end
+
+        context "but it could not refresh the service" do
+          before do
+            allow(service).to receive(:refresh!)
+            allow(system_service).to receive(:perform_start).and_raise(Yast::CouldNotRefreshUnitError, service)
+          end
+
+          it "does not register any error for the action" do
+            system_service.save
+
+            expect(system_service.errors).to_not have_key(:active)
+          end
+        end
       end
 
       context "and the action cannot be performed" do
@@ -1083,7 +1096,7 @@ describe Yast2::SystemService do
 
     context "when the service cannot be refreshed" do
       before do
-        allow(service).to receive(:refresh!).and_raise(Yast::SystemctlError.new("error"))
+        allow(service).to receive(:refresh!).and_raise(Yast::CouldNotRefreshUnitError, service)
       end
 
       it "returns false" do

--- a/library/systemd/test/yast2/system_service_test.rb
+++ b/library/systemd/test/yast2/system_service_test.rb
@@ -1043,7 +1043,7 @@ describe Yast2::SystemService do
           allow(service).to receive(:start).and_return(true)
           allow(socket).to receive(:start).and_return(true)
 
-          allow(service).to receive(:refresh!).and_raise(Yast::SystemctlError.new("error"))
+          allow(service).to receive(:refresh!).and_raise(Yast::CouldNotRefreshUnitError, service)
         end
 
         let(:service_active) { false }
@@ -1051,8 +1051,8 @@ describe Yast2::SystemService do
 
         let(:action) { :start }
 
-        it "raises an exception" do
-          expect { system_service.save }.to raise_error(Yast::SystemctlError)
+        it "reutrns true" do
+          expect(system_service.save).to eq(true)
         end
       end
     end


### PR DESCRIPTION
Related to https://trello.com/c/XZUCetog/160-create-new-exception-for-failure-when-refreshing-a-service