### PR TITLE
Add configuration_management section to control file

### DIFF
--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -305,7 +305,7 @@ module Yast
       @system_roles = @productControl.fetch(SYSTEM_ROLES_KEY, [])
 
       Builtins.foreach(
-        ["software", "globals", "network", "partitioning", "texts"]
+        ["software", "globals", "network", "partitioning", "texts", "configuration_management"]
       ) do |section|
         if Builtins.haskey(@productControl, section)
           ProductFeatures.SetSection(

--- a/library/control/src/modules/ProductFeatures.rb
+++ b/library/control/src/modules/ProductFeatures.rb
@@ -49,7 +49,7 @@ module Yast
       # Default values for features
       # two-level map, section_name -> [ feature -> value ]
       @defaults = {
-        "globals"      => {
+        "globals"                  => {
           "incomplete_translation_treshold" => "95",
           "ui_mode"                         => "expert",
           "enable_autologin"                => true,
@@ -76,12 +76,12 @@ module Yast
           "full_system_download_url"        => "",
           "save_y2logs"                     => true
         },
-        "partitioning" => {
+        "partitioning"             => {
           "use_flexible_partitioning"    => false,
           "flexible_partitioning"        => {},
           "vm_keep_unpartitioned_region" => false
         },
-        "software"     => {
+        "software"                 => {
           "software_proposal"                    => "selection",
           "selection_type"                       => :auto,
           "delete_old_packages"                  => true,
@@ -93,7 +93,8 @@ module Yast
           "addon_selections"                     => [],
           "inform_about_suboptimal_distribution" => false
         },
-        "network"      => { "force_static_ip" => false }
+        "network"                  => { "force_static_ip" => false },
+        "configuration_management" => {}
       }
     end
 

--- a/library/control/src/modules/ProductFeatures.rb
+++ b/library/control/src/modules/ProductFeatures.rb
@@ -94,6 +94,8 @@ module Yast
           "inform_about_suboptimal_distribution" => false
         },
         "network"                  => { "force_static_ip" => false },
+        # Defaults are defined in the ConfigurationManagement::Configurations classes:
+        # https://github.com/yast/yast-configuration-management/blob/27c93ba9d592271a299706aca323d9d371d44058/src/lib/configuration_management/configurations/base.rb#L13
         "configuration_management" => {}
       }
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 18 11:21:31 UTC 2018 - igonzalezsosa@suse.com
+
+- Add a <configuration_management/> section to the control file
+  (fate#322722).
+- 4.1.44
+
+-------------------------------------------------------------------
 Tue Dec 18 10:42:10 CET 2018 - aschnell@suse.com
 
 - avoid use of shellescape function on non string types

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.43
+Version:        4.1.44
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Add a `configuration_management` to the control file. Related to https://github.com/yast/yast-installation-control/pull/76.
https://fate.suse.com/322722