### PR TITLE
Fix return value

### DIFF
--- a/library/cwm/src/modules/CWM.rb
+++ b/library/cwm/src/modules/CWM.rb
@@ -834,7 +834,6 @@ module Yast
           end
         end
 
-        ret = :next if ret == :ok
         ret = :abort if ret == :cancel
 
         if ret == :next && functions[:next]

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Sep 12 14:11:56 UTC 2018 - jlopez@suse.com
+
+- CWM: avoid to always return :next when accepting a dialog.
+- Needed for Expert Partitioner (fate#318196).
+- 4.0.91
+
+-------------------------------------------------------------------
 Wed Sep 12 14:05:49 UTC 2018 - knut.anderssen@suse.com
 
 - Added the missing SuSEFirewallProposal.rb file to the Makefile

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.90
+Version:        4.0.91
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
`:next` button was consider the same than `:ok`, and when the dialog used `:ok` it returned `:next`. Now this is avoided because some client code expects `:ok` being returned.