### PR TITLE
Fixed build

### DIFF
--- a/library/packages/test/test_helper.rb
+++ b/library/packages/test/test_helper.rb
@@ -2,3 +2,15 @@ require_relative "../../../test/test_helper.rb"
 require "pathname"
 
 PACKAGES_FIXTURES_PATH = Pathname.new(File.dirname(__FILE__)).join("data")
+
+# mock missing YaST modules
+module Yast
+  # we cannot depend on this module (circular dependency)
+  class InstURLClass
+    def installInf2Url(_extra_dir = "")
+      ""
+    end
+  end
+
+  InstURL = InstURLClass.new
+end


### PR DESCRIPTION
- We need to mock the Yast::InstURL module completely to avoid circular yast2 <-> yast2-packager build dependency.
- Fix up for #958 which [failed in Jenkins](https://ci.opensuse.org/job/yast-yast-yast2-master/127/console)