### PR TITLE
Improved self-update to use some packages as an add-on (bsc#1101016)

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1497,7 +1497,8 @@ module Yast
         Yast::WorkflowManager.RemoveWorkflow(
           :package,
           merged_base_product.installation_package_repo,
-          merged_base_product.installation_package)
+          merged_base_product.installation_package
+        )
       end
 
       AddWorkflow(:package, product.installation_package_repo, product.installation_package)

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -437,7 +437,8 @@ describe Yast::WorkflowManager do
 
   describe "#merge_product_workflow" do
     let(:product) do
-      instance_double("Y2Packager::Product", label: "SLES", installation_package: "package")
+      instance_double("Y2Packager::Product", label: "SLES", installation_package: "package",
+        installation_package_repo: 42)
     end
 
     before do
@@ -448,7 +449,7 @@ describe Yast::WorkflowManager do
     end
 
     it "merges installation package workflow" do
-      expect(subject).to receive(:AddWorkflow).with(:package, 0, "package")
+      expect(subject).to receive(:AddWorkflow).with(:package, product.installation_package_repo, "package")
       subject.merge_product_workflow(product)
     end
 
@@ -458,7 +459,7 @@ describe Yast::WorkflowManager do
       end
 
       it "removes the previous workflow" do
-        expect(subject).to receive(:RemoveWorkflow).with(:package, 0, "package")
+        expect(subject).to receive(:RemoveWorkflow).with(:package, product.installation_package_repo, "package")
         subject.merge_product_workflow(product)
       end
     end

--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -41,13 +41,15 @@ module Y2Packager
     attr_reader :order
     # @return [String] package including installation.xml for install on top of lean os
     attr_reader :installation_package
+    # @return [Integer] repository for the installation_package
+    attr_reader :installation_package_repo
 
     class << self
       PKG_BINDINGS_ATTRS = ["name", "short_name", "display_name", "version", "arch",
                             "category", "vendor"].freeze
 
       # Create a product from pkg-bindings hash data.
-      # @param p [Hash] the pkg-binindgs product hash
+      # @param p [Hash] the pkg-bindings product hash
       # @return [Y2Packager::Product] converted product
       def from_h(p)
         params = PKG_BINDINGS_ATTRS.each_with_object({}) { |a, h| h[a.to_sym] = p[a] }

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Sep 17 12:12:52 UTC 2018 - lslezak@suse.cz
+
+- Allow reading the installation.xml (skelcd-* package) from other
+  repository than the initial one (e.g. the self update), select
+  the highest version of the package (instead of the first found)
+  (bsc#1101016)
+- 4.1.13
+
+-------------------------------------------------------------------
 Mon Sep 17 11:21:58 UTC 2018 - knut.anderssen@suse.com
 
 - Firewalld: Fixed the API cmd call for removing services from

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.12
+Version:        4.1.13
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1101016

## Notes

The full functionality depends also on these other pull requests:
- https://github.com/yast/yast-packager/pull/374
- https://github.com/yast/yast-installation/pull/741

## Tested Manually

- Tested manually with a customized `skelcd-control-SLES` package (Knut, thanks! :wink: ), applied using a DUD with `self_update=` boot parameter pointing to a repository with the new skelcd.
- Also tested an AutoYaST installation
- The extra addon repository is removed at the end

![self-update-role](https://user-images.githubusercontent.com/907998/45540956-05227f80-b80e-11e8-9e6d-604ceb9677c5.png)
