### PR TITLE
Check if a service is supported from the list of current ones

### DIFF
--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -211,8 +211,6 @@ module Yast
     def InitAllowedInterfaces(services)
       service_status = {}
 
-      services.each { |s| firewalld.find_service(s) }
-
       zone_services(services).each do |_s, status|
         status.each do |iface, en|
           service_status[iface] = service_status.fetch(iface, true) && en
@@ -833,7 +831,7 @@ module Yast
         return { "widget" => :custom, "custom_widget" => not_installed_widget, "help" => "" }
       end
 
-      if services.any? { |s| !firewalld.api.service_supported?(s) }
+      if services.any? { |s| !firewalld.current_service_names.include?(s) }
         return {
           "widget"        => :custom,
           "custom_widget" => services_not_defined_widget(services),
@@ -1009,7 +1007,7 @@ module Yast
       services_status = {}
 
       services.each do |service|
-        service_supported = firewalld.api.service_supported?(service)
+        service_supported = firewalld.current_service_names.include?(service)
         services_status[service] = {}
 
         firewalld.zones.each do |zone|
@@ -1058,7 +1056,7 @@ module Yast
     def services_not_defined_widget(services)
       services_list =
         services.map do |service|
-          if !firewalld.api.service_supported?(service)
+          if !firewalld.current_service_names.include?(service)
             # TRANSLATORS: do not modify '%{service}', it will be replaced with service name.
             # TRANSLATORS: item in a list, '-' is used as marker. Feel free to change it
             HBox(HSpacing(2), Left(Label(_("- %{service} (Not available)") % { service: service })))

--- a/library/network/test/cwm_firewall_interfaces_test.rb
+++ b/library/network/test/cwm_firewall_interfaces_test.rb
@@ -11,10 +11,11 @@ describe Yast::CWMFirewallInterfaces do
   subject { Yast::CWMFirewallInterfaces }
   let(:firewalld) { Y2Firewall::Firewalld.instance }
   let(:api) { instance_double("Y2Firewall::Firewalld::Api") }
+  let(:supported_services) { [] }
 
   before do
-    allow(api).to receive(:service_supported?)
     allow(firewalld).to receive(:api).and_return(api)
+    allow(firewalld).to receive(:current_service_names).and_return(supported_services)
   end
 
   describe "#CreateOpenFirewallWidget" do
@@ -56,10 +57,6 @@ describe Yast::CWMFirewallInterfaces do
     context "when the widget settings does not contain any service" do
       let(:widget_settings) { { "services" => ["service"] } }
 
-      before do
-        allow(api).to receive(:service_supported?).with("service").and_return(false)
-      end
-
       it "returns a hash with only the 'widget', 'custom_widget' and 'help' keys" do
         allow(subject).to receive(:services_not_defined_widget).with(["service"])
           .and_return(Frame("unsupported_services_summary"))
@@ -72,7 +69,6 @@ describe Yast::CWMFirewallInterfaces do
       it "returns a summary with the unavailable services as the 'custom_widget'" do
         expect(subject).to receive(:services_not_defined_widget).with(["service"])
           .and_return(Frame("unsupported_services_summary"))
-        expect(api).to receive(:service_supported?).with("service").and_return(false)
 
         ret = subject.CreateOpenFirewallWidget(widget_settings)
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Oct 17 15:17:04 UTC 2018 - knut.anderssen@suse.com
+
+- CWMFirewallInterfaces: Improved the user UX replacing the api
+  calls for checking supported services once the list supported
+  ones are already known by the firewalld instance (fate#324662)
+- 4.0.102
+
+-------------------------------------------------------------------
 Fri Oct 12 10:28:48 CEST 2018 - schubi@suse.de
 
 - Added tags full_system_media_name and full_system_download_url

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.0.101
+Version:        4.0.102
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Since this [PR](https://github.com/yast/yast-yast2/pull/818) was merged, the `firewalld` instance already knows about the supported list of services, so, we can avoid the extra `API` calls made by the widget improving the user experience.

Example from https://github.com/SUSE/yast2-rmt/pull/34

## Before the fix
![test](https://user-images.githubusercontent.com/7056681/47099900-325bb680-d22e-11e8-97c9-d72dfa222e94.gif)

## After the fix

![test_2](https://user-images.githubusercontent.com/7056681/47099907-34be1080-d22e-11e8-975d-39f23e6b0dc2.gif)

With more services it is probably easiest to appreciate.


