### PR TITLE
Remove old sysctl.conf values

### DIFF
--- a/library/general/src/lib/cfa/sysctl.rb
+++ b/library/general/src/lib/cfa/sysctl.rb
@@ -17,6 +17,7 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "cfa/base_model"
 require "yast2/target_file"
 
@@ -43,6 +44,8 @@ module CFA
   #   sysctl.raw_forward_ipv6 = "1"
   #   sysctl.forward_ipv6? #=> true
   class Sysctl < BaseModel
+    include Yast::Logger
+
     PARSER = AugeasParser.new("sysctl.lns")
     PATH = "/etc/sysctl.d/30-yast.conf".freeze
 
@@ -141,6 +144,7 @@ module CFA
       lines = sysctl_conf.lines.reject { |l| KNOWN_KEYS_REGEXP =~ l }
       Yast::TargetFile.write(MAIN_SYSCTL_CONF_PATH, lines.join)
     rescue Errno::ENOENT
+      log.info "File #{MAIN_SYSCTL_CONF_PATH} was not found"
     end
   end
 end

--- a/library/general/src/lib/cfa/sysctl.rb
+++ b/library/general/src/lib/cfa/sysctl.rb
@@ -137,7 +137,7 @@ module CFA
     SYSCTL_AGENT_PATH = Yast::Path.new(".etc.sysctl_conf")
 
     MAIN_SYSCTL_CONF_PATH = "/etc/sysctl.conf".freeze
-    KNOWN_KEYS_REGEXP = /^(#{KNOWN_KEYS.join("|")})/
+    KNOWN_KEYS_REGEXP = /^(#{KNOWN_KEYS.join("|")})/.freeze
     # Cleans up present values from +/etc/sysctl.conf+ to reduce confusion
     def clean_old_values
       sysctl_conf = Yast::TargetFile.read(MAIN_SYSCTL_CONF_PATH)

--- a/library/general/test/cfa/sysctl_test.rb
+++ b/library/general/test/cfa/sysctl_test.rb
@@ -133,6 +133,18 @@ describe CFA::Sysctl do
         .with(Yast::Path.new(".etc.sysctl_conf.\"net.ipv4.tcp_syncookies\""), anything)
       sysctl.save
     end
+
+    context "when /etc/sysctl.conf does not exist" do
+      before do
+        allow(Yast::TargetFile).to receive(:read).with("/etc/sysctl.conf")
+          .and_raise(Errno::ENOENT)
+      end
+
+      it "logs an error" do
+        expect(sysctl.log).to receive(:info).with(/not found/)
+        sysctl.save
+      end
+    end
   end
 
   describe "#forward_ipv4?" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct  7 16:00:09 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Remove old values from /etc/sysctl.conf (jsc#SLE-9077).
+- 4.2.26
+
+-------------------------------------------------------------------
 Thu Oct  3 12:31:35 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a CFA based class to adjust sysctl settings (jsc#SLE-9077).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.25
+Version:        4.2.26
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
In #967 we decided to simply update old values in `/etc/sysctl.conf` because the `.sysctl_conf` agent could empty the file when trying to remove the last entry. To work around this problem, this change simply uses a regular expression to drop the unwanted lines, keeping the comments.