### PR TITLE
Fix firewall-offline-cmd call for removing services from zones (bsc#1108628)

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/api/zones.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api/zones.rb
@@ -131,8 +131,7 @@ module Y2Firewall
         #   modifies the permanent configuration
         # @return [Boolean] True if the interface was removed from the zone
         def remove_interface(zone, interface, permanent: permanent?)
-          modify_command("--zone=#{zone}", "--remove-interface=#{interface}",
-            permanent: permanent)
+          modify_command("--zone=#{zone}", "--remove-interface=#{interface}", permanent: permanent)
         end
 
         # @param zone [String] The firewall zone
@@ -234,7 +233,8 @@ module Y2Firewall
         #   modifies the permanent configuration
         # @return [Boolean] True if service was removed from zone
         def remove_service(zone, service, permanent: permanent?)
-          modify_command("--zone=#{zone}", "--remove-service=#{service}", permanent: permanent)
+          remove_arg = offline? ? "--remove-service-from-zone" : "--remove-service"
+          modify_command("--zone=#{zone}", "#{remove_arg}=#{service}", permanent: permanent)
         end
 
         # @param zone [String] The firewall zone

--- a/library/network/test/y2firewall/firewalld/api/zones_test.rb
+++ b/library/network/test/y2firewall/firewalld/api/zones_test.rb
@@ -157,6 +157,29 @@ describe Y2Firewall::Firewalld::Api::Zones do
     end
   end
 
+  describe "#add_service" do
+    it "adds the given service to the specified zone" do
+      expect(api).to receive(:modify_command)
+        .with("--zone=test", "--add-service=samba", permanent: api.permanent?)
+
+      api.add_service("test", "samba")
+    end
+  end
+
+  describe "#remove_service" do
+    let(:api_running) { Y2Firewall::Firewalld::Api.new(mode: :running) }
+
+    it "removes the given service from the specified zone" do
+      expect(api).to receive(:modify_command)
+        .with("--zone=public", "--remove-service-from-zone=ssh", permanent: api.permanent?)
+      api.remove_service("public", "ssh")
+
+      expect(api_running).to receive(:modify_command)
+        .with("--zone=public", "--remove-service=vnc", permanent: api_running.permanent?)
+      api_running.remove_service("public", "vnc")
+    end
+  end
+
   describe "#source_enabled?" do
     it "returns false if the source is not binded to the zone" do
       allow(api).to receive(:query_command)

--- a/library/network/test/y2firewall/firewalld/api_test.rb
+++ b/library/network/test/y2firewall/firewalld/api_test.rb
@@ -149,6 +149,15 @@ describe Y2Firewall::Firewalld::Api do
   end
 
   describe "#state" do
+    subject(:api) { described_class.new(mode: :running) }
+
+    it "returns 'unknown' in case of an unexpected state" do
+      allow(Yast::Execute).to receive(:on_target)
+        .with("firewall-cmd", "--state", allowed_exitstatus: [0, 252]).and_return(24)
+
+      expect(api.state).to eql("unknown")
+    end
+
     it "returns 'running' when the firewall is running" do
       allow(Yast::Execute).to receive(:on_target)
         .with("firewall-cmd", "--state", allowed_exitstatus: [0, 252]).and_return(0)
@@ -161,13 +170,6 @@ describe Y2Firewall::Firewalld::Api do
         .with("firewall-cmd", "--state", allowed_exitstatus: [0, 252]).and_return(252)
 
       expect(api.state).to eql("not running")
-    end
-
-    it "returns 'unknown' in case of an unexpected state" do
-      allow(Yast::Execute).to receive(:on_target)
-        .with("firewall-cmd", "--state", allowed_exitstatus: [0, 252]).and_return(24)
-
-      expect(api.state).to eql("unknown")
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 17 11:21:58 UTC 2018 - knut.anderssen@suse.com
+
+- Firewalld: Fixed the API cmd call for removing services from
+  zones when the firewall is in offline mode (bsc#1108628)
+- 4.0.92
+
+-------------------------------------------------------------------
 Wed Sep 12 14:11:56 UTC 2018 - jlopez@suse.com
 
 - CWM: avoid to always return :next when accepting a dialog.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.91
+Version:        4.0.92
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1108628

With the offline cmd (firewall-offline-cmd), the `--remove-service` call can be used only with the default zone, in other case, it has to be called as `--remove-service-from-zone`

See: https://firewalld.org/documentation/man-pages/firewall-offline-cmd.html

Bug introduced when extending the API:

https://github.com/yast/yast-yast2/pull/819/files#diff-fade9352dfa13333ea0f66a045fe53eaL217