### PR TITLE
Read installinf instsys

### DIFF
--- a/library/general/src/modules/Linuxrc.rb
+++ b/library/general/src/modules/Linuxrc.rb
@@ -49,6 +49,11 @@ module Yast
     def ReadInstallInf
       return if !@install_inf.nil?
 
+      # skip from chroot
+      old_SCR = WFM.SCRGetDefault
+      new_SCR = WFM.SCROpen("chroot=/:scr", false)
+      WFM.SCRSetDefault(new_SCR)
+
       @install_inf = {}
       # don't read anything if the file doesn't exist
       if SCR.Read(path(".target.size"), "/etc/install.inf") == -1
@@ -66,6 +71,10 @@ module Yast
         )
         Ops.set(@install_inf, e, val)
       end
+
+      # close and chroot back
+      WFM.SCRSetDefault(old_SCR)
+      WFM.SCRClose(new_SCR)
 
       nil
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 21 14:04:28 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Ensure /etc/install.inf is not read from the target system but
+  from the local one. (bsc#1122493, bsc#1157476)
+- 4.2.36
+
+-------------------------------------------------------------------
 Wed Nov 20 08:32:01 UTC 2019 - David Diaz <dgonzalez@suse.com>
 
 - Do not try to find licenses in the installation medium when they

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.35
+Version:        4.2.36
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Linuxrc maintains the state of what was read from '/etc/install.inf' file. If for any reason the internal state is reset and the SCR root was already modified then, it is probably that we try to read the file from the target system instead of the local one, and if already unmounted that could be like shooting ourselves in the foot.

- https://bugzilla.suse.com/show_bug.cgi?id=1157476 (it also contains a long history of the problem itself)

## Solution

For avoiding that problem we ensure to use "/" as SCR root before reading "/etc/install.inf"