### PR TITLE
Require `tar` for yast2 logs

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar 19 09:02:12 UTC 2019 - David Díaz <dgonzalez@suse.com>
+
+- Require tar as a dependency for yast2-logs
+- 4.1.66
+
+-------------------------------------------------------------------
 Thu Mar 14 15:36:31 UTC 2019 - Ladislav Slezak <lslezak@suse.cz>
 
 - Fixed evaluating the base product, the same products with

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.65
+Version:        4.1.66
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -219,6 +219,8 @@ Group:          System/YaST
 
 Provides:       yast2:/usr/sbin/save_y2logs
 
+Requires:       tar
+
 %description logs
 This package contains scripts for handling YAST logs.
 


### PR DESCRIPTION
Add the `tar` dependency to `yast2-logs`.

_Tested manually_

![Screenshot from 2019-03-19 17-32-16](https://user-images.githubusercontent.com/1691872/54628203-f6db4780-4a6c-11e9-920a-3182ede07703.png)




Related to https://bugzilla.suse.com/show_bug.cgi?id=1125142