### PR TITLE
Support for FHS-compliant skelcd packages (part of fate#325482)

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -476,10 +476,10 @@ module Yast
     # @return [String] name of the control file
     def control_file_at_dir(dir)
       # Lets first try FHS compliant path for a product package (fate#325482)
-      path = ctrl_file_at("#{dir}/usr/share/installation-products")
+      path = find_control_file("#{dir}/usr/share/installation-products")
 
       # If nothing there, try FHS compliant path for a role package (bsc#1114573)
-      path ||= ctrl_file_at("#{dir}/usr/share/system-roles")
+      path ||= find_control_file("#{dir}/usr/share/system-roles")
 
       # As last resort, use the default location at /installation.xml
       path ||= File.join(dir, "installation.xml")
@@ -495,16 +495,16 @@ module Yast
     #
     # @param dir [String] directory where the control file is expected to be
     # @return [String, nil] nil if there is no control file
-    def ctrl_file_at(dir)
+    def find_control_file(dir)
       # sadly no glob escaping - https://bugs.ruby-lang.org/issues/8258
       # but as we generate directory, it should be ok
       files = Dir.glob("#{dir}/*.xml")
-      if files.size == 1
-        files.first
-      elsif files.size > 1
+
+      if files.size > 1
         log.error "more than one file in #{dir}: #{files.inspect}"
-        files.first
       end
+
+      files.first
     end
 
     # Returns requested control filename. Parameter 'name' is ignored

--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -501,7 +501,7 @@ module Yast
       files = Dir.glob("#{dir}/*.xml")
 
       if files.size > 1
-        log.error "more than one file in #{dir}: #{files.inspect}"
+        log.error "More than one XML file in #{dir}: #{files.inspect}"
       end
 
       files.first

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -398,45 +398,108 @@ describe Yast::WorkflowManager do
         allow(File).to receive(:exist?).with(/installation\.xml\z/).and_return installation_xml
       end
 
-      context "if the package contains a control file in the system-roles dir" do
-        let(:product_files) { [] }
-        let(:role_files) { ["/tmp/usr/share/system-roles/superyast.xml"] }
-        let(:installation_xml) { false }
-
-        it "returns the path of the control file" do
-          expect(subject.control_file(repo_id)).to eq "/tmp/usr/share/system-roles/superyast.xml"
-        end
-      end
-
-      context "if the package contains a control file in the installation-products dir" do
+      context "and the package contains a control file in the installation-products dir" do
         let(:product_files) { ["/tmp/usr/share/installation-products/big_deal.xml"] }
-        let(:role_files) { [] }
-        let(:installation_xml) { false }
 
-        it "returns the path of the control file" do
-          expect(subject.control_file(repo_id))
-            .to eq "/tmp/usr/share/installation-products/big_deal.xml"
+        context "and contains no control file in other locations" do
+          let(:role_files) { [] }
+          let(:installation_xml) { false }
+
+          it "returns the path of the installation-products control file" do
+            expect(subject.control_file(repo_id))
+              .to eq "/tmp/usr/share/installation-products/big_deal.xml"
+          end
+        end
+
+        context "and also contains files in the system-roles dir" do
+          let(:role_files) { ["/tmp/usr/share/system-roles/superyast.xml"] }
+          let(:installation_xml) { false }
+
+          it "returns the path of the installation-products control file" do
+            expect(subject.control_file(repo_id))
+              .to eq "/tmp/usr/share/installation-products/big_deal.xml"
+          end
+        end
+
+        context "and also contains /installation.xml" do
+          let(:role_files) { [] }
+          let(:installation_xml) { true }
+
+          it "returns the path of the installation-products control file" do
+            expect(subject.control_file(repo_id))
+              .to eq "/tmp/usr/share/installation-products/big_deal.xml"
+          end
         end
       end
 
-      context "if the package contains an installation.xml control file" do
-        let(:product_files) { [] }
+      context "and the package contains several control files in the installation-products dir" do
+        let(:product_files) do
+          [
+            "/tmp/usr/share/installation-products/big_deal.xml",
+            "/tmp/usr/share/installation-products/smaller_deal.xml"
+          ]
+        end
         let(:role_files) { [] }
         let(:installation_xml) { true }
 
-        it "returns the path of the control file" do
-          # the returned path contains "/installation.xml" at the end
-          expect(subject.control_file(repo_id)).to end_with("/installation.xml")
+        it "returns the path of one of the installation-products control files" do
+          expect(product_files).to include(subject.control_file(repo_id))
         end
       end
 
-      context "if the package contains no control file in any of the expected locations" do
+      context "and the package contains no control file in the installation-products dir" do
         let(:product_files) { [] }
-        let(:role_files) { [] }
-        let(:installation_xml) { false }
 
-        it "returns nil" do
-          expect(subject.control_file(repo_id)).to be nil
+        context "and it contains a control file in the system-roles dir" do
+          let(:role_files) { ["/tmp/usr/share/system-roles/superyast.xml"] }
+
+          context "and also contains /installation.xml" do
+            let(:installation_xml) { true }
+
+            it "returns the path of the system-roles control file" do
+              expect(subject.control_file(repo_id)).to eq "/tmp/usr/share/system-roles/superyast.xml"
+            end
+          end
+
+          context "and contains no /installation.xml" do
+            let(:installation_xml) { false }
+
+            it "returns the path of the system-roles control file" do
+              expect(subject.control_file(repo_id)).to eq "/tmp/usr/share/system-roles/superyast.xml"
+            end
+          end
+        end
+
+        context "and it contains several control files in the system-roles dir" do
+          let(:role_files) do
+            ["/tmp/usr/share/system-roles/role1.xml", "/tmp/usr/share/system-roles/role2.xml"]
+          end
+          let(:installation_xml) { true }
+
+          it "returns the path of one of the system-roles control files" do
+            expect(role_files).to include(subject.control_file(repo_id))
+          end
+        end
+
+        context "and it contains no control file in the system-roles dir either" do
+          let(:role_files) { [] }
+
+          context "but it contains an installation.xml control file" do
+            let(:installation_xml) { true }
+
+            it "returns the path of the control file" do
+              # the returned path contains "/installation.xml" at the end
+              expect(subject.control_file(repo_id)).to end_with("/installation.xml")
+            end
+          end
+
+          context "and it contains no /installation.xml" do
+            let(:installation_xml) { false }
+
+            it "returns nil" do
+              expect(subject.control_file(repo_id)).to be nil
+            end
+          end
         end
       end
     end

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -386,22 +386,59 @@ describe Yast::WorkflowManager do
       subject.control_file(repo_id)
     end
 
-    it "returns nil if the extracted package does not contain installation.xml" do
-      expect(File).to receive(:exist?).with(/installation\.xml\z/).and_return(false)
-      expect(subject.control_file(repo_id)).to be nil
-    end
+    context "if downloading and extracting worked" do
+      before do
+        allow(Dir).to receive(:glob).with(/installation-products/).and_return product_files
+        allow(Dir).to receive(:glob).with(/system-roles/).and_return role_files
 
-    it "returns the installation.xml path if the extracted package contains it" do
-      expect(File).to receive(:exist?).with(/installation.xml\z/).and_return(true)
-      # the returned path contains "/installation.xml" at the end
-      expect(subject.control_file(repo_id)).to end_with("/installation.xml")
-    end
+        allow(File).to receive(:exist?) do |name|
+          product_files.include?(name) || role_files.include?(name)
+        end
 
-    it "returns path leading to system-roles dir if it exists" do
-      allow(Dir).to receive(:glob).and_return(["/tmp/usr/share/system-roles/superyast.xml"])
-      expect(File).to receive(:exist?).with("/tmp/usr/share/system-roles/superyast.xml").and_return(true)
+        allow(File).to receive(:exist?).with(/installation\.xml\z/).and_return installation_xml
+      end
 
-      expect(subject.control_file(repo_id)).to eq "/tmp/usr/share/system-roles/superyast.xml"
+      context "if the package contains a control file in the system-roles dir" do
+        let(:product_files) { [] }
+        let(:role_files) { ["/tmp/usr/share/system-roles/superyast.xml"] }
+        let(:installation_xml) { false }
+
+        it "returns the path of the control file" do
+          expect(subject.control_file(repo_id)).to eq "/tmp/usr/share/system-roles/superyast.xml"
+        end
+      end
+
+      context "if the package contains a control file in the installation-products dir" do
+        let(:product_files) { ["/tmp/usr/share/installation-products/big_deal.xml"] }
+        let(:role_files) { [] }
+        let(:installation_xml) { false }
+
+        it "returns the path of the control file" do
+          expect(subject.control_file(repo_id))
+            .to eq "/tmp/usr/share/installation-products/big_deal.xml"
+        end
+      end
+
+      context "if the package contains an installation.xml control file" do
+        let(:product_files) { [] }
+        let(:role_files) { [] }
+        let(:installation_xml) { true }
+
+        it "returns the path of the control file" do
+          # the returned path contains "/installation.xml" at the end
+          expect(subject.control_file(repo_id)).to end_with("/installation.xml")
+        end
+      end
+
+      context "if the package contains no control file in any of the expected locations" do
+        let(:product_files) { [] }
+        let(:role_files) { [] }
+        let(:installation_xml) { false }
+
+        it "returns nil" do
+          expect(subject.control_file(repo_id)).to be nil
+        end
+      end
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 17 07:23:47 UTC 2018 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- WorkflowManager: find product definitions located at
+  /usr/share/installation-products/ (part of fate#325482)
+- 4.1.41
+
+-------------------------------------------------------------------
 Wed Dec 12 15:36:34 UTC 2018 - schubi@suse.de
 
 - Added more testcases if e.g. system is running in chroot

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.40
+Version:        4.1.41
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
> See https://trello.com/c/piNC0YZM/529-part-of-fate-325482-make-installationxml-files-fhs-compliant

This is simple a recreation of PR#874 fixing the version number without a merge commit :innocent: 