### PR TITLE
Add missing help text for ServiceWidget

### DIFF
--- a/library/cwm/src/lib/cwm/service_widget.rb
+++ b/library/cwm/src/lib/cwm/service_widget.rb
@@ -56,5 +56,9 @@ module CWM
     def init
       refresh
     end
+
+    def help
+      @service_widget.help
+    end
   end
 end

--- a/library/systemd/src/lib/yast2/service_widget.rb
+++ b/library/systemd/src/lib/yast2/service_widget.rb
@@ -124,6 +124,34 @@ module Yast2
       store_autostart
     end
 
+    # Returns the service widget help text
+    #
+    # @return [String]
+    def help
+      helptext = "<h2>Service configuration</h2>"
+      # TRANSLATORS: helptext for the service current status
+      helptext << _(
+        "<h3>Current status</h3>" \
+        "Displays the curren status of the service."
+      )
+
+      # TRANSLATORS: helptext for the "After writting configuration" service widget option
+      helptext << _(
+        "<h3>After writing configuration</h3>" \
+        "Allow to change the service status immediately after accepting the changes. Available
+        options depend on the current state. The <b>Keep current state</b> special action leaves the
+        service state untouched."
+      )
+
+      # TRANSLATORS: helptext for the "After reboot" service widget option
+      helptext << _(
+        "<h3>After reboot</h3>" \
+        "Let choose if service should be started automatically on boot. Some services could be
+        configured <b>on demand</b>, which means that the associated socket will be running and
+        start the service if needed."
+      )
+    end
+
   private
 
     attr_reader :service

--- a/library/systemd/test/yast2/service_widget_test.rb
+++ b/library/systemd/test/yast2/service_widget_test.rb
@@ -181,4 +181,18 @@ describe Yast2::ServiceWidget do
       subject.store
     end
   end
+
+  describe "#help" do
+    it "returns help for the current status" do
+      expect(subject.help).to match(/Current status/)
+    end
+
+    it "returns help for actions after write settings" do
+      expect(subject.help).to include("After writing configuration", "Keep current state")
+    end
+
+    it "returns help for action on reboot" do
+      expect(subject.help).to include("After reboot", "on demand")
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Dec 28 15:43:49 UTC 2018 - dgonzalez@suse.com
+
+- Add missing help for the service configuration
+
+-------------------------------------------------------------------
 Wed Dec 19 12:15:33 UTC 2018 - jreidinger@suse.com
 
 - NetworkService: fix invoking forced enable (bsc#1119657)


### PR DESCRIPTION
At the time to continue the work (yast/yast-firewall#109) started by @teclator in the yast-firewall module, I realized that the ServiceWidget has not a help text defined yet. In fact, none of modules that already use the new ServiceWidget shows any related help.

That's the reason why I am proposing to add a generic text, vía the `help` widget method, to all of them.
