### PR TITLE
Use "display_name" tag for the product label

### DIFF
--- a/library/packages/test/y2packager/product_control_product_test.rb
+++ b/library/packages/test/y2packager/product_control_product_test.rb
@@ -18,7 +18,7 @@ require "y2packager/product_control_product"
 describe Y2Packager::ProductControlProduct do
   let(:product_data) do
     {
-      "label"           => "SUSE Linux Enterprise Server 15 SP2",
+      "display_name"    => "SUSE Linux Enterprise Server 15 SP2",
       "name"            => "SLES",
       "version"         => "15.2",
       "register_target" => "sle-15-$arch"

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 23 07:27:27 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Use "display_name" tag for the product label, "label" marks a
+  translatable text (jsc#SLE-7214)
+- 4.2.23
+
+-------------------------------------------------------------------
 Thu Sep 19 12:05:17 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added support for reading products from control.xml file

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.22
+Version:        4.2.23
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
- "label" marks a translatable text (jsc#SLE-7214)
- Additionally convert some `Yast::Arch.architecture` to the value expected by the registration server
- 4.2.23