### PR TITLE
Added support for reading products from control.xml file

### DIFF
--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -13,7 +13,7 @@
 Yast.import "Pkg"
 require "y2packager/product_reader"
 require "y2packager/release_notes_reader"
-require "y2packager/product_license"
+require "y2packager/product_license_mixin"
 
 module Y2Packager
   # Represent a product which is present in a repository. At this
@@ -22,6 +22,7 @@ module Y2Packager
   # repositories).
   class Product
     include Yast::Logger
+    include ProductLicenseMixin
 
     # @return [String] Name
     attr_reader :name
@@ -221,69 +222,6 @@ module Y2Packager
     # @return [String] Package label
     def label
       display_name || short_name || name
-    end
-
-    # Return the license to confirm
-    #
-    # @param lang [String] Language
-    # @return [ProductLicense,nil] Product's license; nil if the license was not found.
-    def license
-      @license ||= ProductLicense.find(name)
-    end
-
-    # Return the license text to be confirmed
-    #
-    # @param lang [String] Language
-    # @return [String] Product's license; empty string ("") if no license was found.
-    def license_content(lang)
-      return "" unless license?
-
-      license.content_for(lang)
-    end
-
-    # Determines whether the product has a license
-    #
-    # @param lang [String] Language
-    # @return [Boolean] true if the product has a license
-    def license?
-      !!license
-    end
-
-    # Determine whether the license should be accepted or not
-    #
-    # @return [Boolean] true if the license acceptance is required
-    def license_confirmation_required?
-      return false unless license?
-
-      license.confirmation_required?
-    end
-
-    # Set license confirmation for the product
-    #
-    # @param confirmed [Boolean] determines whether the license should be accepted or not
-    def license_confirmation=(confirmed)
-      return unless license
-
-      confirmed ? license.accept! : license.reject!
-    end
-
-    # Determine whether the license is confirmed
-    #
-    # @return [Boolean] true if the license was confirmed (or acceptance was not needed)
-    def license_confirmed?
-      return false unless license
-
-      license.accepted? || !license_confirmation_required?
-    end
-
-    # [String] Default license language.
-    DEFAULT_LICENSE_LANG = "en_US".freeze
-
-    # Return available locales for product's license
-    #
-    # @return [Array<String>] Language codes ("de_DE", "en_US", etc.)
-    def license_locales
-      license.locales
     end
 
     # Return product's release notes

--- a/library/packages/src/lib/y2packager/product_control_product.rb
+++ b/library/packages/src/lib/y2packager/product_control_product.rb
@@ -1,0 +1,102 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, contact SUSE.
+#
+# To contact SUSE about this file by physical or electronic mail, you may find
+# current contact information at www.suse.com.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "y2packager/product_license_mixin"
+
+Yast.import "Arch"
+Yast.import "Linuxrc"
+Yast.import "ProductFeatures"
+
+module Y2Packager
+  # This class implements a base product read from the control.xml file.
+  class ProductControlProduct
+    # initialize the selected base product
+    @selected = nil
+
+    class << self
+      attr_accessor :selected
+    end
+
+    extend Yast::Logger
+    include ProductLicenseMixin
+
+    attr_reader :name, :version, :arch, :label, :license_url, :register_target
+
+    #
+    # Read the base products from the control.xml file. The products for the incompatible
+    # machine architecture and the hidden products are filtered out.
+    #
+    # @return [Array<Installation::ProductControlProduct>] List of the products
+    def self.products
+      return @products if @products
+
+      control_products = Yast::ProductFeatures.GetFeature("software", "base_products")
+      arch = Yast::Arch.architecture
+      linuxrc_products = (Yast::Linuxrc.InstallInf("specialproduct") || "").split(",").map(&:strip)
+
+      @products = control_products.each_with_object([]) do |p, array|
+        # a hidden product requested?
+        if p["special_product"] && !linuxrc_products.include?(p["name"])
+          log.info "Skipping special hidden product #{p["name"]}"
+          next
+        end
+
+        # compatible arch?
+        if p["archs"] && !p["archs"].split(",").map(&:strip).include?(arch)
+          log.info "Skipping product #{p["name"]} - not compatible with arch #{arch}"
+          next
+        end
+
+        array << new(
+          name:            p["name"],
+          version:         p["version"],
+          arch:            arch,
+          label:           p["label"],
+          license_url:     p["license_url"],
+          # expand the "$arch" placeholder
+          register_target: (p["register_target"] || "").gsub("$arch", arch)
+        )
+      end
+    end
+
+    # Constructor
+    # @param name [String] product name (the identifier, e.g. "SLES")
+    # @param version [String] version ("15.2")
+    # @param arch [String] The architecture ("x86_64")
+    # @param label [String] The user visible name ("SUSE Linux Enterprise Server 15 SP2")
+    # @param license_url [String] License URL
+    # @param register_target [String] The registration target name used
+    #   for registering the product, the $arch variable is replaced
+    #   by the current machine architecture
+    def initialize(name:, version:, arch:, label:, license_url:, register_target:)
+      @name = name
+      @version = version
+      @arch = arch
+      @label = label
+      @license_url = license_url
+      @register_target = register_target
+    end
+
+    # Is the product selected?
+    # @return [Boolean] true if the product is the selected base product
+    def selected?
+      self == self.class.selected
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/product_license_mixin.rb
+++ b/library/packages/src/lib/y2packager/product_license_mixin.rb
@@ -1,0 +1,82 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2019 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "y2packager/product_license"
+
+module Y2Packager
+  # This module is used for sharing the license related methods
+  # for several types of products.
+  module ProductLicenseMixin
+    # Return the license to confirm
+    #
+    # @param lang [String] Language
+    # @return [ProductLicense,nil] Product's license; nil if the license was not found.
+    def license
+      @license ||= ProductLicense.find(name)
+    end
+
+    # Return the license text to be confirmed
+    #
+    # @param lang [String] Language
+    # @return [String] Product's license; empty string ("") if no license was found.
+    def license_content(lang)
+      return "" unless license?
+
+      license.content_for(lang)
+    end
+
+    # Determines whether the product has a license
+    #
+    # @param lang [String] Language
+    # @return [Boolean] true if the product has a license
+    def license?
+      !!license
+    end
+
+    # Determine whether the license should be accepted or not
+    #
+    # @return [Boolean] true if the license acceptance is required
+    def license_confirmation_required?
+      return false unless license?
+
+      license.confirmation_required?
+    end
+
+    # Set license confirmation for the product
+    #
+    # @param confirmed [Boolean] determines whether the license should be accepted or not
+    def license_confirmation=(confirmed)
+      return unless license
+
+      confirmed ? license.accept! : license.reject!
+    end
+
+    # Determine whether the license is confirmed
+    #
+    # @return [Boolean] true if the license was confirmed (or acceptance was not needed)
+    def license_confirmed?
+      return false unless license
+
+      license.accepted? || !license_confirmation_required?
+    end
+
+    # [String] Default license language.
+    DEFAULT_LICENSE_LANG = "en_US".freeze
+
+    # Return available locales for product's license
+    #
+    # @return [Array<String>] Language codes ("de_DE", "en_US", etc.)
+    def license_locales
+      license.locales
+    end
+  end
+end

--- a/library/packages/test/y2packager/product_control_product_test.rb
+++ b/library/packages/test/y2packager/product_control_product_test.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2018 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../test_helper"
+
+require "y2packager/product_control_product"
+
+describe Y2Packager::ProductControlProduct do
+  let(:product_data) do
+    {
+      "label"           => "SUSE Linux Enterprise Server 15 SP2",
+      "name"            => "SLES",
+      "version"         => "15.2",
+      "register_target" => "sle-15-$arch"
+    }
+  end
+
+  describe ".products" do
+    before do
+      allow(Yast::Linuxrc).to receive(:InstallInf).with("specialproduct").and_return("")
+      allow(Yast::ProductFeatures).to receive(:GetFeature)
+        .with("software", "base_products").and_return([])
+      allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
+    end
+
+    after do
+      # the read products are cached, we need to reset them manually for the next test
+      described_class.instance_variable_set(:@products, nil)
+    end
+
+    it "reads the products from the control.xml" do
+      expect(Yast::ProductFeatures).to receive(:GetFeature)
+        .with("software", "base_products").and_return([product_data])
+
+      products = Y2Packager::ProductControlProduct.products
+      expect(products).to_not be_empty
+      expect(products.first).to be_a(Y2Packager::ProductControlProduct)
+      expect(products.first.name).to eq("SLES")
+    end
+
+    it "ignores the hidden products" do
+      data = product_data.merge("special_product" => true)
+      expect(Yast::ProductFeatures).to receive(:GetFeature)
+        .with("software", "base_products").and_return([data])
+
+      products = Y2Packager::ProductControlProduct.products
+      expect(products).to be_empty
+    end
+
+    it "ignores the products for incompatible archs" do
+      data = product_data.merge("archs" => "aarch64")
+      expect(Yast::ProductFeatures).to receive(:GetFeature)
+        .with("software", "base_products").and_return([data])
+
+      products = Y2Packager::ProductControlProduct.products
+      expect(products).to be_empty
+    end
+
+    it "expands the $arch variable in the register_target value" do
+      expect(Yast::ProductFeatures).to receive(:GetFeature)
+        .with("software", "base_products").and_return([product_data])
+
+      product = Y2Packager::ProductControlProduct.products.first
+      expect(product.register_target).to eq("sle-15-x86_64")
+    end
+  end
+
+  describe ".selected" do
+    after do
+      # ensure the selected product is reset after each test
+      described_class.instance_variable_set(:@selected, nil)
+    end
+
+    it "returns nil by default" do
+      expect(described_class.selected).to be_nil
+    end
+
+    it "returns the selected product" do
+      product = described_class.new(name: "SLES", version: "15.2", arch: "x86_64",
+        label: "SUSE Linux Enterprise Server 15 SP2", license_url: "", register_target: "")
+      described_class.selected = product
+      expect(described_class.selected).to be(product)
+    end
+  end
+end

--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -77,7 +77,7 @@ describe Y2Packager::ProductReader do
         end
       end
 
-      context "and more than 1 product exsits" do
+      context "and more than 1 product exists" do
         let(:products) { [prod1, prod2] }
 
         it "returns an empty array" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 19 12:05:17 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added support for reading products from control.xml file
+  (jsc#SLE-7104)
+- 4.2.22
+
+-------------------------------------------------------------------
 Tue Sep 10 07:57:34 UTC 2019 - Steffen Winterfeldt <snwint@suse.com>
 
 - support reading licenses from tar archive (jsc#SLE-7214)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.21
+Version:        4.2.22
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
- Added support for reading the products from the `control.xml` file
- Needed for a repo-less online installation medium, that will not contain any repository (so no product there)
- https://jira.suse.com/browse/SLE-7104
- To share some parts I have moved some code to the `ProductLicenseMixin` module
- This code will be used by some other modules, it was added here into the base YaST package to avoid some circular dependencies between `yast2-packager` and `yast2-installation`.

The base product definition in the `control.xml` file would look like:

```xml
<base_products config:type="list">
  <base_product>
    <label>SUSE Linux Enterprise Server 15 SP2</label>
    <name>SLES</name>
    <version>15.2</version>
    <register_target>sle-15-$arch</register_target>
  </base_product>
</base_products>
```

Optionally a product might be limited to a specific architecture (`archs` key) or can be hidden by default (`special_product` key) like the "SLES BCL" special product.