### PR TITLE
check return value of OpenDialog to prevent crash

### DIFF
--- a/library/packages/src/modules/PackagesUI.rb
+++ b/library/packages/src/modules/PackagesUI.rb
@@ -312,7 +312,8 @@ module Yast
         widget_options
       )
 
-      raise "Opening package selector failed." if !UI.OpenDialog(
+      # exception text
+      raise _("Opening package selector failed.") if !UI.OpenDialog(
         Opt(:defaultsize),
         if !widget_options.empty?
           PackageSelector(Id(:packages), widget_options, "")

--- a/library/packages/src/modules/PackagesUI.rb
+++ b/library/packages/src/modules/PackagesUI.rb
@@ -312,7 +312,7 @@ module Yast
         widget_options
       )
 
-      UI.OpenDialog(
+      raise "Opening package selector failed." if !UI.OpenDialog(
         Opt(:defaultsize),
         if !widget_options.empty?
           PackageSelector(Id(:packages), widget_options, "")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Nov 16 14:38:31 CET 2018 - aschnell@suse.com
+
+- check return value of OpenDialog to prevent crash (bsc#1115745)
+- 4.1.34
+
+-------------------------------------------------------------------
 Tue Nov  6 14:14:04 UTC 2018 - jreidinger@suse.com
 
 - WorkflowManager: Allow system roles to live in

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.33
+Version:        4.1.34
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
For https://trello.com/c/zkLss9CU/460-tw-1115745-p3-yast2-software-management-could-not-load-plug-in-qt-pkg.