### PR TITLE
Make current state methods public

### DIFF
--- a/library/network/src/modules/CWMFirewallInterfaces.rb
+++ b/library/network/src/modules/CWMFirewallInterfaces.rb
@@ -904,55 +904,6 @@ module Yast
       firewalld.modified?
     end
 
-    publish function: :InitAllowedInterfaces, type: "void (list <string>)"
-    publish function: :StoreAllowedInterfaces, type: "void (list <string>)"
-    publish function: :InterfacesInit, type: "void (map <string, any>, string)"
-    publish function: :InterfacesHandle, type: "symbol (map <string, any>, string, map)"
-    publish function: :InterfacesStore, type: "void (map <string, any>, string, map)"
-    publish function: :InterfacesValidate, type: "boolean (map <string, any>, string, map)"
-    publish function: :InterfacesInitWrapper, type: "void (string)"
-    publish function: :InterfacesHandleWrapper, type: "symbol (string, map)"
-    publish function: :InterfacesStoreWrapper, type: "void (string, map)"
-    publish function: :InterfacesValidateWrapper, type: "boolean (string, map)"
-    publish function: :CreateInterfacesWidget, type: "map <string, any> (map <string, any>)"
-    publish function: :DisplayDetailsPopup, type: "symbol (map <string, any>)"
-    publish function: :OpenFirewallInit, type: "void (map <string, any>, string)"
-    publish function: :OpenFirewallStore, type: "void (map <string, any>, string, map)"
-    publish function: :OpenFirewallHandle, type: "symbol (map <string, any>, string, map)"
-    publish function: :OpenFirewallInitWrapper, type: "void (string)"
-    publish function: :OpenFirewallStoreWrapper, type: "void (string, map)"
-    publish function: :OpenFirewallHandleWrapper, type: "symbol (string, map)"
-    publish function: :OpenFirewallModified, type: "boolean (string)"
-    publish function: :EnableOpenFirewallWidget, type: "void ()"
-    publish function: :DisableOpenFirewallWidget, type: "void ()"
-    publish function: :OpenFirewallWidgetExists, type: "boolean ()"
-    publish function: :OpenFirewallHelpTemplate, type: "string (boolean)"
-    publish function: :OpenFirewallHelp, type: "string (boolean)"
-    publish function: :CreateOpenFirewallWidget, type: "map <string, any> (map <string, any>)"
-    publish function: :Modified, type: "boolean ()"
-
-  private
-
-    # Return whether the '_cwm_open_firewall' widget exists or not logging the
-    # error in case of non-existence.
-    #
-    # @return [Boolean] true if the open firewall widget exists
-    def open_firewall_widget?
-      unless UI.WidgetExists(Id("_cwm_open_firewall"))
-        log.error("Widget _cwm_open_firewall does not exist")
-        return false
-      end
-
-      true
-    end
-
-    # Return an instance of Y2Firewall::Firewalld
-    #
-    # @return [Y2Firewall::Firewalld] a firewalld instance
-    def firewalld
-      Y2Firewall::Firewalld.instance
-    end
-
     # Return the current status of the firewall related to the interfaces
     # opened or available
     #
@@ -1001,6 +952,55 @@ module Yast
         # label
         _("No network interfaces are configured")
       end
+    end
+
+    publish function: :InitAllowedInterfaces, type: "void (list <string>)"
+    publish function: :StoreAllowedInterfaces, type: "void (list <string>)"
+    publish function: :InterfacesInit, type: "void (map <string, any>, string)"
+    publish function: :InterfacesHandle, type: "symbol (map <string, any>, string, map)"
+    publish function: :InterfacesStore, type: "void (map <string, any>, string, map)"
+    publish function: :InterfacesValidate, type: "boolean (map <string, any>, string, map)"
+    publish function: :InterfacesInitWrapper, type: "void (string)"
+    publish function: :InterfacesHandleWrapper, type: "symbol (string, map)"
+    publish function: :InterfacesStoreWrapper, type: "void (string, map)"
+    publish function: :InterfacesValidateWrapper, type: "boolean (string, map)"
+    publish function: :CreateInterfacesWidget, type: "map <string, any> (map <string, any>)"
+    publish function: :DisplayDetailsPopup, type: "symbol (map <string, any>)"
+    publish function: :OpenFirewallInit, type: "void (map <string, any>, string)"
+    publish function: :OpenFirewallStore, type: "void (map <string, any>, string, map)"
+    publish function: :OpenFirewallHandle, type: "symbol (map <string, any>, string, map)"
+    publish function: :OpenFirewallInitWrapper, type: "void (string)"
+    publish function: :OpenFirewallStoreWrapper, type: "void (string, map)"
+    publish function: :OpenFirewallHandleWrapper, type: "symbol (string, map)"
+    publish function: :OpenFirewallModified, type: "boolean (string)"
+    publish function: :EnableOpenFirewallWidget, type: "void ()"
+    publish function: :DisableOpenFirewallWidget, type: "void ()"
+    publish function: :OpenFirewallWidgetExists, type: "boolean ()"
+    publish function: :OpenFirewallHelpTemplate, type: "string (boolean)"
+    publish function: :OpenFirewallHelp, type: "string (boolean)"
+    publish function: :CreateOpenFirewallWidget, type: "map <string, any> (map <string, any>)"
+    publish function: :Modified, type: "boolean ()"
+
+  private
+
+    # Return whether the '_cwm_open_firewall' widget exists or not logging the
+    # error in case of non-existence.
+    #
+    # @return [Boolean] true if the open firewall widget exists
+    def open_firewall_widget?
+      unless UI.WidgetExists(Id("_cwm_open_firewall"))
+        log.error("Widget _cwm_open_firewall does not exist")
+        return false
+      end
+
+      true
+    end
+
+    # Return an instance of Y2Firewall::Firewalld
+    #
+    # @return [Y2Firewall::Firewalld] a firewalld instance
+    def firewalld
+      Y2Firewall::Firewalld.instance
     end
 
     def zone_services(services)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 24 12:48:18 UTC 2018 - knut.anderssen@suse.com
+
+- CWMFirewallInterfaces: make some "current state" methods public
+  needed by yast2-rmt (fate#326634)
+- 4.1.29
+
+-------------------------------------------------------------------
 Tue Oct 23 08:55:40 UTC 2018 - knut.anderssen@suse.com
 
 - Network (Firewall): Added modify_masquerade method to zones API

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.28
+Version:        4.1.29
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
yast2-rmt is extending the class for having these private methods, so why not just public them?

https://github.com/SUSE/yast2-rmt/commit/aa1f4b96b1ca96301515cf7f2d405c5eb1ce7eaa

https://github.com/yast/yast-yast2/blob/5ea19cfc81666603b1919cd05aed0aef986268eb/library/network/src/modules/CWMFirewallInterfaces.rb#L910-L955