### PR TITLE
Downgrade to 3.2.46.1 because 3.2.47 is something different in SP4

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,7 +2,7 @@
 Tue Apr 30 08:52:35 UTC 2019 - mvidner@suse.com
 
 - Stop "ls: write error: Broken pipe" messages (bsc#1128032)
-- 3.2.47
+- 3.2.46.1
 
 -------------------------------------------------------------------
 Tue Sep 25 09:28:19 UTC 2018 - knut.anderssen@suse.com

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.47
+Version:        3.2.46.1
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
A fix-up for #929 (which is a merge of #922)
- https://build.suse.de/package/view_file/SUSE:SLE-12-SP3:Update/yast2/yast2.changes?expand=1
- vs https://build.suse.de/package/view_file/SUSE:SLE-12-SP4:Update/yast2/yast2.changes?expand=1
(It diverged with 3.2.46 already)

Accordingly, I've revoked https://build.suse.de/request/show/193644