### PR TITLE
fix broken yast module startup (bsc#1122473)

### DIFF
--- a/scripts/yast2
+++ b/scripts/yast2
@@ -295,8 +295,10 @@ if [ -n "$CMDLINE_HELP" ]; then
 fi
 ARGS=( )
 for i in "$@"; do
-  ARGS+=( "--arg" )
-  ARGS+=( "$i" )
+  if [ -n "$i" ] ; then
+    ARGS+=( "--arg" )
+    ARGS+=( "$i" )
+  fi
 done
 set -- "${ARGS[@]}"
 


### PR DESCRIPTION
For some reason the constructed command line from the ncurses control center
looks like this:
> y2start bootloader --arg ncurses -name YaST2 -icon yast

with an superfluous '--arg'. I've no idea where that comes from but
the check in this patch is a safe-guard against this anyway.