### PR TITLE
Deprecate itanium

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -151,6 +151,7 @@ module Yast
     end
 
     # true for all IA64 (itanium) architectures
+    # @deprecated Itanium is no longer supported
     def ia64
       architecture == "ia64"
     end

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1030,8 +1030,6 @@ module Yast
         "ib"
       ]
 
-      # ia64 specific device types
-      ia64_dev_types = ["xp"]
 
       dev_types = deep_copy(common_dev_types)
 
@@ -1042,14 +1040,6 @@ module Yast
           to:   "list <string>"
         )
       else
-        if Arch.ia64
-          dev_types = Convert.convert(
-            Builtins.merge(dev_types, ia64_dev_types),
-            from: "list",
-            to:   "list <string>"
-          )
-        end
-
         dev_types = Convert.convert(
           Builtins.merge(dev_types, s390_unknown_dev_types),
           from: "list",

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1030,22 +1030,7 @@ module Yast
         "ib"
       ]
 
-
-      dev_types = deep_copy(common_dev_types)
-
-      if Arch.s390
-        dev_types = Convert.convert(
-          Builtins.merge(dev_types, s390_dev_types),
-          from: "list",
-          to:   "list <string>"
-        )
-      else
-        dev_types = Convert.convert(
-          Builtins.merge(dev_types, s390_unknown_dev_types),
-          from: "list",
-          to:   "list <string>"
-        )
-      end
+      dev_types = common_dev_types + (Arch.s390 ? s390_dev_types : s390_unknown_dev_types)
 
       Builtins.foreach(dev_types) do |device|
         if !Builtins.contains(

--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -325,8 +325,6 @@ module Yast
         else
           ["kernel-ppc64"]
         end
-      elsif Arch.ia64
-        @kernel_packages = ["kernel-default"]
       elsif Arch.s390
         @kernel_packages = ["kernel-default"]
         @binary = "image"

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Jun  5 13:19:01 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- deprecate Arch.ia64 and drop all support for ia64
+
+-------------------------------------------------------------------
 Wed Jun  5 10:44:18 UTC 2019 - Knut Anderssen <kanderssen@suse.de>
 
 - bsc#1086454

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Jun  5 13:19:01 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
-- deprecate Arch.ia64 and drop all support for ia64
+- deprecate Arch.ia64 and drop all support for ia64 (last seen in SLE 11)
 
 -------------------------------------------------------------------
 Wed Jun  5 10:44:18 UTC 2019 - Knut Anderssen <kanderssen@suse.de>

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
 Wed Jun  5 13:19:01 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
-- deprecate Arch.ia64 and drop all support for ia64 (last seen in SLE 11)
+- deprecate Arch.ia64 and drop all support for ia64 (last seen in
+  SLE 11)
 
 -------------------------------------------------------------------
 Wed Jun  5 10:44:18 UTC 2019 - Knut Anderssen <kanderssen@suse.de>


### PR DESCRIPTION
Itanium is last build for SLE11 code stream, so it is no longer used and should be removed from code.