### PR TITLE
Fixed evaluating the base product (bsc#1129257)

### DIFF
--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -175,5 +175,18 @@ describe Y2Packager::ProductReader do
 
       expect(subject.all_products).to_not be_empty
     end
+
+    it "treats the selected and available products as duplicates even with different arch" do
+      selected = products.first.dup
+      selected["status"] = :selected
+      available = products.first.dup
+      available["status"] = :available
+      available["arch"] = "i586"
+
+      allow(Yast::Pkg).to receive(:ResolvableProperties).with("", :product, "")
+        .and_return([selected, available])
+
+      expect(subject.all_products.size).to eq(1)
+    end
   end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Mar 14 15:36:31 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
+
+- Fixed evaluating the base product, the same products with
+  the available and selected status must be treated as duplicate
+  products (bsc#1129257)
+- 4.1.65
+
+-------------------------------------------------------------------
 Wed Mar 13 15:34:17 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
 
 - Process the "specialproduct" value like a linuxrc parameter

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.64
+Version:        4.1.65
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- The same products with the available and selected status must be treated as duplicate products.
- Fixes duplicate "Tumbleweed" products offered to install
- Related to the previous fix #908 
- https://bugzilla.suse.com/show_bug.cgi?id=1129257
- 4.1.65

## Details

- There are two TW products, one with the `i586` arch and one with the `x86_64` arch. These are considered as duplicates at the beginning. (The libzypp will select the correct architecture automatically when selecting the product, we can ignore it.)
- But after selecting the `x86_64` product to installation the previous change (#908) caused that because of the different status they are not considered as duplicates anymore.
- The fix is to consider the `selected` and `available` states as the same. Similarly for `installed` and `removed`.