### PR TITLE
Linuxrc: Ensure the new SCR instance is closed

### DIFF
--- a/library/system/test/fs_snapshot_store_test.rb
+++ b/library/system/test/fs_snapshot_store_test.rb
@@ -64,22 +64,23 @@ describe Yast2::FsSnapshotStore do
 
       described_class.clean("test")
     end
-  end
 
-  context "in initial stage before SCR switched" do
-    it "use path on mounted target system" do
-      Yast.import "Installation"
-      Yast::Installation.destdir = "/mnt"
+    context "in initial stage before SCR switched" do
+      it "use path on mounted target system" do
+        Yast.import "Installation"
+        Yast::Installation.destdir = "/mnt"
 
-      Yast.import "Stage"
-      allow(Yast::Stage).to receive(:initial).and_return(true)
+        Yast.import "Stage"
+        allow(Yast::Stage).to receive(:initial).and_return(true)
+        allow(Yast::WFM).to receive(:scr_chrooted?).and_return(false)
 
-      expect(Yast::SCR).to receive(:Execute).with(
-        path(".target.remove"),
-        "/mnt/var/lib/YaST2/pre_snapshot_test.id"
-      )
+        expect(Yast::SCR).to receive(:Execute).with(
+          path(".target.remove"),
+          "/mnt/var/lib/YaST2/pre_snapshot_test.id"
+        )
 
-      described_class.clean("test")
+        described_class.clean("test")
+      end
     end
   end
 end

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -36,11 +36,13 @@ describe Yast2::FsSnapshot do
 
   describe ".configured?" do
     let(:command) { format(Yast2::FsSnapshot::FIND_CONFIG_CMD, root: "/") }
+    let(:chrooted) { true }
 
     before do
       allow(Yast::SCR).to receive(:Execute)
         .with(path(".target.bash_output"), command)
         .and_return("stdout" => "", "exit" => find_code)
+      allow(Yast::WFM).to receive(:scr_chrooted?).and_return chrooted
     end
 
     context "when snapper's configuration does not exist" do
@@ -62,6 +64,7 @@ describe Yast2::FsSnapshot do
 
     context "in initial stage before scr switched" do
       let(:command) { format(Yast2::FsSnapshot::FIND_CONFIG_CMD, root: "/mnt") }
+      let(:chrooted) { false }
 
       let(:find_code) { 0 }
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 21 21:28:58 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Linuxrc: Ensure the new opened SCR instace is closed when reading
+  the /etc/install.inf file (bsc#1122493, bsc#1157476)
+- 4.2.37
+
+-------------------------------------------------------------------
 Thu Nov 21 14:04:28 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
 
 - Ensure /etc/install.inf is not read from the target system but

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.36
+Version:        4.2.37
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

in the previous PR #984 we opened a new SCR instance when reading the /etc/install.inf file, but we are not ensuring we close it in case of empty or not present.

## Solution

Ensure we set back the original default and close the new instance.

## Tests

- Tested the changes in a docker image running the tests in the same order that were failing.