### PR TITLE
Fixed command line error reporting, fixed testsuite

### DIFF
--- a/library/commandline/test/commandline_test.rb
+++ b/library/commandline/test/commandline_test.rb
@@ -19,18 +19,22 @@ describe Yast::CommandLine do
     allow(Yast::Debugger).to receive(:installed?).and_return(false)
   end
 
+  # NOTE: when using the byebug debugger here temporarily comment out
+  # all "expect($stdout)" lines otherwise the byebug output will be
+  # lost in the rspec mocks and you won't see anything.
+
   it "invokes initialize, handler and finish" do
-    expect(STDOUT).to receive(:puts).with("Initialize called").ordered
-    expect(STDOUT).to receive(:puts).with("something").ordered
-    expect(STDOUT).to receive(:puts).with("Finish called").ordered
+    expect($stdout).to receive(:puts).with("Initialize called").ordered
+    expect($stdout).to receive(:puts).with("something").ordered
+    expect($stdout).to receive(:puts).with("Finish called").ordered
 
     Yast::WFM.CallFunction("dummy_cmdline", ["echo", "text=something"])
   end
 
   it "displays errors and aborts" do
-    expect(STDOUT).to receive(:puts).with("Initialize called").ordered
+    expect($stdout).to receive(:puts).with("Initialize called").ordered
     expect(Yast::CommandLine).to receive(:Print).with(/I crashed/).ordered
-    expect(STDOUT).to_not receive(:puts).with("Finish called")
+    expect($stdout).to_not receive(:puts).with("Finish called")
 
     Yast::WFM.CallFunction("dummy_cmdline", ["crash"])
   end

--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -605,7 +605,9 @@ module Yast
       Builtins.y2error(1, "%1", error_string) if @log_errors
 
       if @display_errors
-        if Ops.greater_than(@timeout_errors, 0)
+        if Mode.commandline
+          CommandLine.Print "Error: #{error_string}"
+        elsif Ops.greater_than(@timeout_errors, 0)
           Popup.TimedLongErrorGeometry(error_string, @timeout_errors, width, height)
         else
           Popup.LongErrorGeometry(error_string, width, height)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar  5 08:00:03 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed a failing testsuite, the Report.LongError used in the
+  global exception handler did not support the command line mode
+  (related to bnc#1127685)
+- 4.1.58
+
+-------------------------------------------------------------------
 Mon Mar  4 09:02:22 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1127685 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.57
+Version:        4.1.58
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- It is related to this change: https://github.com/yast/yast-ruby-bindings/pull/227
- It turned out that the `Report.LongError` call did not support the command line mode (as the `Report.Error` does), so after changing that in the global exception handler the popup was displayed even in the command line mode.
- Added a debugging hint into `commandline_test.rb`, running `byebug` is a bit tricky there.
- Switched from `STDOUT` (the default stdout stream) to `$stdout` (the current stdout stream) (Just a minor thing, but it would handle possible stdout redirection better.)