### PR TITLE
NetworkService: Check if systemd is running for determining the network backend

### DIFF
--- a/library/network/src/modules/NetworkService.rb
+++ b/library/network/src/modules/NetworkService.rb
@@ -210,8 +210,7 @@ module Yast
     def Read
       return if @initialized
 
-      @current_name = backend_in_use
-      @cached_name = @current_name
+      @cached_name = @current_name = backend_in_use
 
       log.info "Current backend: #{@current_name}"
       @initialized = true

--- a/library/network/src/modules/NetworkService.rb
+++ b/library/network/src/modules/NetworkService.rb
@@ -207,6 +207,12 @@ module Yast
       nil
     end
 
+    def reset!
+      @initialized = false
+      @current_name = nil
+      @cached_name = nil
+    end
+
     # Helper to apply a change of the network service
     def EnableDisableNow
       return if !Modified()
@@ -216,7 +222,7 @@ module Yast
         disable_service(current_name)
       end
 
-      RunSystemCtl(BACKENDS[cached_name], "enable", force: true) if cached_name
+      enable_service(cached_name) if cached_name
 
       @initialized = false
       Read()
@@ -431,6 +437,10 @@ module Yast
 
     def disable_service(service)
       RunSystemCtl(BACKENDS[service], "disable")
+    end
+
+    def enable_service(service)
+      RunSystemCtl(BACKENDS[service], "enable", force: true)
     end
 
     publish function: :Read, type: "void ()"

--- a/library/network/src/modules/NetworkService.rb
+++ b/library/network/src/modules/NetworkService.rb
@@ -76,6 +76,7 @@ module Yast
       Yast.import "Mode"
       Yast.import "Stage"
       Yast.import "PackageSystem"
+      Yast.import "Systemd"
 
       textdomain "base"
 
@@ -190,7 +191,7 @@ module Yast
     def Read
       return if @initialized
 
-      if Stage.initial
+      if Stage.initial && !Systemd.Running
         @current_name = DEFAULT_BACKEND
         log.info "Running in installer/AutoYaST, use default: #{@current_name}"
       else

--- a/library/systemd/src/lib/yast2/systemd/unit.rb
+++ b/library/systemd/src/lib/yast2/systemd/unit.rb
@@ -35,6 +35,7 @@ module Yast2
     #
     class Unit
       Yast.import "Stage"
+      Yast.import "Systemd"
       include Yast::Logger
 
       SUPPORTED_TYPES = %w[service socket target].freeze
@@ -105,7 +106,7 @@ module Yast2
       # @return [Yast2::Systemd::UnitProperties]
       def show(property_text = nil)
         # Using different handler during first stage (installation, update, ...)
-        if Yast::Stage.initial
+        if Yast::Stage.initial && !Yast::Systemd.Running
           UnitInstallationProperties.new(self)
         else
           UnitProperties.new(self, property_text)

--- a/library/systemd/test/yast2/systemd_unit_test.rb
+++ b/library/systemd/test/yast2/systemd_unit_test.rb
@@ -72,6 +72,11 @@ module Yast2
     end
 
     describe "#properties" do
+      let(:properties_methods) do
+        [:supported?, :not_found?, :static?, :error, :raw] + delegated_methods
+      end
+      let(:delegated_methods) { [:enabled?, :active?, :loaded?, :path, :can_reload?] }
+
       it "always returns struct including default properties" do
         unit = Systemd::Unit.new("iscsi.socket")
         expect(unit.properties.to_h.keys).to include(*Yast2::Systemd::UnitPropMap::DEFAULT.keys)
@@ -79,25 +84,12 @@ module Yast2
 
       it "provides status properties methods" do
         unit = Systemd::Unit.new("iscsid.socket")
-        expect(unit.properties[:enabled?]).not_to be_nil
-        expect(unit.properties[:active?]).not_to be_nil
-        expect(unit.properties[:loaded?]).not_to be_nil
-        expect(unit.properties[:supported?]).not_to be_nil
-        expect(unit.properties[:not_found?]).not_to be_nil
-        expect(unit.properties[:static?]).not_to be_nil
-        expect(unit.properties[:path]).not_to be_nil
-        expect(unit.properties[:error]).not_to be_nil
-        expect(unit.properties[:raw]).not_to be_nil
-        expect(unit.properties[:can_reload?]).not_to be_nil
+        properties_methods.each { |m| expect(unit.properties[m]).not_to be_nil }
       end
 
       it "delegates the status properties onto the unit object" do
         unit = Systemd::Unit.new("iscsid.socket")
-        expect(unit).to respond_to(:enabled?)
-        expect(unit).to respond_to(:active?)
-        expect(unit).to respond_to(:loaded?)
-        expect(unit).to respond_to(:path)
-        expect(unit).to respond_to(:can_reload?)
+        delegated_methods.each { |m| expect(unit).to respond_to(m) }
       end
     end
 

--- a/library/systemd/test/yast2/systemd_unit_test.rb
+++ b/library/systemd/test/yast2/systemd_unit_test.rb
@@ -22,6 +22,7 @@ module Yast2
     context "Installation system without full support of systemd" do
       before do
         allow(Yast::Stage).to receive(:initial).and_return(true)
+        allow(Yast::Systemd).to receive(:Running).and_return(false)
       end
 
       describe "#properties" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 21 06:59:33 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Network: During an installation, check which backend is in use
+  when Systemd is running. (bsc#1151291)
+- 4.2.31
+
+-------------------------------------------------------------------
 Tue Oct 29 07:22:13 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - fix showing release notes for online upgrade (bsc#1155134)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Mon Oct 21 06:59:33 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+Thu Oct 31 12:59:33 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Network: During an installation, check which backend is in use
   when Systemd is running. (bsc#1151291)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.30
+Version:        4.2.31
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

In general, YaST assumes wicked as the default network service for any kind of installation. But that is not the case for a live installation.

In a live installation systemd is already running and we can determine the backend checking the network.service link.

- https://trello.com/c/qvY7Oygp/1375-3-osdistribution-p1-1151291-build-1330-openqa-test-fails-in-awaitinstall-yast-breaks-network-during-install

## Solution

Check whether `systemd` is running or not for determining the current network backend.