### PR TITLE
avoid use of shellescape function on non string types (bsc#1119678)

### DIFF
--- a/library/systemd/src/lib/yast2/systemctl.rb
+++ b/library/systemd/src/lib/yast2/systemctl.rb
@@ -83,14 +83,14 @@ module Yast2
 
       def list_unit_files(type: nil)
         command = " list-unit-files "
-        command << " --type=#{type.shellescape} " if type
+        command << " --type=#{type.to_s.shellescape} " if type
         execute(command).stdout
       end
 
       def list_units(type: nil, all: true)
         command = " list-units "
         command << " --all " if all
-        command << " --type=#{type.shellescape} " if type
+        command << " --type=#{type.to_s.shellescape} " if type
         execute(command).stdout
       end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 18 10:42:10 CET 2018 - aschnell@suse.com
+
+- avoid use of shellescape function on non string types
+  (bsc#1119678)
+- 4.1.43
+
+-------------------------------------------------------------------
 Mon Dec 17 08:09:10 UTC 2018 - jlopez@suse.com
 
 - Extend Yast::Execute API (needed for bsc#1118291)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.42
+Version:        4.1.43
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Manually tested (yast2 clone_system does not show an error popup anymore).