### PR TITLE
Fix the forced base product selection (1/3)

### DIFF
--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -53,8 +53,6 @@ module Y2Packager
       # @return [true]
       def reset
         @forced_base_product = nil
-
-        true
       end
 
       # Create a product from pkg-bindings hash data.
@@ -110,7 +108,7 @@ module Y2Packager
         all.select { |p| p.status?(*statuses) }
       end
 
-      # Returns, if any, the base product which must be select
+      # Returns, if any, the base product which must be selected
       #
       # A base product can be forced to be selected through the `select_product`
       # element in the software section of the control.xml file (bsc#1124590,

--- a/library/packages/test/y2packager/product_test.rb
+++ b/library/packages/test/y2packager/product_test.rb
@@ -3,6 +3,7 @@
 require_relative "../test_helper"
 
 require "y2packager/product"
+Yast.import "ProductFeatures"
 
 describe Y2Packager::Product do
   PRODUCT_BASE_ATTRS = {
@@ -53,6 +54,71 @@ describe Y2Packager::Product do
     it "filters package with the given status" do
       expect(described_class.with_status(:installed))
         .to eq([sles])
+    end
+  end
+
+  describe ".forced_base_product" do
+    let(:select_product) { nil }
+
+    let(:opensuse) do
+      instance_double(Y2Packager::Product, name: "openSUSE", installation_package: true)
+    end
+
+    let(:sle) do
+      instance_double(Y2Packager::Product, name: "SLE", installation_package: true)
+    end
+
+    before do
+      described_class.reset
+
+      allow(described_class).to receive(:available_base_products)
+        .and_return([opensuse, sle])
+
+      allow(Yast::ProductFeatures).to receive(:GetStringFeature)
+        .with("software", "select_product")
+        .and_return(select_product)
+    end
+
+    context "when the control file is not forcing to select a base product selected" do
+      it "returns nil" do
+        expect(described_class.forced_base_product).to be_nil
+      end
+    end
+
+    context "when the control file is not forcing to select a base product selected" do
+      context "and the product is available" do
+        let(:select_product) { "openSUSE" }
+
+        it "returns the prodcut" do
+          expect(described_class.forced_base_product).to eq(opensuse)
+        end
+      end
+
+      context "but none available base product name match" do
+        let(:select_product) { "Whatever product" }
+
+        it "returns nil" do
+          expect(described_class.forced_base_product).to be_nil
+        end
+      end
+
+      context "but is empty" do
+        let(:select_product) { "" }
+
+        it "returns nil" do
+          expect(described_class.forced_base_product).to be_nil
+        end
+      end
+    end
+
+    let(:not_selected) { instance_double(Y2Packager::Product, selected?: false) }
+    let(:selected) { instance_double(Y2Packager::Product, selected?: true) }
+
+    it "returns base selected packages" do
+      allow(described_class).to receive(:available_base_products)
+        .and_return([not_selected, selected])
+
+      expect(described_class.selected_base).to eq(selected)
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Aug  5 07:55:15 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Allow to know if there is a forced base product
+  (bsc#1124590, bsc#1143943).
+- 4.2.17
+
+-------------------------------------------------------------------
 Wed Jul 31 07:16:08 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a dependency on hostname, as it is needed by the Hostname

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.16
+Version:        4.2.17
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Recently, the `select_product` option was added to the control file to allow **forcing** the base product selection when having multiple products in a single repository (see https://github.com/yast/yast-installation/pull/790).

But seems that the feature was not fully implemented and the installer only avoids displaying the product selector, but not marking the forced product as selected, raising an internal error when trying to access to `#installation_package`.

* https://bugzilla.suse.com/show_bug.cgi?id=1143943
* https://trello.com/c/YuiJfYBt/1201-ostumbleweed-p1-1143943-build-20190801-undefined-method-installationpackage

## Solution

To select the **foced** product properly.

## Additional notes

* The _automatic product selection_ is being performed in the [`InstRepositoriesInitialization`](https://github.com/yast/yast-packager/blob/f7e82e7c902b0c4723735e33698c4c8e6cb6e933/src/lib/y2packager/clients/inst_repositories_initialization.rb#L90) client (yast2-packager) but the logic to decide if the product selector will be shown to the user is a _shared_ responsibility of [`InstComplexWelcome`](https://github.com/yast/yast-installation/blob/master/src/clients/inst_complex_welcome.rb) client and [`ComplexWelcome`](https://github.com/yast/yast-installation/blob/master/src/lib/installation/dialogs/complex_welcome.rb) dialog (yast2-installation), reason why the method to ask for the forced base product has been added/centralized here.

* The use of the "preselected" term in the original implementation was not a good idea. Actually, if the product given through the `select_option` is found, it will selected and use, not allowing to user to change it later. So, it is not preselected, it is **forced**.

## Tests

* Added unit tests
* Tested manually via DUD (twice, before and after the code reviews), reproducing the openQA scenario provided in the bug report (https://openqa.opensuse.org/tests/997803/modules/online_repos/)

## Screenshots <sub>

<details>
<summary>Click to show/hide some related screenshots</summary>

---

<sub>NOTE: the screenshots were taken again in a new test with a fresh driver update after the code review and before merge the changes.</sub>

---

![Screenshot_openSUSE-Leap_2019-08-05_15:34:45](https://user-images.githubusercontent.com/1691872/62472719-3e9e0980-b797-11e9-95a7-92bee4343e72.png)

<p align="center">
The installer reach the "ComplexWelcome" dialog.
</p>

![Screenshot_openSUSE-Leap_2019-08-05_15:36:47](https://user-images.githubusercontent.com/1691872/62472826-786f1000-b797-11e9-94b7-5790e64ac770.png)

<p align="center">
In the logs, it could be seen that the control file is forcing to use the "openSUSE" product, discarding "openSUSE-MicroOS".
</p>

![Screenshot_openSUSE-Leap_2019-08-05_15:37:51](https://user-images.githubusercontent.com/1691872/62472835-7dcc5a80-b797-11e9-962d-08de0de3a56e.png)

<p align="center">
The installation summary.
</p>

</details>

---

Related to:

* https://github.com/yast/yast-installation/pull/790 - Allow to preselect the product.
* https://github.com/yast/yast-packager/pull/466 - Fix the forced base product selection (2/3)
* https://github.com/yast/yast-installation/pull/807 - Fix the forced base product selection (3/3)