### PR TITLE
Increase the timeout for systemctl command execution

### DIFF
--- a/library/systemd/src/lib/yast2/systemctl.rb
+++ b/library/systemd/src/lib/yast2/systemctl.rb
@@ -20,7 +20,7 @@ module Yast
     COMMAND_OPTIONS = " --no-legend --no-pager --no-ask-password ".freeze
     ENV_VARS        = " LANG=C TERM=dumb COLUMNS=1024 ".freeze
     SYSTEMCTL       = ENV_VARS + CONTROL + COMMAND_OPTIONS
-    TIMEOUT         = 30 # seconds
+    TIMEOUT         = 40 # seconds
 
     class << self
       BASH_SCR_PATH = Yast::Path.new(".target.bash_output")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 30 11:21:14 UTC 2018 - David Díaz <dgonzalez@suse.com>
+
+- Increase timeout for the execution of systemctl commands
+  (bsc#1098910).
+- 4.0.86
+
+-------------------------------------------------------------------
 Tue Aug 14 17:32:02 UTC 2018 - igonzalezsosa@suse.com
 
 - Add support for systemd services that can only be started

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.85
+Version:        4.0.86
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
> Since systemd by itself has a 30 sec timeout, YaST should add some more
> seconds to allow for systemctl to exit gracefully even if it has a
> timeout and not just kill the systemctl command just one seconds before
> it would time out itself.

See https://bugzilla.suse.com/show_bug.cgi?id=1098910#c3

---

Related to https://trello.com/c/udasbOtt/135-lhf-osdistribution-p4-1098910-yast2-services-manager-internal-error-writing-run-configuration-to-disk