### PR TITLE
Make the service status label stretchable (bsc#1110407)

### DIFF
--- a/library/systemd/src/lib/yast2/service_widget.rb
+++ b/library/systemd/src/lib/yast2/service_widget.rb
@@ -82,8 +82,8 @@ module Yast2
           Left(
             HBox(
               Label(_("Current status:")),
-              Label(" "),
-              Label(Id(:service_widget_status), status)
+              HSpacing(1),
+              Label(Id(:service_widget_status), Opt(:hstretch), status)
             )
           ),
           Left(action_widget),

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  2 11:11:26 UTC 2018 - lslezak@suse.cz
+
+- Make the service status label stretchable so the updated status
+  is displayed correctly (bsc#1110407)
+- 4.1.20
+
+-------------------------------------------------------------------
 Mon Oct  1 17:29:17 UTC 2018 - mfilka@suse.com
 
 - bnc#964856

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.19
+Version:        4.1.20
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- When changing the label from "Active" to "Inactive" the longer label was not displayed correctly in the ncurses UI.
- Use `HSpacing(1)` instead of `Label(" ")` - if there is lack of space libyui first decreases/removes the spacings, this might be enough without cutting off the labels
- openQA: https://openqa.opensuse.org/tests/765329#step/yast2_dns_server/35
- bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1110407
- 4.1.20