### PR TITLE
Date and time widgets

### DIFF
--- a/library/cwm/examples/date_time.rb
+++ b/library/cwm/examples/date_time.rb
@@ -1,0 +1,69 @@
+# Simple example to demonstrate object API for CWM
+
+require_relative "example_helper"
+
+require "cwm"
+require "cwm/popup"
+
+Yast.import "CWM"
+
+class Name < CWM::InputField
+  def initialize
+    textdomain "example"
+  end
+
+  def label
+    _("Name")
+  end
+end
+
+class EventDate < CWM::DateField
+  def initialize
+    textdomain "example"
+  end
+
+  def init
+    self.value = Time.now.strftime("%Y-%m-%d")
+  end
+
+  def label
+    _("Event date")
+  end
+end
+
+class EventTime < CWM::TimeField
+  def initialize
+    textdomain "example"
+  end
+
+  def init
+    self.value = Time.now.strftime("%H:%M:%S")
+  end
+
+  def label
+    _("Event time")
+  end
+end
+
+class Event < ::CWM::Popup
+  def initialize
+    textdomain "example"
+  end
+
+  def contents
+    VBox(
+      Name.new,
+      HBox(
+        EventDate.new,
+        HSpacing(1),
+        EventTime.new
+      )
+    )
+  end
+
+  def title
+    _("Event Example")
+  end
+end
+
+Event.new.run

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -366,4 +366,22 @@ module CWM
 
     include ValueBasedWidget
   end
+
+  # Time field widget
+  # The {#label} method is mandatory.
+  class TimeField < AbstractWidget
+    self.widget_type = :time_field
+
+    include ValueBasedWidget
+    abstract_method :label
+  end
+
+  # Date field widget
+  # The {#label} method is mandatory.
+  class DateField < AbstractWidget
+    self.widget_type = :date_field
+
+    include ValueBasedWidget
+    abstract_method :label
+  end
 end

--- a/library/cwm/src/lib/cwm/rspec.rb
+++ b/library/cwm/src/lib/cwm/rspec.rb
@@ -153,6 +153,16 @@ RSpec.shared_examples "CWM::IntField" do
   include_examples "CWM::ValueBasedWidget"
 end
 
+RSpec.shared_examples "CWM::DateField" do
+  include_examples "CWM::AbstractWidget"
+  include_examples "CWM::ValueBasedWidget"
+end
+
+RSpec.shared_examples "CWM::TimeField" do
+  include_examples "CWM::AbstractWidget"
+  include_examples "CWM::ValueBasedWidget"
+end
+
 RSpec.shared_examples "CWM::Table" do
   include_examples "CWM::AbstractWidget"
 

--- a/library/cwm/src/modules/CWM.rb
+++ b/library/cwm/src/modules/CWM.rb
@@ -616,6 +616,10 @@ module Yast
           Ops.set(w, "widget", MultiLineEdit(id_term, opt_term, label))
         elsif widget == :richtext
           Ops.set(w, "widget", RichText(id_term, opt_term, ""))
+        elsif widget == :date_field
+          Ops.set(w, "widget", DateField(id_term, opt_term, label))
+        elsif widget == :time_field
+          Ops.set(w, "widget", TimeField(id_term, opt_term, label))
         end
       end
       Ops.set(w, "custom_widget", nil) # not needed any more

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,9 +1,15 @@
 -------------------------------------------------------------------
+Thu Jan 17 00:55:03 UTC 2019 - knut.anderssen@suse.com
+
+- CWM: Added date field and time field widgets (fate#322722)
+- 4.1.53
+
+-------------------------------------------------------------------
 Wed Jan 16 16:52:19 CET 2019 - schubi@suse.de
 
 - Support special products which will be enabled via linuxrc
   (flag "specialproduct") (fate#327099)
-- 4.1.52  
+- 4.1.52
 
 -------------------------------------------------------------------
 Wed Jan 16 13:03:59 UTC 2019 - jreidinger@suse.com

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.52
+Version:        4.1.53
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Trello Card: https://trello.com/c/DS4ULBxR/541-finish-implementation-of-input-widgets

This PR adds CWM widgets for `Date` and `Time` fields.

**Note:** It seems that both are now supported in ncurses and this [check](https://github.com/yast/yast-journal/blob/66f6eebee05903264b9893193a0cf574c4541694/src/lib/y2journal/time_helpers.rb#L57) is not needed probably [since](https://github.com/libyui/libyui-ncurses/commit/e1d3e8043130c64ca2217622f607ff274ab81eb6)

## Example screenshot (Y2STYLE=installation.qss)
<p align="center">
  <img src="https://user-images.githubusercontent.com/7056681/51305867-e9d1b600-1a33-11e9-82dd-1440587b2776.png">
</p>

## Ncurses example screenshot
![dateandtimefieldsncurses](https://user-images.githubusercontent.com/7056681/51305798-c0b12580-1a33-11e9-92bc-88c4e5de09fd.png)