### PR TITLE
save_y2logs: save kernel messages and udev log (bsc#1089647, bsc#1085…

### DIFF
--- a/scripts/save_y2logs
+++ b/scripts/save_y2logs
@@ -118,6 +118,7 @@ VAR_LOG_FILES='\
   zypper.log zypp/history* pk_backend_zypp \
   pbl.log linuxrc.log wickedd.log \
   evms-engine.* \
+  boot.msg messages udev.log \
 '
 cd /var/log
 for i in $VAR_LOG_FILES ; do


### PR DESCRIPTION
…212)

Kernel messages can show up in /var/log/boot.msg (linuxrc redirects there) and
/var/log/messages (syslog).

Since bsc#1085212 linuxrc can run udev in debug mode. In this case udev logs
into /var/log/udev.log.