### PR TITLE
Recognize Infiniband device based on attributes

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -151,7 +151,8 @@ module Yast
       @TypeByKeyExistence = [
         ["ETHERDEVICE", "vlan"],
         ["WIRELESS_MODE", "wlan"],
-        ["MODEM_DEVICE", "ppp"]
+        ["MODEM_DEVICE", "ppp"],
+        ["IPOIB_MODE", "ib"]
       ]
       @TypeByValueMatch = [
         ["BONDING_MASTER", "yes", "bond"],

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,9 +1,17 @@
 -------------------------------------------------------------------
+Wed Jun  5 10:44:18 UTC 2019 - Knut Anderssen <kanderssen@suse.de>
+
+- bsc#1086454
+  - Recognize IB interfaces based on IPOIB_MODE ifcfg attribute
+- 4.2.6
+
+-------------------------------------------------------------------
 Fri May 31 19:14:11 UTC 2019 - Stasiek Michalski <hellcp@mailbox.org>
 
 - Use new schema of desktop files (boo#1084864)
 - Clean up spec
 - Rename desktop files
+- 4.2.5
 
 -------------------------------------------------------------------
 Thu May 30 12:52:13 UTC 2019 - Josef Reidinger <jreidinger@suse.com>

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
It helps to recognize Infiniband devices when only the ifcfg file is present in other case the inteface type is detected as an Ethernet controller.

Referenced bug is about ipoib:

https://trello.com/c/2aiOMbUa/963-also-for-sle-12-sp4-bug-1086454-yast2-breaks-ip-over-ib-interfaces-by-enabling-optional-ib-features-as-default