### PR TITLE
Do no try to fetch the license when it's already provided

### DIFF
--- a/library/packages/src/lib/y2packager/license.rb
+++ b/library/packages/src/lib/y2packager/license.rb
@@ -54,7 +54,7 @@ module Y2Packager
         log.info "Searching for a license for product #{product_name}"
         return cache[product_name] if cache[product_name]
 
-        fetcher = LicensesFetchers.for(product_name)
+        fetcher = LicensesFetchers.for(product_name) unless content
         handler = LicensesHandlers.for(fetcher, product_name) if fetcher
 
         license = License.new(product_name: product_name, fetcher: fetcher,

--- a/library/packages/test/y2packager/license_test.rb
+++ b/library/packages/test/y2packager/license_test.rb
@@ -34,14 +34,16 @@ describe Y2Packager::License do
 
   describe ".find" do
     context "when some content is given" do
-      before do
-        allow(Y2Packager::License).to receive(:new)
-          .with(product_name: "SLES", fetcher: fetcher, handler: handler, content: content)
-          .and_return(license)
+      it "does not look for a license fetcher" do
+        expect(Y2Packager::LicensesFetchers).to_not receive(:for)
+
+        described_class.find("SLES", content: content)
       end
 
-      it "uses the content as license's content" do
-        expect(described_class.find("SLES", content: content)).to be(license)
+      it "uses the content as license's text" do
+        product_license = described_class.find("SLES", content: content)
+
+        expect(product_license.content_for).to eq(content)
       end
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 19 09:51:48 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not try to fetch the license text when it is already provided
+  (bsc#1153326).
+- 4.1.75
+
+-------------------------------------------------------------------
 Fri Sep  6 11:15:40 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix a problem when long warnings reports in command line

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.74
+Version:        4.1.75
 
 Release:        0
 Summary:        YaST2 - Main Package


### PR DESCRIPTION
## Problem

Changes made in #880 try to ~~fetch the license content~~ look for a license fetcher even when ~~it~~ the content for default language was already provided ~~, which is wrong although it will not fail most of times.~~

* Trello: https://trello.com/c/ORqk8sk7/1444-1-p1-yast-asks-for-media-because-of-a-license-to-show-but-the-license-is-missing
* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1153326

## Solution

Don't try to fetch the license text when it is given.

---

Kudos to @lslezak 

