### PR TITLE
Fixed evaluating release notes

### DIFF
--- a/library/commandline/test/commandline_test.rb
+++ b/library/commandline/test/commandline_test.rb
@@ -15,6 +15,10 @@ describe Yast::CommandLine do
     Yast::Mode.SetUI(orig_ui)
   end
 
+  before do
+    allow(Yast::Debugger).to receive(:installed?).and_return(false)
+  end
+
   it "invokes initialize, handler and finish" do
     expect(STDOUT).to receive(:puts).with("Initialize called").ordered
     expect(STDOUT).to receive(:puts).with("something").ordered

--- a/library/network/test/firewalld_wrapper_test.rb
+++ b/library/network/test/firewalld_wrapper_test.rb
@@ -15,6 +15,7 @@ describe Yast::FirewalldWrapper do
     allow(subject).to receive(:firewalld).and_return(firewalld)
     allow(firewalld).to receive(:zones).and_return(zones)
     allow(firewalld).to receive(:installed?).and_return(true)
+    allow(Yast::NetworkInterfaces).to receive(:List).with("").and_return([])
     external.interfaces = ["eth0"]
     external.services = ["dhcp"]
   end

--- a/library/packages/src/lib/y2packager/release_notes_fetchers/rpm.rb
+++ b/library/packages/src/lib/y2packager/release_notes_fetchers/rpm.rb
@@ -174,9 +174,15 @@ module Y2Packager
         langs << prefs.user_lang.split("_", 2).first if prefs.user_lang.include?("_")
         langs << prefs.fallback_lang
 
-        path = Dir.glob(
-          File.join(directory, "**", "RELEASE-NOTES.{#{langs.join(",")}}.#{prefs.format}")
-        ).first
+        path = nil
+        langs.any? do |lang|
+          path = Dir.glob(
+            File.join(directory, "**", "RELEASE-NOTES.#{lang}.#{prefs.format}")
+          ).first
+
+          !path.nil?
+        end
+
         return nil if path.nil?
         [path, path[/RELEASE-NOTES\.(.+)\.#{prefs.format}\z/, 1]] if path
       end

--- a/library/packages/src/lib/y2packager/release_notes_fetchers/rpm.rb
+++ b/library/packages/src/lib/y2packager/release_notes_fetchers/rpm.rb
@@ -175,12 +175,12 @@ module Y2Packager
         langs << prefs.fallback_lang
 
         path = nil
-        langs.any? do |lang|
+        langs.each do |lang|
           path = Dir.glob(
             File.join(directory, "**", "RELEASE-NOTES.#{lang}.#{prefs.format}")
           ).first
 
-          !path.nil?
+          break unless path.nil?
         end
 
         return nil if path.nil?

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 18 07:47:37 UTC 2019 - lslezak@suse.cz
+
+- Fixed license file ordering issue causing a random test failure
+  (gh#yast-yast2#895)
+- 4.1.55
+
+-------------------------------------------------------------------
 Thu Feb  7 10:01:59 UTC 2019 - knut.anderssen@suse.com
 
 - Firewall: added some help methods for moving interfaces between

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,7 +2,7 @@
 Mon Feb 18 07:47:37 UTC 2019 - lslezak@suse.cz
 
 - Fixed license file ordering issue causing a random test failure
-  (gh#yast-yast2#895)
+  (bsc#1125722)
 - 4.1.55
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.54
+Version:        4.1.55
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- The `./y2packager/release_notes_fetchers/rpm_test.rb` unit test randomly failed in OBS (see #895).

From a debugging session:

```
(byebug) p = File.join(directory, "**", "RELEASE-NOTES.{#{langs.join(",")}}.#{prefs.format}")
"/tmp/d20190215-22316-ra8tss/**/RELEASE-NOTES.{de_DE,de,en}.txt"
(byebug) Dir.glob(p)
["/tmp/d20190215-22316-ra8tss/usr/share/doc/release-notes/dummy/RELEASE-NOTES.en.txt",
"/tmp/d20190215-22316-ra8tss/usr/share/doc/release-notes/dummy/RELEASE-NOTES.de.txt"]
```

So the glob for the `RELEASE-NOTES.{de_DE,de,en}.txt` files returns `"RELEASE-NOTES.en.txt", "RELEASE-NOTES.de.txt"` files (in this order!). So the order of the files might be different than in the input glob, the code does not expect this and uses the first one (via `.first`).

## Additional Problems

- The commandline tests always failed for me when running locally, however it was fine in Travis, Jenkins or OBS so I ignored that. This time I checked the details and the problem is that locally I have installed the byebug debugger. The test raises some exception and expect to print something in the exception handler. However when the debugger is installed YaST displays a popup asking to start the debugger. (In the test mode there is just dummy UI so in reality nothing is displayed in the end.)

- The firewall test failed when started via `rake test:unit` by passed when started via `rspec ./library/network/test/firewalld_wrapper_test.rb`. It turned out that when running in full test the `Yast::NetworkInterfaces.List` method returns some known interfaces, when running standalone the result is empty list.