### PR TITLE
Fixed removing product duplicates (bsc#1128459)

### DIFF
--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -148,8 +148,9 @@ module Y2Packager
 
       # remove duplicates, there migth be different flavors ("DVD"/"POOL")
       # or archs (x86_64/i586), when selecting the product to install later
-      # libzypp will select the correct arch automatically
-      products.uniq! { |p| "#{p["name"]}__#{p["version"]}" }
+      # libzypp will select the correct arch automatically,
+      # keep products with different state, they are filtered out later
+      products.uniq! { |p| "#{p["name"]}__#{p["version"]}__#{p["status"]}" }
       log.info "Found products: #{products.map { |p| p["name"] }}"
 
       products

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 12 08:38:32 UTC 2019 - lslezak@suse.cz
+
+- Fixed product filtering in product_reader.rb, fixes problem
+  when upgrading SLE15-SP1 to SLE15-SP1 (usually used to fix
+  a broken system) (bsc#1128459)
+- 4.1.62
+
+-------------------------------------------------------------------
 Fri Mar  8 08:15:47 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1127798

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.61
+Version:        4.1.62
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- Upgrading SLE15-SP1 to SLE15-SP1 does not work, "No product to upgrade found"
- https://bugzilla.suse.com/show_bug.cgi?id=1128459

## Solution

- Do not remove products with different status, they are filtered later when querying the installed or available products

## Tests

- Added unit test
- Tested manually