### PR TITLE
Network: drop unsupported technologies

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -100,7 +100,7 @@ module Yast
       @CardRegex =
         # other: irlan|lo|plip|...
         {
-          "netcard" => "ath|bnep|ci|ctc|slc|dummy|bond|escon|eth|fddi|ficon|hsi|qeth|lcs|iucv|myri|tr|usb|wlan|xp|vlan|br|tun|tap|ib|em|p|p[0-9]+p",
+          "netcard" => "ath|ci|ctc|slc|dummy|bond|eth|ficon|hsi|qeth|lcs|iucv|wlan|xp|vlan|br|tun|tap|ib|em|p|p[0-9]+p",
           "modem"   => "ppp|modem",
           "isdn"    => "isdn|ippp",
           "dsl"     => "dsl"
@@ -1013,18 +1013,14 @@ module Yast
     # for this hardware
     def GetDeviceTypes
       # common linux device types available on all architectures
-      common_dev_types = ["eth", "tr", "vlan", "br", "tun", "tap", "bond"]
+      common_dev_types = ["eth", "vlan", "br", "tun", "tap", "bond"]
 
       # s390 specific device types
-      s390_dev_types = ["hsi", "ctc", "escon", "ficon", "iucv", "qeth", "lcs"]
+      s390_dev_types = ["hsi", "ctc", "ficon", "iucv", "qeth", "lcs"]
 
       # device types which cannot be present on s390 arch
       s390_unknown_dev_types = [
-        "bnep",
         "dummy",
-        "fddi",
-        "myri",
-        "usb",
         "wlan",
         "ib"
       ]
@@ -1067,16 +1063,9 @@ module Yast
 
       device_types = {
         # Device type label
-        "arc"   => [_("ARCnet"), _("ARCnet Network Card")],
-        # Device type label
         "atm"   => [
           _("ATM"),
           _("Asynchronous Transfer Mode (ATM)")
-        ],
-        # Device type label
-        "bnep"  => [
-          _("Bluetooth"),
-          _("Bluetooth Connection")
         ],
         # Device type label
         "bond"  => [_("Bond"), _("Bond Network")],
@@ -1085,8 +1074,6 @@ module Yast
           _("CLAW"),
           _("Common Link Access for Workstation (CLAW)")
         ],
-        # Device type label
-        "contr" => [_("ISDN"), _("ISDN Card")],
         # Device type label
         "ctc"   => [
           _("CTC"),
@@ -1097,17 +1084,10 @@ module Yast
         # Device type label
         "dummy" => [_("Dummy"), _("Dummy Network Device")],
         # Device type label
-        "escon" => [
-          _("ESCON"),
-          _("Enterprise System Connector (ESCON)")
-        ],
-        # Device type label
         "eth"   => [
           _("Ethernet"),
           _("Ethernet Network Card")
         ],
-        # Device type label
-        "fddi"  => [_("FDDI"), _("FDDI Network Card")],
         # Device type label
         "ficon" => [
           _("FICON"),
@@ -1143,8 +1123,6 @@ module Yast
         # Device type label
         "modem" => [_("Modem"), _("Modem")],
         # Device type label
-        "myri"  => [_("Myrinet"), _("Myrinet Network Card")],
-        # Device type label
         "net"   => [_("ISDN"), _("ISDN Connection")],
         # Device type label
         "plip"  => [
@@ -1169,21 +1147,12 @@ module Yast
           _("Serial Line Connection")
         ],
         # Device type label
-        "tr"    => [
-          _("Token Ring"),
-          _("Token Ring Network Card")
-        ],
-        # Device type label
-        "usb"   => [_("USB"), _("USB Network Device")],
-        # Device type label
         "vmnet" => [_("VMWare"), _("VMWare Network Device")],
         # Device type label
         "wlan"  => [
           _("Wireless"),
           _("Wireless Network Card")
         ],
-        # Device type label
-        "xp"    => [_("XPNET"), _("XP Network")],
         # Device type label
         "vlan"  => [_("VLAN"), _("Virtual LAN")],
         # Device type label

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -100,7 +100,7 @@ module Yast
       @CardRegex =
         # other: irlan|lo|plip|...
         {
-          "netcard" => "ath|ci|ctc|slc|dummy|bond|eth|ficon|hsi|qeth|lcs|wlan|xp|vlan|br|tun|tap|ib|em|p|p[0-9]+p",
+          "netcard" => "ath|ci|ctc|slc|dummy|bond|eth|ficon|hsi|qeth|lcs|wlan|vlan|br|tun|tap|ib|em|p|p[0-9]+p",
           "modem"   => "ppp|modem",
           "isdn"    => "isdn|ippp",
           "dsl"     => "dsl"

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -100,7 +100,7 @@ module Yast
       @CardRegex =
         # other: irlan|lo|plip|...
         {
-          "netcard" => "ath|ci|ctc|slc|dummy|bond|eth|ficon|hsi|qeth|lcs|iucv|wlan|xp|vlan|br|tun|tap|ib|em|p|p[0-9]+p",
+          "netcard" => "ath|ci|ctc|slc|dummy|bond|eth|ficon|hsi|qeth|lcs|wlan|xp|vlan|br|tun|tap|ib|em|p|p[0-9]+p",
           "modem"   => "ppp|modem",
           "isdn"    => "isdn|ippp",
           "dsl"     => "dsl"
@@ -1111,11 +1111,6 @@ module Yast
         "irda"  => [_("IrDA"), _("Infrared Device")],
         # Device type label
         "isdn"  => [_("ISDN"), _("ISDN Connection")],
-        # Device type label
-        "iucv"  => [
-          _("IUCV"),
-          _("Inter User Communication Vehicle (IUCV)")
-        ],
         # Device type label
         "lcs"   => [_("OSA LCS"), _("OSA LCS Network Card")],
         # Device type label

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1016,7 +1016,7 @@ module Yast
       common_dev_types = ["eth", "vlan", "br", "tun", "tap", "bond"]
 
       # s390 specific device types
-      s390_dev_types = ["hsi", "ctc", "ficon", "iucv", "qeth", "lcs"]
+      s390_dev_types = ["hsi", "ctc", "ficon", "qeth", "lcs"]
 
       # device types which cannot be present on s390 arch
       s390_unknown_dev_types = [

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1009,6 +1009,7 @@ module Yast
       true
     end
 
+    # @deprecated Not longer needed
     # Return supported network device types (for type netcard)
     # for this hardware
     def GetDeviceTypes
@@ -1042,6 +1043,7 @@ module Yast
       deep_copy(dev_types)
     end
 
+    # @deprecated Not longer needed
     # Return textual device type
     # @param [String] type device type
     # @param [String] longdescr description type

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 28 10:21:31 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Network: drop support for obsolete network device types
+  (jsc#SLE-7753)
+- 4.2.42
+
+-------------------------------------------------------------------
 Wed Nov 27 10:24:28 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use /etc/login.defs.d/70-yast.defs to write login.defs

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.41
+Version:        4.2.42
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

There are many network interfaces that are rarely used or the support in SUSE has been deprecated. As we do not plant to support them in network-ng we should remove them in order to not be offered when adding a new connection.

The current list is obtained by the 'Yast::NetworkInterfaces.GetDeviceTypes' method

https://github.com/yast/yast-network/blob/90bf250c3cd8becf7f7196dea1e83449adaac900/src/lib/y2network/widgets/interface_type.rb#L51

![AddConnection](https://user-images.githubusercontent.com/7056681/69281089-94c87880-0bdf-11ea-9893-52f3a5315ba7.png)

- https://trello.com/c/qg8k5n8y/1379-3-feature-jscsle-7753-drop-deprecated-network-technologies-in-yast2

## Solution

By now, the interfaces requested in the feature have been removed from the list used for configuring a new connection.

The `NetworkInterfaces.GetDeviceTypes` dependency has been also removed from yast2-network but without depending on the specific yast2 version used by this PR. For that reason, we have not dropped the methods yet and just adapted them.

