### PR TITLE
DnsServerAPI: skip 'bind' absence in mode test

### DIFF
--- a/library/network/src/modules/DnsServerAPI.pm
+++ b/library/network/src/modules/DnsServerAPI.pm
@@ -61,6 +61,7 @@ YaST::YCP::Import ("Report");
 YaST::YCP::Import ("IP");
 # for syntax checking
 YaST::YCP::Import ("Hostname");
+YaST::YCP::Import ("Mode");
 
 our %TYPEINFO;
 my $package_installed = -1;
@@ -654,6 +655,11 @@ sub UnquoteString {
 }
 
 sub Init {
+    if (Mode->test ()) {
+      $package_installed = 1;
+      y2milestone("TestMode -> PackageSystem->Installed: ", $package_installed);
+    }
+
     if ($package_installed != -1){
         return $package_installed;
     }

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul  1 13:41:45 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- bsc#1138668
+  - Fixed failing old testsuite in yast2-dns-server package: do not
+    depend on the environment, skip bind absence in Mode.test()
+- 4.2.11
+
+-------------------------------------------------------------------
 Fri Jun 21 13:19:01 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - deprecate Arch.ia64 and drop all support for ia64 (last seen in

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2
 #
-# Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.10
+Version:        4.2.11
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only
@@ -72,8 +72,8 @@ Requires:       rubygem(%{rb_default_ruby_abi}:abstract_method)
 # for file access using augeas
 Requires:       rubygem(%{rb_default_ruby_abi}:cfa)
 # For converting to/from punycode strings
-Requires:       rubygem(%{rb_default_ruby_abi}:simpleidn)
 Requires:       sysconfig >= 0.80.0
+Requires:       rubygem(%{rb_default_ruby_abi}:simpleidn)
 # for running scripts
 Requires:       rubygem(%{rb_default_ruby_abi}:cheetah)
 # ag_ini section_private


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1138668

## Problem
- Failing old testsuite in yast2-dns-server
- It depends on bind rpm installed.

## Fix

- Do not depend on the package installed at all in Mode.test()
- 4.2.11