### PR TITLE
Fix Report.LongWarning method in command line

### DIFF
--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -570,7 +570,7 @@ module Yast
 
       if @display_warnings
         if Mode.commandline
-          CommandLine.Print("Warning: #{error_string}")
+          CommandLine.Print("Warning: #{warning_string}")
         elsif Ops.greater_than(@timeout_warnings, 0)
           Popup.TimedLongWarningGeometry(warning_string, @timeout_warnings, width, height)
         else

--- a/library/general/test/report_test.rb
+++ b/library/general/test/report_test.rb
@@ -108,6 +108,17 @@ describe Yast::Report do
       subject.LongWarning("Message")
       expect(subject.GetMessages(0, 1, 0, 0)).to match(/Message/)
     end
+
+    context "when running on command line mode" do
+      before do
+        allow(Yast::Mode).to receive(:commandline).and_return(true)
+      end
+
+      it "prints the message" do
+        expect(Yast::CommandLine).to receive(:Print).with("Warning: message")
+        subject.LongWarning("message")
+      end
+    end
   end
 
   describe ".LongError" do
@@ -127,6 +138,17 @@ describe Yast::Report do
     it "stores the message" do
       subject.LongError("Message")
       expect(subject.GetMessages(0, 1, 0, 0)).to match(/Message/)
+    end
+
+    context "when running on command line mode" do
+      before do
+        allow(Yast::Mode).to receive(:commandline).and_return(true)
+      end
+
+      it "prints the message" do
+        expect(Yast::CommandLine).to receive(:Print).with("Error: message")
+        subject.LongError("message")
+      end
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep  6 11:15:40 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix a problem when long warnings reports in command line
+  (bsc#1149776).
+- 4.1.74
+
+-------------------------------------------------------------------
 Fri Aug 30 13:10:04 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - yast completions have to be named after their respective command

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.73
+Version:        4.1.74
 
 Release:        0
 Summary:        YaST2 - Main Package


### PR DESCRIPTION
Fixes [bsc#1149776](https://bugzilla.suse.com/show_bug.cgi?id=1149776).