### PR TITLE
Use snapper machine-readable output

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -94,11 +94,13 @@ module Yast2
     #
     # @param number          [Fixnum]        Snapshot's number.
     # @param snapshot_type   [Symbol]        Snapshot's type: :pre, :post or :single.
-    # @param previous_number [Fixnum, nil]   Previous snapshot's number.
-    # @param timestamp       [DateTime, nil] Timestamp
-    # @param user            [String, nil]   Snapshot's owner username.
-    # @param cleanup_algo    [Symbol, nil]   Clean-up algorithm.
-    # @param description     [String, nil]   Snapshot's description.
+    # @param previous_number [Fixnum, nil]   Previous snapshot's number; nil if the snapshot has no pre
+    #                                        snapshot associated to it.
+    # @param timestamp       [DateTime, nil] Timestamp; nil if the datetime is unknown.
+    # @param user            [String, nil]   Snapshot's owner username; nil if the owner is unknown.
+    # @param cleanup_algo    [Symbol, nil]   Clean-up algorithm; nil if the algorithm is unknown.
+    # @param description     [String, nil]   Snapshot's description; nil if the snapshot has no
+    #                                        description.
     # @return [FsSnapshot] New FsSnapshot object.
     def initialize(number, snapshot_type, previous_number, timestamp, user, cleanup_algo, description)
       @number = number

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -274,6 +274,11 @@ module Yast2
 
           fields = row.fields
 
+          if !fields[3].is_a?(DateTime)
+            log.warn("Error when parsing date/time: #{fields[3]}")
+            fields[3] = nil
+          end
+
           fields[1] = fields[1].to_sym # type
           fields[5] = fields[5].to_sym if fields[5] # cleanup
 

--- a/library/system/test/fixtures/empty-snapper-list.txt
+++ b/library/system/test/fixtures/empty-snapper-list.txt
@@ -1,2 +1,1 @@
- # | Type   | Pre # | Date                             | User | Cleanup | Description  | Userdata     
----+--------+-------+----------------------------------+------+---------+--------------+--------------
+number,type,pre-number,date,user,cleanup,description

--- a/library/system/test/fixtures/snapper-list.txt
+++ b/library/system/test/fixtures/snapper-list.txt
@@ -1,7 +1,6 @@
-  # | Type   | Pre # | Date                             | User | Cleanup | Description  | Userdata     
-----+--------+-------+----------------------------------+------+---------+--------------+--------------
- 0  | single |       |                                  | root |         | current      |              
- 1  | pre    |       | Wed 13 May 2015 04:14:14 PM WEST | root | number  | zypp(y2base) | important=no 
- 3  | pre    |       | Wed 13 May 2015 05:01:47 PM WEST | root | number  | zypp(zypper) | important=no 
- 4  | post   |     3 | Wed 13 May 2015 05:03:13 PM WEST | root | number  | zypp(zypper) | important=no 
-15* | single |       | Wed 13 May 2015 05:11:25 PM WEST | root |         |              |              
+number,type,pre-number,date,user,cleanup,description
+0,single,,,root,,current
+1,pre,,2015-05-13 04:14:14,root,number,zypp(y2base)
+3,pre,,2015-05-15 05:01:47,root,number,zypp(zypper)
+4,post,3,2015-05-13 05:03:13,root,number,zypp(zypper)
+15,single,,2015-05-13 05:11:25,root,,

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -449,7 +449,6 @@ describe Yast2::FsSnapshot do
 
     context "when snapper is configured" do
       let(:configured) { true }
-      let(:output) { File.read(output_path) }
 
       let(:command) { format(Yast2::FsSnapshot::LIST_SNAPSHOTS_CMD, root: "/") }
 
@@ -460,6 +459,7 @@ describe Yast2::FsSnapshot do
       end
 
       context "given some snapshots exist" do
+        let(:output) { File.read(output_path) }
         let(:output_path) { File.expand_path("fixtures/snapper-list.txt", __dir__) }
 
         it "should return the snapshots and log about how many were found" do
@@ -471,10 +471,24 @@ describe Yast2::FsSnapshot do
       end
 
       context "given no snapshots exist" do
+        let(:output) { File.read(output_path) }
         let(:output_path) { File.expand_path("fixtures/empty-snapper-list.txt", __dir__) }
 
         it "should return an empty array" do
           expect(described_class.all).to eq([])
+        end
+      end
+
+      context "when an snapshot contains a wrong date" do
+        let(:output) do
+          "number,type,pre-number,date,user,cleanup,description\n" \
+          "1,single,,bad-date,root,,\n"
+        end
+
+        it "sets timestamp to nil" do
+          snapshot = described_class.all.first
+
+          expect(snapshot.timestamp).to be_nil
         end
       end
     end

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -1,5 +1,24 @@
 #!/usr/bin/env rspec
 
+# Copyright (c) [2015-2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require_relative "test_helper"
 require "yast2/fs_snapshot"
 
@@ -7,10 +26,6 @@ describe Yast2::FsSnapshot do
   def logger
     described_class.log
   end
-
-  FIND_CONFIG = "/usr/bin/snapper --no-dbus --root=/ list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
-  FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
-  LIST_SNAPSHOTS = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list --disable-used-space".freeze
 
   let(:dummy_snapshot) { double("snapshot") }
 
@@ -20,9 +35,11 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".configured?" do
+    let(:command) { format(Yast2::FsSnapshot::FIND_CONFIG_CMD, root: "/") }
+
     before do
       allow(Yast::SCR).to receive(:Execute)
-        .with(path(".target.bash_output"), FIND_CONFIG)
+        .with(path(".target.bash_output"), command)
         .and_return("stdout" => "", "exit" => find_code)
     end
 
@@ -44,7 +61,10 @@ describe Yast2::FsSnapshot do
     end
 
     context "in initial stage before scr switched" do
+      let(:command) { format(Yast2::FsSnapshot::FIND_CONFIG_CMD, root: "/mnt") }
+
       let(:find_code) { 0 }
+
       before do
         Yast.import "Installation"
         Yast::Installation.destdir = "/mnt"
@@ -53,13 +73,13 @@ describe Yast2::FsSnapshot do
         allow(Yast::Stage).to receive(:initial).and_return true
 
         allow(Yast::SCR).to receive(:Execute)
-          .with(path(".target.bash_output"), FIND_IN_ROOT_CONFIG)
+          .with(path(".target.bash_output"), command)
           .and_return("stdout" => "", "exit" => 0)
       end
 
       it "detects snapper configuration in installation target dir" do
         expect(Yast::SCR).to receive(:Execute)
-          .with(path(".target.bash_output"), FIND_IN_ROOT_CONFIG)
+          .with(path(".target.bash_output"), command)
           .and_return("stdout" => "", "exit" => 0)
 
         expect(described_class.configured?).to eq(true)
@@ -431,9 +451,11 @@ describe Yast2::FsSnapshot do
       let(:configured) { true }
       let(:output) { File.read(output_path) }
 
+      let(:command) { format(Yast2::FsSnapshot::LIST_SNAPSHOTS_CMD, root: "/") }
+
       before do
         allow(Yast::SCR).to receive(:Execute)
-          .with(path(".target.bash_output"), LIST_SNAPSHOTS)
+          .with(path(".target.bash_output"), command)
           .and_return("stdout" => output, "exit" => 0)
       end
 
@@ -477,9 +499,11 @@ describe Yast2::FsSnapshot do
       let(:output) { File.read(output_path) }
       let(:output_path) { File.expand_path("fixtures/snapper-list.txt", __dir__) }
 
+      let(:command) { format(Yast2::FsSnapshot::LIST_SNAPSHOTS_CMD, root: "/") }
+
       before do
         allow(Yast::SCR).to receive(:Execute)
-          .with(path(".target.bash_output"), LIST_SNAPSHOTS)
+          .with(path(".target.bash_output"), command)
           .and_return("stdout" => output, "exit" => 0)
       end
 
@@ -489,7 +513,7 @@ describe Yast2::FsSnapshot do
           expect(snapshot.number).to eq(4)
           expect(snapshot.snapshot_type).to eq(:post)
           expect(snapshot.previous_number).to eq(3)
-          expect(snapshot.timestamp).to eq(DateTime.parse("Wed 13 May 2015 05:03:13 PM WEST"))
+          expect(snapshot.timestamp).to eq(DateTime.parse("2015-05-13 05:03:13"))
           expect(snapshot.user).to eq("root")
           expect(snapshot.cleanup_algo).to eq(:number)
           expect(snapshot.description).to eq("zypp(zypper)")
@@ -517,10 +541,12 @@ describe Yast2::FsSnapshot do
     let(:output) { File.read(output_path) }
     let(:output_path) { File.expand_path("fixtures/snapper-list.txt", __dir__) }
 
+    let(:command) { format(Yast2::FsSnapshot::LIST_SNAPSHOTS_CMD, root: "/") }
+
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(true)
       allow(Yast::SCR).to receive(:Execute)
-        .with(path(".target.bash_output"), LIST_SNAPSHOTS)
+        .with(path(".target.bash_output"), command)
         .and_return("stdout" => output, "exit" => 0)
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 05 14:15:16 UTC 2019 - José Iván López González <jlopez@suse.com>
+
+- Use new snapper machine-readable output to retrieve snapshots
+  information (related to bsc#1149322).
+- 4.2.33
+
+-------------------------------------------------------------------
 Tue Nov 05 13:24:40 UTC 2019 - Oliver Kurz <okurz@suse.com>
 
 - Add linuxrc option "reboot_timeout" to configure the timeout

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -119,6 +119,8 @@ Conflicts:      yast2-installation < 4.2.9
 Conflicts:      yast2-mail < 3.1.7
 # Older packager use removed API
 Conflicts:      yast2-packager < 4.0.33
+# Older snapper does not provide machine-readable output
+Conflicts:	snapper < 0.8.6
 
 Obsoletes:      yast2-devel-doc
 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.32
+Version:        4.2.33
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Class `FsSnapshot` is used to retrieve filesystem snapshots information. To achieve that, some *snapper* cli commands are directly used. Till now, *snapper* commands only generated a human-readable output. That output might change when some new information is displayed. And such changes might ruin scripts relying on the *snapper* cli output.

But now, *snapper* is also offering a machine-readable output that should be used by scripts. 

* Part of https://trello.com/c/YAhIvrHz/417-5-optional-non-default-machine-readable-output-from-snapper.

* Requires https://github.com/openSUSE/snapper/pull/494

## Solution

Class `FsSnapshot` is adapted to use *snapper* machine-readable output (*CSV* output format in this case).

## Tests

* Unit tests have been adapted.
