### PR TITLE
Skip license fetcher

### DIFF
--- a/library/packages/src/lib/y2packager/license.rb
+++ b/library/packages/src/lib/y2packager/license.rb
@@ -54,7 +54,7 @@ module Y2Packager
         log.info "Searching for a license for product #{product_name}"
         return cache[product_name] if cache[product_name]
 
-        fetcher = LicensesFetchers.for(product_name)
+        fetcher = LicensesFetchers.for(product_name) unless content
         handler = LicensesHandlers.for(fetcher, product_name) if fetcher
 
         license = License.new(product_name: product_name, fetcher: fetcher,

--- a/library/packages/src/lib/y2packager/licenses_fetchers/tarball.rb
+++ b/library/packages/src/lib/y2packager/licenses_fetchers/tarball.rb
@@ -58,7 +58,7 @@ module Y2Packager
         expanded_url = Yast::Pkg.ExpandedUrl(url)
 
         src = Yast::Pkg.RepositoryAdd("base_urls" => [expanded_url])
-        @archive_file_name = Yast::Pkg.SourceProvideFile(src, 1, archive_name)
+        @archive_file_name = Yast::Pkg.SourceProvideOptionalFile(src, 1, archive_name)
 
         system("tar -C #{archive_dir.shellescape} -x -f #{@archive_file_name.shellescape}") if @archive_file_name
 

--- a/library/packages/test/y2packager/license_test.rb
+++ b/library/packages/test/y2packager/license_test.rb
@@ -34,14 +34,16 @@ describe Y2Packager::License do
 
   describe ".find" do
     context "when some content is given" do
-      before do
-        allow(Y2Packager::License).to receive(:new)
-          .with(product_name: "SLES", fetcher: fetcher, handler: handler, content: content)
-          .and_return(license)
+      it "does not look for a license fetcher" do
+        expect(Y2Packager::LicensesFetchers).to_not receive(:for)
+
+        described_class.find("SLES", content: content)
       end
 
-      it "uses the content as license's content" do
-        expect(described_class.find("SLES", content: content)).to be(license)
+      it "uses the content as license's text" do
+        product_license = described_class.find("SLES", content: content)
+
+        expect(product_license.content_for).to eq(content)
       end
     end
 

--- a/library/packages/test/y2packager/licenses_fetchers/tarball_test.rb
+++ b/library/packages/test/y2packager/licenses_fetchers/tarball_test.rb
@@ -37,7 +37,7 @@ describe Y2Packager::LicensesFetchers::Tarball do
     allow(Yast::Pkg).to receive(:RepositoryAdd)
       .and_return nil
 
-    allow(Yast::Pkg).to receive(:SourceProvideFile)
+    allow(Yast::Pkg).to receive(:SourceProvideOptionalFile)
       .and_return tar_path
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 20 08:32:01 UTC 2019 - David Diaz <dgonzalez@suse.com>
+
+- Do not try to find licenses in the installation medium when they
+  have been already downloaded from SCC (bsc#1153326).
+- 4.2.35
+
+-------------------------------------------------------------------
 Fri Nov 15 09:30:20 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix crash in upgrade caused by wrong parameter to snapper

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.34
+Version:        4.2.35
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

> YaST downloads the license from SCC, but then it tries to find the license on the installation medium as well. — [comment#13 at bsc#1153326](https://bugzilla.suse.com/show_bug.cgi?id=1153326#c13)

* Trello: https://trello.com/c/ORqk8sk7/1444-1-p1-yast-asks-for-media-because-of-a-license-to-show-but-the-license-is-missing
* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1153326

## Why?

Because the installer is looking for a license fetcher even when the license content was already provided, which 

* seems to be a wrong behavior although _it will not fail_ most of times.
* is a consequence of changes made in #880, at the time to introduce a new license fetcher to get them from an .rpm _fallback repo_


Note: the provided license content is used only for the default language, which was already discussed in a closed - and similar - PR for SLE-15-SP1 branch (see comments in #982).

## Solution

Do not look for a license fetcher when the license content is given.

## Tests

* Unit tests updated
* Tested by hand via ~~driver update~~ [yupdate](https://github.com/lslezak/scripts/blob/master/yast/yupdate/yupdate)

## Screenshots

<details>
<summary>Click to show/hide some screenshots</summary>

<hr/>

<p align="center">The error shown WITHOUT the patch</p>

![canvas](https://user-images.githubusercontent.com/1691872/69241144-0aa7f200-0b96-11ea-8929-153d65abdb16.png)

<hr/>

<p align="center">The step shown WITH the patch applied</p>

![Screenshot_openSUSE-TW_2019-11-20_12:51:38](https://user-images.githubusercontent.com/1691872/69241209-36c37300-0b96-11ea-935a-42cbd7e7ae8a.png)

<p align="center">Other relevant screenshots</p>

| The SLE-HA module selected | A relevant part in the logs |
|----------------------------|-----------------------------|
| ![Screenshot_openSUSE-TW_2019-11-20_12:51:51](https://user-images.githubusercontent.com/1691872/69241284-64a8b780-0b96-11ea-803c-f566d2d6f79c.png) | ![Screenshot_openSUSE-TW_2019-11-20_12:51:29](https://user-images.githubusercontent.com/1691872/69241312-712d1000-0b96-11ea-951c-b00d694fd752.png) |

</details>







---

Kudos to @lslezak 

