### PR TITLE
Improve the #wrap_text helper

### DIFF
--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -27,17 +27,14 @@ module UI
     #
     # @param text [String] text to be wrapped
     # @param line_width [Integer] max line length
-    # @option preprend_text [String] the text to prepended
     # @param n_lines [Integer, nil] the maximum number of lines
     # @param cut_text [String] the omission text to be used when the text should be cut
     #
     # @return [String]
-    def wrap_text(text, line_width = 76, prepend_text: "", n_lines: nil, cut_text: "")
-      full_text = prepend_text + text
+    def wrap_text(text, line_width = 76, n_lines: nil, cut_text: "")
+      return text if line_width > text.length
 
-      return full_text if line_width > full_text.length
-
-      wrapped_text = full_text.lines.collect! do |line|
+      wrapped_text = text.lines.collect! do |line|
         l = (line.length > line_width) ? line.gsub(/(.{1,#{line_width}})(?:\s+|$)/, "\\1\n") : line
         l.strip
       end

--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -43,18 +43,20 @@ module UI
       end
 
       result = wrapped_text.join("\n")
-      result = excerpt(result, n_lines, omission: cut_text) if n_lines
+      result = head(result, n_lines, omission: cut_text) if n_lines
       result
     end
 
-    # Extract an excerpt of given text if it has more lines than the maximum allowed
+    # Returns only the first requested lines of the given text
+    #
+    # If the omission param is given, an extra line holding it will be included
     #
     # @param text [String]
     # @param max_lines [Integer]
     # @param omission [String] the text to be added
     #
-    # @return [String] an excerpt if given text had more lines than requested; full text otherwise
-    def excerpt(text, max_lines, omission: "")
+    # @return [String] the first requested lines if the text has more; full text otherwise
+    def head(text, max_lines, omission: "")
       lines = text.lines
 
       return text if lines.length <= max_lines

--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -20,36 +20,48 @@
 module UI
   # Provides a set of methods to manipulate and transform UI text
   module TextHelpers
-    # Wrap given text breaking lines longer than given wrap size. It supports
-    # custom separator, max number of lines to split in and cut text to add
-    # as last line if cut was needed.
+    # Wrap text breaking lines in the first whitespace that does not exceed given line width
     #
-    # @param [String] text to be wrapped
-    # @param [String] wrap size
-    # @param [Hash <String>] optional parameters as separator and prepend_text.
-    # @return [String] wrap text
-    def wrap_text(text, wrap = 76, separator: " ", prepend_text: "",
-      n_lines: nil, cut_text: nil)
-      lines = []
-      message_line = prepend_text
-      text.split(/\s+/).each_with_index do |t, i|
-        if !message_line.empty? && "#{message_line}#{t}".size > wrap
-          lines << message_line
-          message_line = ""
-        end
+    # Additionally, it also allows retrieving only an excerpt of the wrapped text according to the
+    # maximum number of lines indicated, adding one more with the cut_text text when it is given.
+    #
+    # @param text [String] text to be wrapped
+    # @param line_width [Integer] max line length
+    # @option preprend_text [String] the text to prepended
+    # @param n_lines [Integer, nil] the maximum number of lines
+    # @param cut_text [String] the omission text to be used when the text should be cut
+    #
+    # @return [String]
+    def wrap_text(text, line_width = 76, prepend_text: "", n_lines: nil, cut_text: "")
+      full_text = prepend_text + text
 
-        message_line << separator if !message_line.empty? && i != 0
-        message_line << t
+      return full_text if line_width > full_text.length
+
+      wrapped_text = full_text.lines.collect! do |line|
+        l = (line.length > line_width) ? line.gsub(/(.{1,#{line_width}})(?:\s+|$)/, "\\1\n") : line
+        l.strip
       end
 
-      lines << message_line if !message_line.empty?
+      result = wrapped_text.join("\n")
+      result = excerpt(result, n_lines, omission: cut_text) if n_lines
+      result
+    end
 
-      if n_lines && lines.size > n_lines
-        lines = lines[0..n_lines - 1]
-        lines << cut_text if cut_text
-      end
+    # Extract an excerpt of given text if it has more lines than the maximum allowed
+    #
+    # @param text [String]
+    # @param max_lines [Integer]
+    # @param omission [String] the text to be added
+    #
+    # @return [String] an excerpt if given text had more lines than requested; full text otherwise
+    def excerpt(text, max_lines, omission: "")
+      lines = text.lines
 
-      lines.join("\n")
+      return text if lines.length <= max_lines
+
+      result = text.lines[0...max_lines]
+      result << omission unless omission.empty?
+      result.join
     end
 
     # Wrap a given text in direction markers

--- a/library/general/test/text_helpers_test.rb
+++ b/library/general/test/text_helpers_test.rb
@@ -10,43 +10,112 @@ end
 
 describe ::UI::TextHelpers do
   subject { TestTextHelpers.new }
+  let(:text) do
+    "This is a long paragraph.
+    It contains a not_real_but_really_long_word which must not be broken
+    and the length of its longer lines is a little git greater than the default line width.
+    Let's see if it's work."
+  end
 
   describe "#wrap_text" do
-    let(:devices) { ["eth0", "eth1", "eth2", "eth3", "a_very_long_device_name"] }
-    let(:more_devices) do
-      [
-        "enp5s0", "enp5s1", "enp5s2", "enp5s3",
-        "enp5s4", "enp5s5", "enp5s6", "enp5s7"
-      ]
+    context "when the text does not exceed the line width" do
+      let(:text) { "A very short text." }
+
+      it "returns the same text" do
+        expect(subject.wrap_text(text)).to eq(text)
+      end
+
+      context "but a prepend text is given" do
+        let(:prepend_text) { "This is: " }
+
+        it "includes the prepend text" do
+          expect(subject.wrap_text(text, prepend_text: prepend_text)).to match(/^This is/)
+        end
+
+        context "and both of them exceed the line width" do
+          it "returns wrapped text" do
+            wrapped_text = subject.wrap_text(text, 15, prepend_text: prepend_text)
+
+            expect(wrapped_text.lines.size).to eq(2)
+          end
+        end
+      end
     end
 
-    context "given a text" do
-      it "returns same text if it does not exceed the wrap size" do
-        text = "eth0, eth1, eth2, eth3, a_very_long_device_name"
+    context "when the text exceed the given line width" do
+      it "produces a text with lines no longer than given line width" do
+        line_width = 60
+        wrapped_text = subject.wrap_text(text, line_width)
 
-        expect(subject.wrap_text(devices.join(", "))).to eql(text)
+        expect(wrapped_text.lines.map(&:length)).to all(be < line_width)
       end
 
-      context "and a line size" do
-        it "returns given text splitted in lines by given line size" do
-          text = "eth0, eth1, eth2,\n"     \
-                 "eth3,\n"                 \
-                 "a_very_long_device_name"
+      it "respect present carriage returns" do
+        current_lines = text.lines.size
 
-          expect(subject.wrap_text(devices.join(", "), 16)).to eql(text)
+        expect(subject.wrap_text(text).lines.size).to be > current_lines
+      end
+
+      it "does not break words" do
+        wrapped_text = subject.wrap_text(text)
+
+        expect(wrapped_text).to match(/it\'s/)
+        expect(wrapped_text).to match(/not_real_but_really_long_word/)
+      end
+
+      context "and a prepend text is given" do
+        let(:prepend_text) { "This is: " }
+
+        it "includes the prepend text" do
+          expect(subject.wrap_text(text, prepend_text: prepend_text)).to match(/^This is/)
         end
       end
 
-      context "and a number of lines and '...' as cut text" do
-        it "returns wrapped text until given line's number adding '...' as a new line" do
-          devices_s = (devices + more_devices).join(", ")
-          text = "eth0, eth1, eth2,\n"        \
-                 "eth3,\n"                    \
-                 "a_very_long_device_name,\n" \
-                 "..."
+      context "and a max number of lines is set (n_lines)" do
+        it "returns only the first n_lines" do
+          wrapped_text = subject.wrap_text(text, n_lines: 2)
 
-          expect(subject.wrap_text(devices_s, 20, n_lines: 3, cut_text: "...")).to eql(text)
+          expect(wrapped_text.lines.size).to eq(2)
+          expect(wrapped_text).to match(/^This is/)
+          expect(wrapped_text).to match(/broken$/)
         end
+
+        context "with an ommission text (cut_text)" do
+          it "includes an additional line with the cut_text" do
+            omission = "..."
+            wrapped_text = subject.wrap_text(text, n_lines: 2, cut_text: omission)
+
+            expect(wrapped_text.lines.size).to eq(3)
+            expect(wrapped_text).to match(/^This is/)
+            expect(wrapped_text.lines.last).to eq("...")
+          end
+        end
+      end
+    end
+  end
+
+  describe "#excerpt" do
+    let(:omission_text) { "read more" }
+
+    context "when the text has less lines than requested" do
+      it "returns the full text" do
+        expect(subject.excerpt(text, 10)).to eq(text)
+      end
+
+      context "and the omision text is given" do
+        it "does not include the omission text" do
+          expect(subject.excerpt(text, 10, omission: omission_text)).to_not include(omission_text)
+        end
+      end
+    end
+
+    context "when the text has more lines than requested" do
+      it "returns only the first requested lines" do
+        excerpt = subject.excerpt(text, 2)
+
+        expect(excerpt.lines.size).to eq(2)
+        expect(excerpt).to match(/^This is/)
+        expect(excerpt).to match(/broken$/)
       end
     end
   end

--- a/library/general/test/text_helpers_test.rb
+++ b/library/general/test/text_helpers_test.rb
@@ -24,22 +24,6 @@ describe ::UI::TextHelpers do
       it "returns the same text" do
         expect(subject.wrap_text(text)).to eq(text)
       end
-
-      context "but a prepend text is given" do
-        let(:prepend_text) { "This is: " }
-
-        it "includes the prepend text" do
-          expect(subject.wrap_text(text, prepend_text: prepend_text)).to match(/^This is/)
-        end
-
-        context "and both of them exceed the line width" do
-          it "returns wrapped text" do
-            wrapped_text = subject.wrap_text(text, 15, prepend_text: prepend_text)
-
-            expect(wrapped_text.lines.size).to eq(2)
-          end
-        end
-      end
     end
 
     context "when the text exceed the given line width" do
@@ -61,14 +45,6 @@ describe ::UI::TextHelpers do
 
         expect(wrapped_text).to match(/it\'s/)
         expect(wrapped_text).to match(/not_real_but_really_long_word/)
-      end
-
-      context "and a prepend text is given" do
-        let(:prepend_text) { "This is: " }
-
-        it "includes the prepend text" do
-          expect(subject.wrap_text(text, prepend_text: prepend_text)).to match(/^This is/)
-        end
       end
 
       context "and a max number of lines is set (n_lines)" do

--- a/library/general/test/text_helpers_test.rb
+++ b/library/general/test/text_helpers_test.rb
@@ -94,28 +94,28 @@ describe ::UI::TextHelpers do
     end
   end
 
-  describe "#excerpt" do
+  describe "#head" do
     let(:omission_text) { "read more" }
 
     context "when the text has less lines than requested" do
       it "returns the full text" do
-        expect(subject.excerpt(text, 10)).to eq(text)
+        expect(subject.head(text, 10)).to eq(text)
       end
 
       context "and the omision text is given" do
         it "does not include the omission text" do
-          expect(subject.excerpt(text, 10, omission: omission_text)).to_not include(omission_text)
+          expect(subject.head(text, 10, omission: omission_text)).to_not include(omission_text)
         end
       end
     end
 
     context "when the text has more lines than requested" do
       it "returns only the first requested lines" do
-        excerpt = subject.excerpt(text, 2)
+        head = subject.head(text, 2)
 
-        expect(excerpt.lines.size).to eq(2)
-        expect(excerpt).to match(/^This is/)
-        expect(excerpt).to match(/broken$/)
+        expect(head.lines.size).to eq(2)
+        expect(head).to match(/^This is/)
+        expect(head).to match(/broken$/)
       end
     end
   end


### PR DESCRIPTION
## Problem

The [`wrap_text`](https://github.com/yast/yast-yast2/blob/43753ef77843e1a43a691b59154e52efb966785c/library/general/src/lib/ui/text_helpers.rb#L31-L53) helper method [does not respect new lines already present](https://github.com/yast/yast-installation/pull/827#issuecomment-553808305) in the given text.

## Solution

Just to preserve the already present new lines.

Now the method,  _slightly_ inspired in the [Rails' `word_wrap`](https://github.com/rails/rails/blob/dcaa388badf49423fb8613bc02652e448890f879/actionview/lib/action_view/helpers/text_helper.rb#L260-L264), is also a bit more efficient.

Additionally, the logic to extract only a few lines after wrap the text has been moved to a new [`head`](https://github.com/yast/yast-yast2/blob/ea2d2d304b234721aae82b91547a1593f50fee68/library/general/src/lib/ui/text_helpers.rb#L50-L67) method.

## Some considerations

* No version bump is needed. Just wait until next one.
* Please, see also [my self review below](#pullrequestreview-317581410) :point_down: 

## Tests

* Unit tests adapted
* Tested manually via dud

## Screenshots

<details>
<summary>Click to toggle the screenshots</summary>

<hr/>

<p align="center">Before</p>

  ![using wrap_text](https://user-images.githubusercontent.com/1691872/68845358-31ac8280-06c3-11ea-9ff4-a926c4e0a0e8.png)

   
<p align="center">After</p>
  
  ![fixed_wrap_text](https://user-images.githubusercontent.com/1691872/68934157-13f81f80-078e-11ea-8176-c161fbc0ad0e.png)
</details>

---

Related to https://github.com/yast/yast-installation/pull/827#issuecomment-553808305
