### PR TITLE
Sle 15 sp1 bsc 1136708

### DIFF
--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -663,7 +663,9 @@ module Yast
     end
 
     # Rebuild the dialog. Useful if slides become available post-creating the dialog.
-    def RebuildDialog
+    #
+    # @param [Boolean] show_release_notes release notes tab will be shown.
+    def RebuildDialog( show_release_notes = false )
       contents = Empty()
 
       show_slides = Slides.HaveSlideSupport && Slides.HaveSlides
@@ -677,13 +679,15 @@ module Yast
           tabs.unshift(Item(Id(:showSlide), _("Slide Sho&w")))
         end
 
-        @_rn_tabs = {}
-        if @_relnotes.key?(@_base_product)
-          add_relnotes_for_product @_base_product, @_relnotes[@_base_product], tabs
-        end
-        @_relnotes.each do |product, relnotes|
-          if @_base_product != product
-            add_relnotes_for_product product, relnotes, tabs
+        if show_release_notes
+          @_rn_tabs = {}
+          if @_relnotes.key?(@_base_product)
+            add_relnotes_for_product @_base_product, @_relnotes[@_base_product], tabs
+          end
+          @_relnotes.each do |product, relnotes|
+            if @_base_product != product
+              add_relnotes_for_product product, relnotes, tabs
+            end
           end
         end
 

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -665,7 +665,7 @@ module Yast
     # Rebuild the dialog. Useful if slides become available post-creating the dialog.
     #
     # @param [Boolean] show_release_notes release notes tab will be shown.
-    def RebuildDialog( show_release_notes = false )
+    def RebuildDialog(show_release_notes = false)
       contents = Empty()
 
       show_slides = Slides.HaveSlideSupport && Slides.HaveSlides

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 18 09:06:13 CEST 2019 - schubi@suse.de
+
+- Slideshow: Flag for switchin on/off release notes tab.
+  (bsc#1136708)
+- 4.1.69
+
+-------------------------------------------------------------------
 Tue Apr  9 09:50:45 CEST 2019 - schubi@suse.de
 - Updated map for evaluating upgraded products
   (e.g. for SUSE-Manager). (bsc#1131503)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.68
+Version:        4.1.69
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1136708
- https://trello.com/c/hirlFUmw
- see https://github.com/yast/yast-packager/pull/450

While showing the slideshow different YAST modules will be called:
Calling YaST client inst_prepareprogress
Calling YaST client wrapper_slideshow_callbacks
Calling YaST client inst_prepdisk
Calling YaST client inst_instsys_cleanup
Calling YaST client inst_kickoff
Calling YaST client inst_bootloader
Calling YaST client inst_rpmcopy
...
..
.
The problem is that not each of these modules handles UI callbacks. Switching to another tab like the release notes tab will not be supported there.
With this fix the release tab will be shown only while RPM packages will be installed. So it will be shown 3-4 seconds after starting the installation.