### PR TITLE
Process the "specialproduct" value like a linuxrc parameter (bsc#1128901)

### DIFF
--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -67,7 +67,7 @@ module Y2Packager
     # @return [Array<Product>] Available products
     def all_products
       linuxrc_special_products = if Yast::Linuxrc.InstallInf("specialproduct")
-        Yast::Linuxrc.InstallInf("specialproduct").split(",")
+        linuxrc_string(Yast::Linuxrc.InstallInf("specialproduct")).split(",")
       else
         []
       end
@@ -78,7 +78,7 @@ module Y2Packager
         if prod_pkg
           # remove special products if they have not been defined in linuxrc
           prod_pkg["deps"].find { |dep| dep["provides"] =~ /\Aspecialproduct\(\s*(.*?)\s*\)\z/ }
-          special_product_tag = Regexp.last_match[1] if Regexp.last_match
+          special_product_tag = linuxrc_string(Regexp.last_match[1]) if Regexp.last_match
           if special_product_tag && !linuxrc_special_products.include?(special_product_tag)
             log.info "Special product #{prod["name"]} has not been defined via linuxrc. --> do not offer it"
             next
@@ -186,6 +186,20 @@ module Y2Packager
 
     def installation_package_mapping
       @installation_package_mapping ||= self.class.installation_package_mapping
+    end
+
+    # Process the string in a linuxrc way: remove the "-", "_", "." characters,
+    # convert it to downcase for case insensitive comparison.
+    #
+    # @param input [String] the input string
+    #
+    # @return [String] the processed string
+    #
+    def linuxrc_string(input)
+      return nil if input.nil?
+
+      ret = input.gsub(/[-_.]/, "")
+      ret.downcase
     end
   end
 end

--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -138,6 +138,31 @@ describe Y2Packager::ProductReader do
       expect(subject.all_products.size).to eq(2)
     end
 
+    it "ignores case of the linuxrc specialproduct parameter" do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("specialproduct").and_return("sles_bcl")
+      expect(subject.all_products.size).to eq(2)
+    end
+
+    it "ignores underscores in the linuxrc specialproduct parameter" do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("specialproduct").and_return("sles_b_c_l")
+      expect(subject.all_products.size).to eq(2)
+    end
+
+    it "ignores underscores in the product name" do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("specialproduct").and_return("SLESBCL")
+      expect(subject.all_products.size).to eq(2)
+    end
+
+    it "ignores dashes in the linuxrc specialproduct parameter" do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("specialproduct").and_return("sles-b-c-l")
+      expect(subject.all_products.size).to eq(2)
+    end
+
+    it "ignores dots in the linuxrc specialproduct parameter" do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("specialproduct").and_return("sles.b.c.l")
+      expect(subject.all_products.size).to eq(2)
+    end
+
     it "returns the available product also when an installed product is found" do
       installed = products.first.dup
       installed["status"] = :installed

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar 13 15:34:17 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
+
+- Process the "specialproduct" value like a linuxrc parameter
+  (ignore "-_." characters, ignore case) (bsc#1128901)
+- 4.1.64
+
+-------------------------------------------------------------------
 Wed Mar 13 09:02:12 UTC 2019 - David Díaz <dgonzalez@suse.com>
 
 - Fix how a product features is read in a running system.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.63
+Version:        4.1.64
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1128901
- Ignore the "-_." characters, ignore case (like in https://en.opensuse.org/SDB:Linuxrc#Passing_parameters)
- 4.1.64