### PR TITLE
Fixed evaluating the available package versions (bsc#1151824)

### DIFF
--- a/library/packages/test/y2packager/package_test.rb
+++ b/library/packages/test/y2packager/package_test.rb
@@ -14,7 +14,8 @@ describe Y2Packager::Package do
     let(:package) { instance_double(Y2Packager::Package) }
 
     it "returns packages with a given name" do
-      expect(Yast::Pkg).to receive(:ResolvableProperties).with(name, :package, "")
+      expect(Yast::Pkg).to receive(:Resolvables)
+        .with({ kind: :package, name: "yast2" }, [:name, :source, :version])
         .and_return([{ "name" => "yast2", "source" => 1, "version" => "12.3" }])
       expect(Y2Packager::Package).to receive(:new).with(name, 1, "12.3")
         .and_return(package)
@@ -24,15 +25,23 @@ describe Y2Packager::Package do
 
   describe ".last_version" do
     let(:name) { "yast2" }
-    let(:unknown_status) { { "status" => :unknown } }
-    let(:available_status) { { "status" => :available } }
-    let(:selected_status) { { "status" => :selected } }
+    let(:unknown_status) { [{ "status" => :unknown }] }
+    let(:available_status) { [{ "status" => :available }] }
+    let(:selected_status) { [{ "status" => :selected }] }
 
     before do
-      allow(Yast::Pkg).to receive(:PkgProperties).with(name)
-        .and_return(unknown_status, available_status, selected_status)
+      allow(Yast::Pkg).to receive(:Resolvables)
+        .with({ kind: :package, name: "yast2", version: "15.0", source: 0 }, [:status])
+        .and_return(unknown_status)
+      allow(Yast::Pkg).to receive(:Resolvables)
+        .with({ kind: :package, name: "yast2", version: "12.3", source: 1 }, [:status])
+        .and_return(selected_status)
+      allow(Yast::Pkg).to receive(:Resolvables)
+        .with({ kind: :package, name: "yast2", version: "12.0", source: 2 }, [:status])
+        .and_return(available_status)
 
-      allow(Yast::Pkg).to receive(:ResolvableProperties).with(name, :package, "")
+      allow(Yast::Pkg).to receive(:Resolvables)
+        .with({ kind: :package, name: "yast2" }, [:name, :source, :version])
         .and_return(
           [
             { "name" => "yast2", "source" => 0, "version" => "15.0" },
@@ -104,8 +113,9 @@ describe Y2Packager::Package do
 
   describe "#status" do
     it "returns package status" do
-      expect(Yast::Pkg).to receive(:PkgProperties)
-        .with(package.name).and_return("status" => :available)
+      expect(Yast::Pkg).to receive(:Resolvables)
+        .with({ kind: :package, name: "release-notes-dummy", version: "15.0", source: 1 }, [:status])
+        .and_return(["status" => :available])
       expect(package.status).to eq(:available)
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  9 08:02:32 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed evaluating the available package versions, fixed crash
+  when trying to download a non-existing package (bsc#1151824)
+- 4.2.27
+
+-------------------------------------------------------------------
 Mon Oct  7 16:00:09 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Remove old values from /etc/sysctl.conf (jsc#SLE-9077).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.26
+Version:        4.2.27
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
### The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1151824
- https://openqa.suse.de/tests/3406978#step/resolve_dependency_issues/2
- Fixed a crash when trying to download a non-existing package
- The `PackageDownloader::FetchError` exception is raised when YaST wants to download a package from source `-1` (that actually means the package is installed in the system, not available on any medium)

### The Fix

- I could not reproduce locally, but checking the code I found that the problem is in using the `Pkg.PkgProperties` call which does not allow to specify the package more precisely, it can return the result for any package instance
- Tested manually, at least no regression was found
- Reported by openQA, we should see quickly if this fix helps
- Additionally I switched from memory hungry `Pkg.PkgProperties` to the more efficient `Pkg.Resolvables` call
- 4.2.27