### PR TITLE
Ignore the old release notes packages (bsc#1112866)

### DIFF
--- a/library/packages/test/y2packager/release_notes_fetchers/rpm_test.rb
+++ b/library/packages/test/y2packager/release_notes_fetchers/rpm_test.rb
@@ -11,7 +11,10 @@ describe Y2Packager::ReleaseNotesFetchers::Rpm do
   let(:package) { Y2Packager::Package.new("release-notes-dummy", 2, "15.1") }
   let(:dependencies) do
     [
-      { "deps" => [{ "provides" => "release-notes() = dummy" }] }
+      {
+        "status" => :selected,
+        "deps"   => [{ "provides" => "release-notes() = dummy" }]
+      }
     ]
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan  7 08:40:21 UTC 2019 - lslezak@suse.cz
+
+- Ignore the old packages when fetching the release notes
+  (bsc#1112866)
+- 4.1.48
+
+-------------------------------------------------------------------
 Thu Jan  3 12:51:47 UTC 2019 - dgonzalez@suse.com
 
 - Fix a fragile unit test (related to changes introduced

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.47
+Version:        4.1.48
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1112866
- The `y2log` did not tell much and  I could not reproduce the problem locally, the release notes were displayed properly. :worried:
- But when checking the code I found a potential issue, the old installed package does not provide the `release-notes` tag so in theory when using the installed package as the first found it would not match.
  Running the code in the debugger found these dependencies:
  ```
  [
    {"provides"=>"release-notes-sles = 12.3.20170706-1.2"},
    {"requires"=>"dejavu-fonts"},
    {"requires"=>"google-opensans-fonts"},
    {"requires"=>"rpmlib(CompressedFileNames) <= 3.0.4-1"},
    {"requires"=>"rpmlib(PayloadFilesHavePrefix) <= 4.0-1"},
    {"requires"=>"rpmlib(PayloadIsLzma) <= 4.4.6-1"}
  ],
  [
    {"provides"=>"release-notes() = SLES"},
    {"provides"=>"release-notes-sles = 15.1.20180918-3.7.53"},
    {"requires"=>"dejavu-fonts"},
    {"requires"=>"google-opensans-fonts"}
  ],
  [
    {"provides"=>"release-notes() = SLES"},
    {"provides"=>"release-notes-sles = 15.1.20180918-3.7.53"},
    {"requires"=>"dejavu-fonts"},
    {"requires"=>"google-opensans-fonts"}
    ]
  ]
  ```
  So using the first package would not work properly.
- Also improved the regexp matching:
  - Check also the beginning of the line
  - Escape the product name (in theory the product name might contain some special regexp. charters like `.()[]`, these need to be escaped)
- Added more logging to get more details if this still does not help
- 4.1.48