### PR TITLE
Base product fix

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 23 12:50:07 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed evaluating the base products to avoid the "No base product
+  found" error message at upgrade, for reading the product data
+  prefer the new products (bsc#1142522)
+- 4.2.13
+
+-------------------------------------------------------------------
 Tue Jul  9 12:05:19 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - fixed symlink creation in jenkins

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -48,7 +48,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:simpleidn)
 # Needed already in build time
 BuildRequires:  yast2-core >= 2.18.12
 BuildRequires:  yast2-devtools >= 3.1.10
-BuildRequires:  yast2-pkg-bindings >= 2.20.3
+# Pkg.Resolvables()
+BuildRequires:  yast2-pkg-bindings >= 4.2.0
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # To have Yast::WFM.scr_root
 BuildRequires:  yast2-ruby-bindings >= 3.2.8
@@ -82,8 +83,8 @@ Requires:       yast2-core >= 2.23.0
 Requires:       yast2-hardware-detection
 # for SLPAPI.pm
 Requires:       yast2-perl-bindings
-# changed StartPackage callback signature
-Requires:       yast2-pkg-bindings >= 2.20.3
+# Pkg.Resolvables()
+Requires:       yast2-pkg-bindings >= 4.2.0
 # for y2start
 Requires:       yast2-ruby-bindings >= 3.2.10
 Requires:       yast2-xml


### PR DESCRIPTION
## Problem

- During upgrade in some cases the "No base product found" error message is displayed and the upgrade fails.
- Found by openQA: https://openqa.opensuse.org/tests/987957#step/start_install/4

![base_product_failure](https://user-images.githubusercontent.com/907998/61721377-a7818c80-ad68-11e9-951a-332239745774.png)

## Fix

- It turned out that it depends on the product installed and depends on the order of the products as returned by libzypp, as we used the `.first` product found.
- This means the bug is more or less random, in some cases libzypp returns the products in the order which works, sometimes not.
- Fixed by preferring the data from the new selected or available product, that should contain newer data than the old installed product.
- Additionally switched to the new and more memory efficient `Yast::Pkg.Resolvables` call instead of the old `Yast::Pkg.ResolvableDependencies`.

## Testing

- Tested manually in a VM, works fine
- Added an unit test
