### PR TITLE
Log viewer: replace invalid UTF-8 characters (bsc#1110549)

### DIFF
--- a/library/system/src/clients/view_anymsg.rb
+++ b/library/system/src/clients/view_anymsg.rb
@@ -192,6 +192,8 @@ module Yast
         file_content = SCR.Read(path(".target.string"), @filename)
 
         if file_content
+          # replace invalid byte sequences with Unicode "replacement character"
+          file_content.scrub!("�")
           # remove ANSI color escape sequences
           file_content.remove_ansi_sequences
           # remove remaining ASCII control characters (ASCII 0-31 and 127 (DEL))

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  9 08:25:42 UTC 2018 - lslezak@suse.cz
+
+- Log viewer: replace invalid UTF-8 characters from the displayed
+  log to avoid a crash (bsc#1110549)
+- 4.0.99
+
+-------------------------------------------------------------------
 Wed Oct  3 07:48:30 UTC 2018 - knut.anderssen@suse.com
 
 - Network (Firewall):

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.98
+Version:        4.0.99
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Log viewer: replace invalid UTF-8 characters from the displayed log to avoid a crash
- The crash can be reproduced with `printf '\255' >> /var/log/messages` command
- See https://bugzilla.suse.com/show_bug.cgi?id=1110549
- Works correctly also with the ANSI color removal
- 4.0.99