### PR TITLE
Make sure the wizard buttons always remain visible in NCurses (SLE-15-SP1 branch)

### DIFF
--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -279,22 +279,25 @@ module Yast
       VBox(
         Id(:WizardDialog),
         ReplacePoint(Id(:topmenu), Empty()),
-        HBox(
-          HSpacing(1),
-          VBox(
-            VSpacing(0.2),
-            HBox(
-              # translators: dialog title to appear before any content is initialized
-              Heading(Id(:title), Opt(:hstretch), _("Initializing ...")),
-              HStretch(),
-              ReplacePoint(Id(:relnotes_rp), Empty())
+        VWeight(
+          1, # Layout trick: Lower layout priority with weight
+          HBox(
+            HSpacing(1),
+            VBox(
+              VSpacing(0.2),
+              HBox(
+                # translators: dialog title to appear before any content is initialized
+                Heading(Id(:title), Opt(:hstretch), _("Initializing ...")),
+                HStretch(),
+                ReplacePoint(Id(:relnotes_rp), Empty())
+              ),
+              VWeight(
+                1, # Layout trick: Lower layout priority with weight
+                HVCenter(Opt(:hvstretch), ReplacePoint(Id(:contents), Empty()))
+              )
             ),
-            VWeight(
-              1, # Layout trick: Lower layout priority with weight
-              HVCenter(Opt(:hvstretch), ReplacePoint(Id(:contents), Empty()))
-            )
-          ),
-          HSpacing(1)
+            HSpacing(1)
+          )
         ),
         ReplacePoint(Id(:rep_button_box), button_box),
         VSpacing(0.2)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 16 09:01:59 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Make sure the wizard buttons always remain visible in NCurses
+  (bsc#1133367)
+- 4.1.70
+
+-------------------------------------------------------------------
 Fri Apr 26 08:38:39 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Uninstall the "SUSE-Manager-Proxy" product when upgrading from

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.69
+Version:        4.1.70
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
_This is for the SLE-15-SP1 branch. The merge to master will follow._

# Trello

https://trello.com/c/kUpqSPGu

# Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1133367

# Problem

In the NCurses UI, the wizard buttons can disappear when the wizard content is too large.

![registration-ncurses-80x24-broken](https://user-images.githubusercontent.com/11538225/57790724-9d755900-773b-11e9-9f17-10d32b79efc0.png)
_Notice there are no wizard buttons visible._

# Cause

Unlike in the Qt UI, the NCurses UI does not have a dedicated Wizard widget; a wizard dialog is pieced together from standard widgets. This includes the outer wizard dialog, the wizard buttons and the framework for the wizard contents which is basically a fancy ReplacePoint where the application later puts the dialog content.

Since all those parts were created equal, in case the UI runs out of screen space because a wizard dialog is overcrowded, it has to cut off widgets somewhere. In the standard algorithm it cuts off some part of all the widgets in the dimension where there is not enough space; so the dialog content loses some space, and the wizard buttons also lose some space.

But since an NCurses button is only one line high, it will quickly disappear if that happens in the vertical dimension, making the buttons useless.


# Fix

Give higher layout priority to the wizard buttons, i.e. lower the layout priority for the dialog content in the vertical dimension.

This is commonly done with a VWeight widget: In a VBox, each item gets the space that it reports it needs, and excess space is distributed evenly or, if there are VWeights, according to those VWeights.

In the opposite case when there is not enough space, the widgets _without_ a VWeight get their desired space, and the rest goes to the widgets with a VWeight. If there is only one of those, it gets all the remaining space.


# Screenshots

![registration-ncurses-80x24-fixed](https://user-images.githubusercontent.com/11538225/57791298-cc3fff00-773c-11e9-9dbf-ab8cc7042579.png)
_80x24: The problematic case in this bug. Notice the wizard buttons are now there alright._

![registration-ncurses-128x40-fixed](https://user-images.githubusercontent.com/11538225/57791319-d530d080-773c-11e9-9d89-05926eed8b8c.png)
_128x40: Works fine with much larger than standard resolution._

![registration-ncurses-80x20-fixed](https://user-images.githubusercontent.com/11538225/57791332-dbbf4800-773c-11e9-9237-e04396db07c7.png)
_80x20: Even works fine with much less resolution (but this is really pushing the limits)._


# Effect on other dialogs and modules

They won't ever lose their wizard buttons again. They will be the last screen element to disappear.

So this fix fixes not only this particular case, but all NCurses wizard buttons in all dialogs and modules forevermore.

------------------

The diff is best viewed with _Diff Settings_ -> _Hide Whitespace Changes_.