### PR TITLE
Interface zone mapping improvements

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/interface.rb
+++ b/library/network/src/lib/y2firewall/firewalld/interface.rb
@@ -96,6 +96,15 @@ module Y2Firewall
         fw.zones.find { |z| z.interfaces.include?(name) }
       end
 
+      # Assign the interface to the given zone
+      #
+      # @param zone_name [String] the name of the zone to be assigned to
+      def zone=(zone_name)
+        fw.zones.map { |z| z.remove_interface(name) if z.interfaces.include?(name) }
+        z = fw.find_zone(zone_name)
+        z && z.add_interface(name)
+      end
+
     private
 
       # Return an instance of Y2Firewall::Firewalld

--- a/library/network/src/lib/y2firewall/firewalld/interface.rb
+++ b/library/network/src/lib/y2firewall/firewalld/interface.rb
@@ -100,7 +100,7 @@ module Y2Firewall
       #
       # @param zone_name [String] the name of the zone to be assigned to
       def zone=(zone_name)
-        fw.zones.map { |z| z.remove_interface(name) if z.interfaces.include?(name) }
+        fw.zones.each { |z| z.remove_interface(name) if z.interfaces.include?(name) }
         z = fw.find_zone(zone_name)
         z && z.add_interface(name)
       end

--- a/library/network/src/lib/y2firewall/firewalld/zone.rb
+++ b/library/network/src/lib/y2firewall/firewalld/zone.rb
@@ -136,6 +136,15 @@ module Y2Firewall
         api.change_interface(name, interface)
       end
 
+      # Assign the interface to the zone removing it previously from any other
+      # zone that was including it.
+      #
+      # @param interface [String] interface name
+      def change_interface(interface)
+        firewalld.zones.each { |z| z.remove_interface(interface) }
+        add_interface(interface)
+      end
+
     private
 
       # Convenience method which return an instance of Y2Firewall::Firewalld

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -865,7 +865,6 @@ module Yast
               # TODO : delete PREFIXLEN from config file
             end
           end
-          devmap["ZONE"] = nil if devmap["ZONE"] && devmap["ZONE"].empty?
           # write all keys to config
           Builtins.maplist(
             Convert.convert(

--- a/library/network/test/y2firewall/firewalld/interface_test.rb
+++ b/library/network/test/y2firewall/firewalld/interface_test.rb
@@ -123,4 +123,27 @@ describe Y2Firewall::Firewalld::Interface do
       end
     end
   end
+
+  describe "#zone=" do
+    let(:public_zone) { Y2Firewall::Firewalld::Zone.new(name: "public") }
+    let(:dmz_zone) { Y2Firewall::Firewalld::Zone.new(name: "dmz") }
+
+    before do
+      allow(Y2Firewall::Firewalld.instance).to receive(:zones)
+        .and_return([public_zone, dmz_zone])
+      public_zone.interfaces = ["eth1"]
+      dmz_zone.interfaces = ["eth0"]
+    end
+
+    it "removes the interface from the zones that include the interface" do
+      iface.zone = "public"
+      expect(dmz_zone.interfaces).to be_empty
+    end
+
+    it "adds the interface to the given zone" do
+      expect(public_zone.interfaces).to_not include("eth0")
+      iface.zone = "public"
+      expect(public_zone.interfaces).to include("eth0")
+    end
+  end
 end

--- a/library/network/test/y2firewall/firewalld/zone_test.rb
+++ b/library/network/test/y2firewall/firewalld/zone_test.rb
@@ -178,4 +178,26 @@ describe Y2Firewall::Firewalld::Zone do
       end
     end
   end
+
+  describe "#change_interface" do
+    subject { described_class.new(name: "test") }
+    let(:public_zone) { Y2Firewall::Firewalld::Zone.new(name: "public") }
+    let(:dmz_zone) { Y2Firewall::Firewalld::Zone.new(name: "dmz") }
+
+    before do
+      allow(firewalld).to receive(:zones).and_return([public_zone, dmz_zone, subject])
+      public_zone.interfaces = ["eth1 bond0"]
+      dmz_zone.interfaces = ["eth0"]
+    end
+
+    it "removes the given interface from other zones" do
+      subject.change_interface("eth0")
+      expect(dmz_zone.interfaces).to be_empty
+    end
+
+    it "adds the given interface to this zone" do
+      subject.change_interface("eth0")
+      expect(subject.interfaces).to include("eth0")
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  7 10:01:59 UTC 2019 - knut.anderssen@suse.com
+
+- Firewall: added some help methods for moving interfaces between
+  zones in a safe way (fate#324662).
+- 4.1.54
+
+-------------------------------------------------------------------
 Thu Jan 17 00:55:03 UTC 2019 - knut.anderssen@suse.com
 
 - CWM: Added date field and time field widgets (fate#322722)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.53
+Version:        4.1.54
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Do not delete the **ZONE** attribute when empty ("default zone")
- Added methods to `Interface` and `Zone` for changing the current map.