### PR TITLE
Handle shadow configuration when it is split into `/etc` and `/usr/etc`

### DIFF
--- a/library/general/src/lib/cfa/login_defs.rb
+++ b/library/general/src/lib/cfa/login_defs.rb
@@ -20,6 +20,9 @@
 require "yast"
 require "cfa/base_model"
 require "yast2/target_file"
+require "yast2/execute"
+
+Yast.import "FileUtils"
 
 module CFA
   # Model to handle login.defs configuration files
@@ -129,11 +132,24 @@ module CFA
     # Loads the file content
     #
     # If the file does not exist, consider the file as empty.
+    #
+    # @see CFA::BaseModel#load
     def load
       super
     rescue Errno::ENOENT # PATH does not exist yet
       self.data = @parser.empty
       @loaded = true
+    end
+
+    # Saves the file content
+    #
+    # It creates the directory if it does not exist.
+    #
+    # @see CFA::BaseModel#save
+    def save
+      directory = File.dirname(file_path)
+      Yast::Execute.on_target("/usr/bin/mkdir", "--parents", directory) if !Yast::FileUtils.IsDirectory(directory)
+      super
     end
   end
 end

--- a/library/general/src/lib/cfa/login_defs.rb
+++ b/library/general/src/lib/cfa/login_defs.rb
@@ -1,0 +1,139 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cfa/base_model"
+require "yast2/target_file"
+
+module CFA
+  # Model to handle login.defs configuration files
+  #
+  # @example Reading a value
+  #   file = LoginDefs.new(file_path: "/etc/login.defs")
+  #   file.load
+  #   file.encrypt_method #=> "SHA512"
+  #
+  # @example Writing a value
+  #   file = LoginDefs.new(file_path: "/etc/login.defs.d/70-yast.conf")
+  #   file.encrypt_method = "DES"
+  #   file.save
+  #
+  # @example Loading shortcut
+  #   file = LoginDefs.load(file_path: "/etc/login.defs.d/70-yast.conf")
+  #   file.encrypt_method #=> "SHA512"
+  class LoginDefs < BaseModel
+    include Yast::Logger
+
+    # @return [Array<Symbol>] List of known login.defs attributes
+    KNOWN_ATTRIBUTES = [
+      :character_class,
+      :encrypt_method,
+      :fail_delay,
+      :gid_max,
+      :gid_min,
+      :groupadd_cmd,
+      :pass_max_days,
+      :pass_min_days,
+      :pass_warn_age,
+      :sys_gid_max,
+      :sys_gid_min,
+      :sys_uid_max,
+      :sys_uid_min,
+      :uid_max,
+      :uid_min,
+      :useradd_cmd,
+      :userdel_postcmd,
+      :userdel_precmd
+    ].freeze
+
+    class << self
+      # Returns the list of known attributes
+      #
+      # @return [Array<Symbol>]
+      def known_attributes
+        KNOWN_ATTRIBUTES
+      end
+
+      # Instantiates and loads a file
+      #
+      # This method is basically a shortcut to instantiate and load the content in just one call.
+      #
+      # @param file_handler [#read,#write] something able to read/write a string (like File)
+      # @param file_path    [String] File path
+      # @return [LoginDefs] File with the already loaded content
+      def load(file_path:, file_handler: Yast::TargetFile)
+        new(file_path: file_path, file_handler: file_handler).tap(&:load)
+      end
+    end
+
+    attributes(
+      known_attributes.each_with_object({}) { |a, hsh| hsh[a] = a.to_s.upcase }
+    )
+
+    # @return [String] File path
+    attr_reader :file_path
+
+    # Constructor
+    #
+    # @param file_handler [#read,#write] something able to read/write a string (like File)
+    # @param file_path    [String] File path
+    #
+    # @see CFA::BaseModel#initialize
+    def initialize(file_path:, file_handler: Yast::TargetFile)
+      super(AugeasParser.new("login_defs.lns"), file_path, file_handler: file_handler)
+    end
+
+    # Determines whether an attribute has a value
+    #
+    # @return [Boolean] +true+ if it is defined; +false+ otherwise.
+    def present?(attr)
+      !public_send(attr).nil?
+    end
+
+    # Returns the list of attributes with a value
+    #
+    # @return [Array<Symbol>] List of attribute names
+    # @see #present?
+    def present_attributes
+      self.class.known_attributes.select { |a| present?(a) }
+    end
+
+    # Determines the list of conflicting attributes for two files
+    #
+    # Two attributes are conflicting when both of them are defined with
+    # different values.
+    #
+    # @param other [BaseModel] The file to compare with
+    # @return [Array<Symbol>] List of conflicting attributes
+    def conflicts(other)
+      conflicting_attrs = present_attributes & other.present_attributes
+      conflicting_attrs.reject { |a| public_send(a) == other.public_send(a) }
+    end
+
+    # Loads the file content
+    #
+    # If the file does not exist, consider the file as empty.
+    def load
+      super
+    rescue Errno::ENOENT # PATH does not exist yet
+      self.data = @parser.empty
+      @loaded = true
+    end
+  end
+end

--- a/library/general/src/lib/cfa/login_defs_config.rb
+++ b/library/general/src/lib/cfa/login_defs_config.rb
@@ -1,0 +1,158 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cfa/login_defs"
+
+Yast.import "FileUtils"
+
+module CFA
+  # This class allows to interact with the login.defs configuration files
+  #
+  # @example Reading a configuration parameter value
+  #   config = LoginDefsConfig.new
+  #   config.load
+  #   config.encrypt_method #=> "SHA512"
+  #
+  # @example Setting a value
+  #   config = LoginDefsConfig.new
+  #   config.load
+  #   config.fail_delay = "5"
+  #   config.save
+  class LoginDefsConfig
+    YAST_FILE_PATH = "/etc/login.defs.d/70-yast.conf".freeze
+
+    class << self
+      # Define an attribute
+      #
+      # @param attr [Symbol] Attribute name
+      def define_attr(attr)
+        define_method attr do
+          file = files.reverse.find { |f| f.present?(attr) }
+          return file.public_send(attr) if file
+
+          yast_config_file.public_send(attr)
+        end
+
+        define_method "#{attr}=" do |value|
+          yast_config_file.public_send("#{attr}=", value)
+        end
+      end
+    end
+
+    LoginDefs.known_attributes.each { |a| define_attr(a) }
+
+    # Returns the path to the local configuration file
+    #
+    # @return [String] File path
+    def local_file_path
+      "/etc/login.defs"
+    end
+
+    # Returns the path to the vendor configuration file
+    #
+    # @return [String] File path
+    def vendor_file_path
+      "/usr/etc/login.defs"
+    end
+
+    # Loads the configuration
+    def load
+      files.each(&:load)
+    end
+
+    # Save changes to the YaST specific file
+    def save
+      yast_config_file.save
+    end
+
+    # Returns the conflicting attributes
+    #
+    # @return [Array<Symbol>]
+    def conflicts
+      higher_precedence_files.each_with_object([]) do |file, attrs|
+        attrs.concat(yast_config_file.conflicts(file))
+      end
+    end
+
+  private
+
+    # Return the involved configuration files
+    #
+    # @return [Array<LoginDefs>] Configuration files
+    # @see #paths
+    def files
+      @files ||= paths.map { |p| LoginDefs.new(file_path: p) }
+    end
+
+    # Return the paths to the configuration files
+    #
+    # @return [Array<String>]
+    def paths
+      @paths ||=
+        if Yast::FileUtils.Exists(local_file_path)
+          [local_file_path] + local_override_paths
+        else
+          paths = Yast::FileUtils.Exists(vendor_file_path) ? [vendor_file_path] : []
+          paths + vendor_override_paths + local_override_paths
+        end
+    end
+
+    # Returns the paths of the local override files (including the YaST one)
+    #
+    # @return [Array<String>]
+    def local_override_paths
+      (override_paths(local_file_path) + [YAST_FILE_PATH]).uniq.sort
+    end
+
+    # Returns the paths of the vendor override files
+    #
+    # @return [Array<String>]
+    def vendor_override_paths
+      override_paths(vendor_file_path)
+    end
+
+    # @param path [String]
+    # @return [Array<String>]
+    def override_paths(path)
+      directory = "#{path}.d"
+      paths = Yast::SCR.Read(Yast::Path.new(".target.dir"), directory)
+      return [] if paths.nil?
+
+      paths.map { |p| File.join(directory, p) }
+    end
+
+    # Returns the YaST specific configuration file
+    #
+    # @return [LoginDefs]
+    def yast_config_file
+      @yast_config_file ||= files.find { |f| f.file_path == YAST_FILE_PATH }
+    end
+
+    # Returns the files with higher precedence that the YaST one
+    #
+    # @return [Array<LoginDefs>] List of files
+    def higher_precedence_files
+      return @higher_precedence_files if @higher_precedence_files
+
+      yast_config_file_idx = files.find_index { |f| f == yast_config_file }
+      @higher_precedence_files ||= files[yast_config_file_idx + 1..]
+    end
+  end
+end

--- a/library/general/src/lib/cfa/login_defs_config.rb
+++ b/library/general/src/lib/cfa/login_defs_config.rb
@@ -19,13 +19,14 @@
 
 require "yast"
 require "cfa/login_defs"
+require "cfa/multi_file_config"
 
 Yast.import "FileUtils"
 
 module CFA
   # This class allows to interact with the login.defs configuration files
   #
-  # @example Reading a configuration parameter value
+  # @example Reading a configuration parameter
   #   config = LoginDefsConfig.new
   #   config.load
   #   config.encrypt_method #=> "SHA512"
@@ -35,124 +36,9 @@ module CFA
   #   config.load
   #   config.fail_delay = "5"
   #   config.save
-  class LoginDefsConfig
-    YAST_FILE_PATH = "/etc/login.defs.d/70-yast.conf".freeze
-
-    class << self
-      # Define an attribute
-      #
-      # @param attr [Symbol] Attribute name
-      def define_attr(attr)
-        define_method attr do
-          file = files.reverse.find { |f| f.present?(attr) }
-          return file.public_send(attr) if file
-
-          yast_config_file.public_send(attr)
-        end
-
-        define_method "#{attr}=" do |value|
-          yast_config_file.public_send("#{attr}=", value)
-        end
-      end
-    end
-
-    LoginDefs.known_attributes.each { |a| define_attr(a) }
-
-    # Returns the path to the local configuration file
-    #
-    # @return [String] File path
-    def local_file_path
-      "/etc/login.defs"
-    end
-
-    # Returns the path to the vendor configuration file
-    #
-    # @return [String] File path
-    def vendor_file_path
-      "/usr/etc/login.defs"
-    end
-
-    # Loads the configuration
-    def load
-      files.each(&:load)
-    end
-
-    # Save changes to the YaST specific file
-    def save
-      yast_config_file.save
-    end
-
-    # Returns the conflicting attributes
-    #
-    # @return [Array<Symbol>]
-    def conflicts
-      higher_precedence_files.each_with_object([]) do |file, attrs|
-        attrs.concat(yast_config_file.conflicts(file))
-      end
-    end
-
-  private
-
-    # Return the involved configuration files
-    #
-    # @return [Array<LoginDefs>] Configuration files
-    # @see #paths
-    def files
-      @files ||= paths.map { |p| LoginDefs.new(file_path: p) }
-    end
-
-    # Return the paths to the configuration files
-    #
-    # @return [Array<String>]
-    def paths
-      @paths ||=
-        if Yast::FileUtils.Exists(local_file_path)
-          [local_file_path] + local_override_paths
-        else
-          paths = Yast::FileUtils.Exists(vendor_file_path) ? [vendor_file_path] : []
-          paths + vendor_override_paths + local_override_paths
-        end
-    end
-
-    # Returns the paths of the local override files (including the YaST one)
-    #
-    # @return [Array<String>]
-    def local_override_paths
-      (override_paths(local_file_path) + [YAST_FILE_PATH]).uniq.sort
-    end
-
-    # Returns the paths of the vendor override files
-    #
-    # @return [Array<String>]
-    def vendor_override_paths
-      override_paths(vendor_file_path)
-    end
-
-    # @param path [String]
-    # @return [Array<String>]
-    def override_paths(path)
-      directory = "#{path}.d"
-      paths = Yast::SCR.Read(Yast::Path.new(".target.dir"), directory)
-      return [] if paths.nil?
-
-      paths.map { |p| File.join(directory, p) }
-    end
-
-    # Returns the YaST specific configuration file
-    #
-    # @return [LoginDefs]
-    def yast_config_file
-      @yast_config_file ||= files.find { |f| f.file_path == YAST_FILE_PATH }
-    end
-
-    # Returns the files with higher precedence that the YaST one
-    #
-    # @return [Array<LoginDefs>] List of files
-    def higher_precedence_files
-      return @higher_precedence_files if @higher_precedence_files
-
-      yast_config_file_idx = files.find_index { |f| f == yast_config_file }
-      @higher_precedence_files ||= files[yast_config_file_idx + 1..]
-    end
+  class LoginDefsConfig < MultiFileConfig
+    self.file_name = "login.defs"
+    self.yast_file_name = "70-yast.conf"
+    self.file_class = LoginDefs
   end
 end

--- a/library/general/src/lib/cfa/multi_file_config.rb
+++ b/library/general/src/lib/cfa/multi_file_config.rb
@@ -43,6 +43,8 @@ module CFA
   #
   # @see LoginDefsConfig
   class MultiFileConfig
+    include Yast::Logger
+
     class << self
       # Instantiates and loads configuration
       #
@@ -102,6 +104,7 @@ module CFA
 
     # Save changes to the YaST specific file
     def save
+      log_conflicts
       yast_config_file.save
     end
 
@@ -230,6 +233,14 @@ module CFA
     # @return [String]
     def yast_file_name
       self.class.yast_file_name
+    end
+
+    # Logs conflicts
+    def log_conflicts
+      conflicting_attrs = conflicts
+      return if conflicting_attrs.empty?
+
+      log.warn "These configuration values are overridden: #{conflicting_attrs.map(&:to_s).join(", ")}"
     end
   end
 end

--- a/library/general/src/lib/cfa/multi_file_config.rb
+++ b/library/general/src/lib/cfa/multi_file_config.rb
@@ -1,0 +1,235 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module CFA
+  # API to handle configuration of services that are split between {/usr/etc} + {/etc} directories
+  #
+  # This class is intended to work as base to implement support for that kind of configuration. It
+  # abstracts the details about which files are read/written, precedence, etc.
+  #
+  # Individual files are handled through a separate class (usually CFA based).
+  #
+  # @example Defining a class to handle a Foo service configuration
+  #   class FooConfig < MultiFileConfig
+  #     self.file_name = "foo.conf"
+  #     self.yast_file_name = "70-yast.conf"
+  #     self.file_class = CFA::Foo
+  #   end
+  #
+  # @example Using the previous Foo configuration handler class
+  #   config = FooConfig.load
+  #   config.some_param = "some_value1"
+  #   config.save
+  #
+  # @example Detecting conflicts
+  #   config = FooConfig.load
+  #   config.conflicts #=> [:conflicting_param]
+  #
+  # @see LoginDefsConfig
+  class MultiFileConfig
+    class << self
+      # Instantiates and loads configuration
+      #
+      # Convenience method to create instance and load the configuration in just one call.
+      #
+      # @return [MultiFileConfig]
+      def load
+        new.tap(&:load)
+      end
+
+      # Define an attribute
+      #
+      # @param attr [Symbol] Attribute name
+      def define_attr(attr)
+        define_method attr do
+          file = files.reverse.find { |f| f.present?(attr) }
+          return file.public_send(attr) if file
+
+          yast_config_file.public_send(attr)
+        end
+
+        define_method "#{attr}=" do |value|
+          yast_config_file.public_send("#{attr}=", value)
+        end
+      end
+
+      # @!attribute [rw] file_name
+      #   @return [String] Base file name (like 'login.defs'  or 'sysctl.conf')
+      attr_accessor :file_name
+
+      # @!attribute [rw] yast_file_name
+      #   @return [String] YaST specific configuration file name (like '70-yast.conf')
+      attr_accessor :yast_file_name
+
+      # @!attribute [r] file_class
+      #   @return [Class] CFA file class
+      attr_reader :file_class
+
+      def file_class=(klass)
+        raise "It is not possible to redefine the associated file class" if @file_class
+
+        @file_class = klass
+        define_attrs_from(klass)
+      end
+
+    private
+
+      def define_attrs_from(file_class)
+        file_class.known_attributes.each { |a| define_attr(a) }
+      end
+    end
+
+    # Loads the configuration
+    def load
+      files.each(&:load)
+    end
+
+    # Save changes to the YaST specific file
+    def save
+      yast_config_file.save
+    end
+
+    # Returns the conflicting attributes
+    #
+    # Conflicting attributes are the ones which override some value from the YaST specific
+    # configuration file.
+    #
+    # @return [Array<Symbol>]
+    def conflicts
+      higher_precedence_files.each_with_object([]) do |file, attrs|
+        attrs.concat(yast_config_file.conflicts(file))
+      end
+    end
+
+  private
+
+    # Return the involved configuration files
+    #
+    # @return [Array<LoginDefs>] Configuration files
+    # @see #paths
+    def files
+      @files ||= paths.map { |p| LoginDefs.new(file_path: p) }
+    end
+
+    # Return the paths to the configuration files
+    #
+    # @return [Array<String>]
+    def paths
+      @paths ||=
+        if Yast::FileUtils.Exists(local_file_path)
+          [local_file_path] + local_override_paths
+        else
+          paths = Yast::FileUtils.Exists(vendor_file_path) ? [vendor_file_path] : []
+          paths + vendor_override_paths + local_override_paths
+        end
+    end
+
+    # Returns the path to the local configuration file
+    #
+    # @return [String] File path
+    def local_file_path
+      File.join("/etc", file_name)
+    end
+
+    # Returns the path to the vendor configuration file
+    #
+    # @return [String] File path
+    def vendor_file_path
+      File.join("/usr/etc", file_name)
+    end
+
+    # Returns the paths of the local override files (including the YaST one)
+    #
+    # @return [Array<String>]
+    def local_override_paths
+      local_override_dir = override_directory(local_file_path)
+      (paths_in(local_override_dir) + [yast_file_path]).uniq.sort
+    end
+
+    # Returns the paths of the vendor override files
+    #
+    # @return [Array<String>]
+    def vendor_override_paths
+      vendor_override_dir = override_directory(vendor_file_path)
+      paths_in(vendor_override_dir)
+    end
+
+    # Returns the paths to all files in a given directory
+    #
+    # @param directory [String]
+    # @return [Array<String>]
+    def paths_in(directory)
+      paths = Yast::SCR.Read(Yast::Path.new(".target.dir"), directory)
+      return [] if paths.nil?
+
+      paths.sort.map { |p| File.join(directory, p) }
+    end
+
+    # Override directory for a given file
+    #
+    # @param path [String] File path
+    # @return [String]
+    def override_directory(path)
+      "#{path}.d"
+    end
+
+    # Returns the YaST specific configuration file
+    #
+    # @return [LoginDefs]
+    def yast_config_file
+      @yast_config_file ||= files.find { |f| f.file_path == yast_file_path }
+    end
+
+    # Returns the files with higher precedence that the YaST one
+    #
+    # @return [Array<LoginDefs>] List of files
+    def higher_precedence_files
+      return @higher_precedence_files if @higher_precedence_files
+
+      yast_config_file_idx = files.find_index { |f| f == yast_config_file }
+      @higher_precedence_files ||= files[yast_config_file_idx + 1..]
+    end
+
+    # Path to the YaST override file
+    #
+    # @return [String]
+    def yast_file_path
+      @yast_file_path ||= File.join(override_directory(local_file_path), yast_file_name)
+    end
+
+    # Configuration file name
+    #
+    # This is a helper method to get the configuration file name which is defined at class level.
+    #
+    # @return [String]
+    def file_name
+      self.class.file_name
+    end
+
+    # YaST specific configuration file name
+    #
+    # This is a helper method to get the YaST specific configuration file name which is defined at
+    # class level.
+    #
+    # @return [String]
+    def yast_file_name
+      self.class.yast_file_name
+    end
+  end
+end

--- a/library/general/src/lib/cfa/shadow_config.rb
+++ b/library/general/src/lib/cfa/shadow_config.rb
@@ -24,19 +24,19 @@ require "cfa/multi_file_config"
 Yast.import "FileUtils"
 
 module CFA
-  # This class allows to interact with the login.defs configuration files
+  # This class allows to interact with the shadow suite configuration files (login.defs)
   #
   # @example Reading a configuration parameter
-  #   config = LoginDefsConfig.new
+  #   config = ShadowConfig.new
   #   config.load
   #   config.encrypt_method #=> "SHA512"
   #
   # @example Setting a value
-  #   config = LoginDefsConfig.new
+  #   config = ShadowConfig.new
   #   config.load
   #   config.fail_delay = "5"
   #   config.save
-  class LoginDefsConfig < MultiFileConfig
+  class ShadowConfig < MultiFileConfig
     self.file_name = "login.defs"
     self.yast_file_name = "70-yast.conf"
     self.file_class = LoginDefs

--- a/library/general/src/modules/LoginDefsConfig.rb
+++ b/library/general/src/modules/LoginDefsConfig.rb
@@ -1,0 +1,112 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cfa/login_defs_config"
+
+module Yast
+  # This class allows to access the API to handle login.defs attributes from Perl
+  #
+  # @see CFA::LoginDefs
+  # @see CFA::LoginDefsConfig
+  class LoginDefsConfigClass < Module
+    include Logger
+
+    # The given attribute is unknown
+    class UnknownAttributeError < StandardError; end
+
+    # Module initialization
+    def main
+      textdomain "base"
+    end
+
+    # Resets the configuration
+    #
+    # It forces to read the configuration again discarding
+    # the changes.
+    def reset
+      @config = nil
+    end
+
+    # Returns an attribute from login.defs configuration
+    #
+    # @example Getting the encryption method
+    #   Yast::LoginDefsConfig.fetch(:encrypt_method) #=> "SHA512"
+    #
+    # @example Getting the encryption method using the variable name
+    #   Yast::LoginDefsConfig.fetch(ENCRYPT_METHOD) #=> "SHA512"
+    #
+    # @param attr [String,Symbol] Attribute name
+    # @return [String,nil] Attribute value
+    def fetch(attr)
+      normalized_attr = attr.to_s.downcase
+      check_attribute(normalized_attr)
+      config.public_send(normalized_attr)
+    end
+
+    # Sets an attribute to login.defs
+    #
+    # @example Setting the encryption method
+    #   Yast::LoginDefsConfig.set(:encrypt_method, "SHA512")
+    #
+    # @param attr [String,Symbol] Attribute name
+    # @param value [String,nil] Attribute value
+    def set(attr, value)
+      normalized_attr = attr.to_s.downcase
+      check_attribute(normalized_attr)
+      config.public_send("#{normalized_attr}=", value)
+    end
+
+    # Writes the login.defs configuration
+    def write
+      config.save
+    end
+
+    publish function: :fetch, type: "any (string)"
+    publish function: :set, type: "void (string, string)"
+    publish function: :write, type: "void ()"
+    publish function: :reset, type: "void ()"
+
+  private
+
+    # Check whether the attribute is known
+    #
+    # @raise UnknownAttributeError
+    def check_attribute(attr)
+      return if config.respond_to?(attr)
+
+      raise UnknownAttributeError, "Unknown attribute #{attr} for login.defs"
+    end
+
+    # Returns the current login.defs configuration
+    #
+    # @return CFA::LoginDefsConfig
+    # @see CFA::LoginDefsConfig
+    def config
+      return @config if @config
+
+      @config = CFA::LoginDefsConfig.new
+      @config.load
+      @config
+    end
+  end
+
+  LoginDefsConfig = LoginDefsConfigClass.new
+  LoginDefsConfig.main
+end

--- a/library/general/src/modules/ShadowConfig.rb
+++ b/library/general/src/modules/ShadowConfig.rb
@@ -18,14 +18,14 @@
 # find current contact information at www.suse.com.
 
 require "yast"
-require "cfa/login_defs_config"
+require "cfa/shadow_config"
 
 module Yast
   # This class allows to access the API to handle login.defs attributes from Perl
   #
   # @see CFA::LoginDefs
-  # @see CFA::LoginDefsConfig
-  class LoginDefsConfigClass < Module
+  # @see CFA::ShadowConfig
+  class ShadowConfigClass < Module
     include Logger
 
     # The given attribute is unknown
@@ -47,10 +47,10 @@ module Yast
     # Returns an attribute from login.defs configuration
     #
     # @example Getting the encryption method
-    #   Yast::LoginDefsConfig.fetch(:encrypt_method) #=> "SHA512"
+    #   Yast::ShadowConfig.fetch(:encrypt_method) #=> "SHA512"
     #
     # @example Getting the encryption method using the variable name
-    #   Yast::LoginDefsConfig.fetch(ENCRYPT_METHOD) #=> "SHA512"
+    #   Yast::ShadowConfig.fetch(ENCRYPT_METHOD) #=> "SHA512"
     #
     # @param attr [String,Symbol] Attribute name
     # @return [String,nil] Attribute value
@@ -63,7 +63,7 @@ module Yast
     # Sets an attribute to login.defs
     #
     # @example Setting the encryption method
-    #   Yast::LoginDefsConfig.set(:encrypt_method, "SHA512")
+    #   Yast::ShadowConfig.set(:encrypt_method, "SHA512")
     #
     # @param attr [String,Symbol] Attribute name
     # @param value [String,nil] Attribute value
@@ -96,17 +96,17 @@ module Yast
 
     # Returns the current login.defs configuration
     #
-    # @return CFA::LoginDefsConfig
-    # @see CFA::LoginDefsConfig
+    # @return CFA::ShadowConfig
+    # @see CFA::ShadowConfig
     def config
       return @config if @config
 
-      @config = CFA::LoginDefsConfig.new
+      @config = CFA::ShadowConfig.new
       @config.load
       @config
     end
   end
 
-  LoginDefsConfig = LoginDefsConfigClass.new
-  LoginDefsConfig.main
+  ShadowConfig = ShadowConfigClass.new
+  ShadowConfig.main
 end

--- a/library/general/test/cfa/login_defs_config_test.rb
+++ b/library/general/test/cfa/login_defs_config_test.rb
@@ -1,0 +1,145 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "cfa/login_defs_config"
+
+describe CFA::LoginDefsConfig do
+  subject(:config) { described_class.new }
+  let(:scenario) { "custom" }
+
+  around do |example|
+    change_scr_root(File.join(GENERAL_DATA_PATH, "login.defs", scenario), &example)
+  end
+
+  describe "#load" do
+    context "when /etc/login.defs exists" do
+      let(:scenario) { "custom" }
+
+      before do
+        allow(CFA::LoginDefs).to receive(:new).and_call_original
+      end
+
+      it "does not read /usr/etc/login.defs file" do
+        expect(CFA::LoginDefs).to_not receive(:new)
+          .with(file_path: "/usr/etc/login.defs")
+        config.load
+      end
+
+      it "does not read /usr/etc/login.defs.d directory" do
+        expect(CFA::LoginDefs).to_not receive(:new)
+          .with(file_path: "/usr/etc/login.defs.d/encrypt_method.conf")
+        config.load
+      end
+
+      it "reads /etc/login.defs file" do
+        expect(CFA::LoginDefs).to receive(:new)
+          .with(file_path: "/etc/login.defs")
+          .and_call_original
+        config.load
+      end
+
+      it "reads /etc/login.defs.d directory" do
+        expect(CFA::LoginDefs).to receive(:new)
+          .with(file_path: "/etc/login.defs.d/99-local.conf")
+          .and_call_original
+        config.load
+      end
+    end
+
+    context "when /etc/login.defs does not exist" do
+      let(:scenario) { "vendor" }
+
+      before do
+        allow(CFA::LoginDefs).to receive(:new).and_call_original
+      end
+
+      it "reads vendor files" do
+        expect(CFA::LoginDefs).to receive(:new)
+          .with(file_path: "/usr/etc/login.defs")
+          .and_call_original
+        config.load
+      end
+
+      it "reads /usr/etc/login.defs.d directory" do
+        expect(CFA::LoginDefs).to receive(:new)
+          .with(file_path: "/usr/etc/login.defs.d/encrypt_method.conf")
+          .and_call_original
+        config.load
+      end
+
+      it "reads /etc/login.defs.d directory" do
+        expect(CFA::LoginDefs).to receive(:new)
+          .with(file_path: "/etc/login.defs.d/99-local.conf")
+          .and_call_original
+        config.load
+      end
+
+      it "reads the YaST configuration file" do
+        expect(CFA::LoginDefs).to receive(:new)
+          .with(file_path: "/etc/login.defs.d/70-yast.conf")
+          .and_call_original
+        config.load
+      end
+    end
+  end
+
+  describe "#save" do
+    let(:yast_config_file) { CFA::LoginDefs.new(file_path: "/etc/login.defs.d/70-yast.conf") }
+
+    before do
+      allow(CFA::LoginDefs).to receive(:new).and_call_original
+      allow(CFA::LoginDefs).to receive(:new)
+        .with(file_path: "/etc/login.defs.d/70-yast.conf")
+        .and_return(yast_config_file)
+    end
+
+    it "writes changes to /etc/login.defs.d/70-yast.conf" do
+      expect(yast_config_file).to receive(:save)
+      config.save
+    end
+  end
+
+  describe "#conflicts" do
+    before { config.load }
+
+    it "returns override YaST settings" do
+      expect(config.conflicts).to eq([:useradd_cmd])
+    end
+  end
+
+  describe "#encrypt_method" do
+    before { config.load }
+
+    it "returns the highest precedence value" do
+      expect(config.encrypt_method).to eq("SHA256")
+    end
+  end
+
+  describe "#fail_delay=" do
+    let(:scenario) { "custom" }
+
+    before { config.load }
+
+    it "sets the encryption method" do
+      expect { config.fail_delay = "5" }.to change { config.fail_delay }
+        .from("3").to("5")
+    end
+  end
+end

--- a/library/general/test/cfa/login_defs_config_test.rb
+++ b/library/general/test/cfa/login_defs_config_test.rb
@@ -108,11 +108,30 @@ describe CFA::LoginDefsConfig do
       allow(CFA::LoginDefs).to receive(:new)
         .with(file_path: "/etc/login.defs.d/70-yast.conf")
         .and_return(yast_config_file)
+      allow(yast_config_file).to receive(:save)
     end
 
     it "writes changes to /etc/login.defs.d/70-yast.conf" do
       expect(yast_config_file).to receive(:save)
       config.save
+    end
+
+    context "when no conflicts are detected" do
+      it "does not log anything" do
+        expect(config.log).to_not receive(:warn)
+        config.save
+      end
+    end
+
+    context "when a conflict is detected" do
+      before do
+        allow(config).to receive(:conflicts).and_return([:fail_delay, :useradd_cmd])
+      end
+
+      it "logs conflicting attributes" do
+        expect(config.log).to receive(:warn).with(/overridden: fail_delay, useradd_cmd/)
+        config.save
+      end
     end
   end
 

--- a/library/general/test/cfa/login_defs_test.rb
+++ b/library/general/test/cfa/login_defs_test.rb
@@ -19,6 +19,7 @@
 
 require_relative "../test_helper"
 require "cfa/login_defs"
+require "tmpdir"
 
 describe CFA::LoginDefs do
   subject(:login_defs) { described_class.new(file_path: file_path, file_handler: file_handler) }
@@ -31,6 +32,33 @@ describe CFA::LoginDefs do
     it "loads the file content" do
       file = described_class.load(file_path: file_path, file_handler: file_handler)
       expect(file.loaded?).to eq(true)
+    end
+  end
+
+  describe "#save" do
+    let(:file_path) { File.join(tmpdir, "login.defs.d", "70-yast.conf") }
+    let(:tmpdir) { Dir.mktmpdir }
+
+    after do
+      FileUtils.remove_entry(tmpdir)
+    end
+
+    context "when the directory does not exist" do
+      it "creates the directory" do
+        login_defs.save
+        expect(File).to be_directory(File.join(tmpdir, "login.defs.d"))
+      end
+    end
+
+    context "when the directory exists" do
+      before do
+        FileUtils.mkdir(File.join(tmpdir, "login.defs.d"))
+      end
+
+      it "does not create the directory" do
+        expect(Yast::Execute).to_not receive(:on_target).with("/usr/bin/mkdir", any_args)
+        login_defs.save
+      end
     end
   end
 

--- a/library/general/test/cfa/login_defs_test.rb
+++ b/library/general/test/cfa/login_defs_test.rb
@@ -1,0 +1,65 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "cfa/login_defs"
+
+describe CFA::LoginDefs do
+  subject(:login_defs) { described_class.new(file_path: file_path, file_handler: file_handler) }
+  let(:file_path) { File.join(GENERAL_DATA_PATH, "login.defs-example") }
+  let(:file_handler) { File }
+
+  before { login_defs.load }
+
+  describe "#load" do
+    it "loads the file content" do
+      file = described_class.load(file_path: file_path, file_handler: file_handler)
+      expect(file.loaded?).to eq(true)
+    end
+  end
+
+  ATTRS_VALUES = {
+    character_class: "[A-Za-z_][A-Za-z0-9_.-]*",
+    encrypt_method:  "SHA512",
+    fail_delay:      "3",
+    gid_max:         "60000",
+    gid_min:         "1000",
+    groupadd_cmd:    "/usr/sbin/groupadd.local",
+    pass_max_days:   "99999",
+    pass_min_days:   "0",
+    pass_warn_age:   "7",
+    sys_gid_max:     "499",
+    sys_gid_min:     "100",
+    sys_uid_max:     "499",
+    sys_uid_min:     "100",
+    uid_max:         "60000",
+    uid_min:         "1000",
+    useradd_cmd:     "/usr/sbin/useradd.local",
+    userdel_postcmd: "/usr/sbin/userdel-post.local",
+    userdel_precmd:  "/usr/sbin/userdel-pre.local"
+  }.freeze
+
+  ATTRS_VALUES.each do |attr, value|
+    describe "##{attr}" do
+      it "returns the #{attr.upcase} value" do
+        expect(login_defs.public_send(attr)).to eq(value)
+      end
+    end
+  end
+end

--- a/library/general/test/cfa/shadow_config_test.rb
+++ b/library/general/test/cfa/shadow_config_test.rb
@@ -18,9 +18,9 @@
 # find current contact information at www.suse.com.
 
 require_relative "../test_helper"
-require "cfa/login_defs_config"
+require "cfa/shadow_config"
 
-describe CFA::LoginDefsConfig do
+describe CFA::ShadowConfig do
   subject(:config) { described_class.new }
   let(:scenario) { "custom" }
 

--- a/library/general/test/data/login.defs-example
+++ b/library/general/test/data/login.defs-example
@@ -1,0 +1,299 @@
+#
+# /etc/login.defs - Configuration control definitions for the shadow package.
+# Some variables are used by login(1), su(1) and runuser(1) from util-linux
+# package as well pam pam_unix(8) from pam package.
+#
+# For more, see login.defs(5). Please note that SUSE supports only variables
+# listed here! Not listed variables from login.defs(5) have no effect.
+#
+
+#
+# Delay in seconds before being allowed another attempt after a login failure
+# Note: When PAM is used, some modules may enforce a minimum delay (e.g.
+#       pam_unix(8) enforces a 2s delay)
+#
+FAIL_DELAY		3
+
+#
+# Enable display of unknown usernames when login(1) failures are recorded.
+#
+LOG_UNKFAIL_ENAB	no
+
+#
+# Enable "syslog" logging of  newgrp(1) and sg(1) activity.
+#
+SYSLOG_SG_ENAB		yes
+
+#
+# If defined, either full pathname of a file containing device names or
+# a ":" delimited list of device names.  Root logins will be allowed only
+# from these devices.
+#
+CONSOLE		/etc/securetty
+#CONSOLE	console:tty01:tty02:tty03:tty04
+
+#
+# Limit the highest user ID number for which the lastlog entries should
+# be updated.
+#
+# No LASTLOG_UID_MAX means that there is no user ID limit for writing
+# lastlog entries.
+#
+#LASTLOG_UID_MAX
+
+#
+# If defined, all su(1) activity is logged to this file.
+#
+#SULOG_FILE	/var/log/sulog
+
+#
+# If defined, ":" delimited list of "message of the day" files to
+# be displayed upon login.
+#
+#MOTD_FILE	/etc/motd:/usr/share/misc/motd
+
+#
+# If defined, file which maps tty line to TERM environment parameter.
+# Each line of the file is in a format similar to "vt100  tty01".
+#
+#TTYTYPE_FILE	/etc/ttytype
+
+#
+# If defined, file which inhibits all the usual chatter during the login
+# sequence.  If a full pathname, then hushed mode will be enabled if the
+# user's name or shell are found in the file.  If not a full pathname, then
+# hushed mode will be enabled if the file exists in the user's home directory.
+#
+#HUSHLOGIN_FILE	.hushlogin
+HUSHLOGIN_FILE	/etc/hushlogins
+
+# If this variable is set to "yes", hostname will be suppressed in the
+# login: prompt.
+#LOGIN_PLAIN_PROMPT	no
+
+#
+# *REQUIRED*  The default PATH settings, for superuser and normal users.
+#
+# (they are minimal, add the rest in the shell startup files)
+#
+# ENV_PATH: The default PATH settings for non-root.
+#
+# ENV_ROOTPATH: The default PATH settings for root
+# (used by login, su and runuser).
+#
+# ENV_SUPATH is an ENV_ROOTPATH override for su and runuser
+# (and falback for login).
+#
+ENV_PATH	/usr/local/bin:/bin:/usr/bin
+ENV_ROOTPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+#ENV_SUPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# If this variable is set to "yes" (default is "no"), su will always set
+# path. every su call will overwrite the PATH variable.
+#
+# Per default, only "su -" will set a new PATH.
+#
+# The recommended value is "yes". The default "no" behavior could have
+# a security implication in applications that use commands without path.
+#
+ALWAYS_SET_PATH	yes
+
+#
+# Terminal permissions
+#
+#	TTYGROUP	Login tty will be assigned this group ownership.
+#	TTYPERM		Login tty will be set to this permission.
+#
+# If you have a write(1) program which is "setgid" to a special group
+# which owns the terminals, define TTYGROUP as the number of such group
+# and TTYPERM as 0620.  Otherwise leave TTYGROUP commented out and
+# set TTYPERM to either 622 or 600.
+#
+TTYGROUP	tty
+TTYPERM		0620
+
+# Default initial "umask" value used by login(1) on non-PAM enabled systems.
+# Default "umask" value for pam_umask(8) on PAM enabled systems.
+# UMASK is also used by useradd(8) and newusers(8) to set the mode for new
+# home directories.
+# 022 is the default value, but 027, or even 077, could be considered
+# for increased privacy. There is no One True Answer here: each sysadmin
+# must make up their mind.
+UMASK		022
+
+#
+# Password aging controls:
+#
+#	PASS_MAX_DAYS	Maximum number of days a password may be used.
+#	PASS_MIN_DAYS	Minimum number of days allowed between password changes.
+#	PASS_WARN_AGE	Number of days warning given before a password expires.
+#
+PASS_MAX_DAYS	99999
+PASS_MIN_DAYS	0
+PASS_WARN_AGE	7
+
+#
+# Min/max values for automatic uid selection in useradd(8)
+#
+# SYS_UID_MIN to SYS_UID_MAX inclusive is the range for
+# UIDs for dynamically allocated administrative and system accounts.
+# UID_MIN to UID_MAX inclusive is the range of UIDs of dynamically
+# allocated user accounts.
+#
+UID_MIN			 1000
+UID_MAX			60000
+# System accounts
+SYS_UID_MIN		  100
+SYS_UID_MAX		  499
+# Extra per user uids
+SUB_UID_MIN		   100000
+SUB_UID_MAX		600100000
+SUB_UID_COUNT		    65536
+
+#
+# Min/max values for automatic gid selection in groupadd(8)
+#
+# SYS_GID_MIN to SYS_GID_MAX inclusive is the range for
+# GIDs for dynamically allocated administrative and system groups.
+# GID_MIN to GID_MAX inclusive is the range of GIDs of dynamically
+# allocated groups.
+#
+GID_MIN			 1000
+GID_MAX			60000
+# System accounts
+SYS_GID_MIN		  100
+SYS_GID_MAX		  499
+# Extra per user group ids
+SUB_GID_MIN		   100000
+SUB_GID_MAX		600100000
+SUB_GID_COUNT		    65536
+
+#
+# Max number of login(1) retries if password is bad
+#
+LOGIN_RETRIES		3
+
+#
+# Max time in seconds for login(1)
+#
+LOGIN_TIMEOUT		60
+
+#
+# Which fields may be changed by regular users using chfn(1) - use
+# any combination of letters "frwh" (full name, room number, work
+# phone, home phone).  If not defined, no changes are allowed.
+# For backward compatibility, "yes" = "rwh" and "no" = "frwh".
+# 
+CHFN_RESTRICT		rwh
+
+#
+# This variable is deprecated. Use ENCRYPT_METHOD instead!
+#
+#MD5_CRYPT_ENAB	DO_NOT_USE
+
+#
+# If set to MD5, MD5-based algorithm will be used for encrypting password
+# If set to SHA256, SHA256-based algorithm will be used for encrypting password
+# If set to SHA512, SHA512-based algorithm will be used for encrypting password
+# If set to DES, DES-based algorithm will be used for encrypting password (default)
+# Overrides the MD5_CRYPT_ENAB option
+#
+# Note: If you use PAM, it is recommended to use a value consistent with
+# the PAM modules configuration.
+#
+ENCRYPT_METHOD SHA512
+
+#
+# Only works if ENCRYPT_METHOD is set to SHA256 or SHA512.
+#
+# Define the number of SHA rounds.
+# With a lot of rounds, it is more difficult to brute-force the password.
+# However, more CPU resources will be needed to authenticate users if
+# this value is increased.
+#
+# If not specified, the libc will choose the default number of rounds (5000).
+# The values must be within the 1000-999999999 range.
+# If only one of the MIN or MAX values is set, then this value will be used.
+# If MIN > MAX, the highest value will be used.
+#
+#SHA_CRYPT_MIN_ROUNDS 5000
+#SHA_CRYPT_MAX_ROUNDS 5000
+
+#
+# Should login be allowed if we can't cd to the home directory?
+# Default is no.
+#
+DEFAULT_HOME	yes
+
+#
+# If defined, this command is run when adding a user.
+# It should rebuild any NIS database etc. to add the
+# new created account.
+#
+USERADD_CMD             /usr/sbin/useradd.local
+
+#
+# If defined, this command is run when removing a user.
+# It should remove any at/cron/print jobs etc. owned by
+# the user to be removed (passed as the first argument).
+#
+# See also USERDEL_PRECMD and USERDEL_POSTCMD below.
+#
+#USERDEL_CMD	/usr/sbin/userdel_local
+
+#
+# If defined, this command is run before removing a user.
+# It should remove any at/cron/print jobs etc. owned by
+# the user to be removed.
+#
+USERDEL_PRECMD          /usr/sbin/userdel-pre.local
+
+#
+# If defined, this command is run after removing a user.
+# It should rebuild any NIS database etc. to remove the
+# account from it.
+#
+USERDEL_POSTCMD         /usr/sbin/userdel-post.local
+
+#
+# Enable setting of the umask group bits to be the same as owner bits
+# (examples: 022 -> 002, 077 -> 007) for non-root users, if the uid is
+# the same as gid, and username is the same as the primary group name.
+#
+# This also enables userdel(8) to remove user groups if no members exist.
+#
+USERGROUPS_ENAB no
+
+#
+# If set to a non-zero number, the shadow utilities will make sure that
+# groups never have more than this number of users on one line.
+# This permits to support split groups (groups split into multiple lines,
+# with the same group ID, to avoid limitation of the line length in the
+# group file).
+#
+# 0 is the default value and disables this feature.
+#
+#MAX_MEMBERS_PER_GROUP	0
+
+#
+# If useradd(8) should create home directories for users by default (non
+# system users only).
+# This option is overridden with the -M or -m flags on the useradd(8)
+# command-line.
+#
+CREATE_HOME     no
+
+#
+# Force use shadow, even if shadow passwd & shadow group files are
+# missing.
+#
+FORCE_SHADOW    no
+
+#
+# User/group names must match the following regex expression.
+# The default is [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?,
+# but be aware that the result could depend on the locale settings.
+#
+CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*
+
+GROUPADD_CMD                   /usr/sbin/groupadd.local

--- a/library/general/test/data/login.defs/custom/etc/login.defs
+++ b/library/general/test/data/login.defs/custom/etc/login.defs
@@ -1,0 +1,1 @@
+FAIL_DELAY		3

--- a/library/general/test/data/login.defs/custom/etc/login.defs.d/70-yast.conf
+++ b/library/general/test/data/login.defs/custom/etc/login.defs.d/70-yast.conf
@@ -1,0 +1,1 @@
+USERADD_CMD             /usr/sbin/useradd.local

--- a/library/general/test/data/login.defs/custom/etc/login.defs.d/99-local.conf
+++ b/library/general/test/data/login.defs/custom/etc/login.defs.d/99-local.conf
@@ -1,0 +1,2 @@
+ENCRYPT_METHOD          SHA256
+USERADD_CMD             /usr/local/sbin/useradd.local

--- a/library/general/test/data/login.defs/custom/usr/etc/login.defs
+++ b/library/general/test/data/login.defs/custom/usr/etc/login.defs
@@ -1,0 +1,298 @@
+#
+# /etc/login.defs - Configuration control definitions for the shadow package.
+# Some variables are used by login(1), su(1) and runuser(1) from util-linux
+# package as well pam pam_unix(8) from pam package.
+#
+# For more, see login.defs(5). Please note that SUSE supports only variables
+# listed here! Not listed variables from login.defs(5) have no effect.
+#
+
+#
+# Delay in seconds before being allowed another attempt after a login failure
+# Note: When PAM is used, some modules may enforce a minimum delay (e.g.
+#       pam_unix(8) enforces a 2s delay)
+#
+FAIL_DELAY		3
+
+#
+# Enable display of unknown usernames when login(1) failures are recorded.
+#
+LOG_UNKFAIL_ENAB	no
+
+#
+# Enable "syslog" logging of  newgrp(1) and sg(1) activity.
+#
+SYSLOG_SG_ENAB		yes
+
+#
+# If defined, either full pathname of a file containing device names or
+# a ":" delimited list of device names.  Root logins will be allowed only
+# from these devices.
+#
+CONSOLE		/etc/securetty
+#CONSOLE	console:tty01:tty02:tty03:tty04
+
+#
+# Limit the highest user ID number for which the lastlog entries should
+# be updated.
+#
+# No LASTLOG_UID_MAX means that there is no user ID limit for writing
+# lastlog entries.
+#
+#LASTLOG_UID_MAX
+
+#
+# If defined, all su(1) activity is logged to this file.
+#
+#SULOG_FILE	/var/log/sulog
+
+#
+# If defined, ":" delimited list of "message of the day" files to
+# be displayed upon login.
+#
+#MOTD_FILE	/etc/motd:/usr/share/misc/motd
+
+#
+# If defined, file which maps tty line to TERM environment parameter.
+# Each line of the file is in a format similar to "vt100  tty01".
+#
+#TTYTYPE_FILE	/etc/ttytype
+
+#
+# If defined, file which inhibits all the usual chatter during the login
+# sequence.  If a full pathname, then hushed mode will be enabled if the
+# user's name or shell are found in the file.  If not a full pathname, then
+# hushed mode will be enabled if the file exists in the user's home directory.
+#
+#HUSHLOGIN_FILE	.hushlogin
+HUSHLOGIN_FILE	/etc/hushlogins
+
+# If this variable is set to "yes", hostname will be suppressed in the
+# login: prompt.
+#LOGIN_PLAIN_PROMPT	no
+
+#
+# *REQUIRED*  The default PATH settings, for superuser and normal users.
+#
+# (they are minimal, add the rest in the shell startup files)
+#
+# ENV_PATH: The default PATH settings for non-root.
+#
+# ENV_ROOTPATH: The default PATH settings for root
+# (used by login, su and runuser).
+#
+# ENV_SUPATH is an ENV_ROOTPATH override for su and runuser
+# (and falback for login).
+#
+ENV_PATH	/usr/local/bin:/bin:/usr/bin
+ENV_ROOTPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+#ENV_SUPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# If this variable is set to "yes" (default is "no"), su will always set
+# path. every su call will overwrite the PATH variable.
+#
+# Per default, only "su -" will set a new PATH.
+#
+# The recommended value is "yes". The default "no" behavior could have
+# a security implication in applications that use commands without path.
+#
+ALWAYS_SET_PATH	yes
+
+#
+# Terminal permissions
+#
+#	TTYGROUP	Login tty will be assigned this group ownership.
+#	TTYPERM		Login tty will be set to this permission.
+#
+# If you have a write(1) program which is "setgid" to a special group
+# which owns the terminals, define TTYGROUP as the number of such group
+# and TTYPERM as 0620.  Otherwise leave TTYGROUP commented out and
+# set TTYPERM to either 622 or 600.
+#
+TTYGROUP	tty
+TTYPERM		0620
+
+# Default initial "umask" value used by login(1) on non-PAM enabled systems.
+# Default "umask" value for pam_umask(8) on PAM enabled systems.
+# UMASK is also used by useradd(8) and newusers(8) to set the mode for new
+# home directories.
+# 022 is the default value, but 027, or even 077, could be considered
+# for increased privacy. There is no One True Answer here: each sysadmin
+# must make up their mind.
+UMASK		022
+
+#
+# Password aging controls:
+#
+#	PASS_MAX_DAYS	Maximum number of days a password may be used.
+#	PASS_MIN_DAYS	Minimum number of days allowed between password changes.
+#	PASS_WARN_AGE	Number of days warning given before a password expires.
+#
+PASS_MAX_DAYS	99999
+PASS_MIN_DAYS	0
+PASS_WARN_AGE	7
+
+#
+# Min/max values for automatic uid selection in useradd(8)
+#
+# SYS_UID_MIN to SYS_UID_MAX inclusive is the range for
+# UIDs for dynamically allocated administrative and system accounts.
+# UID_MIN to UID_MAX inclusive is the range of UIDs of dynamically
+# allocated user accounts.
+#
+UID_MIN			 1000
+UID_MAX			60000
+# System accounts
+SYS_UID_MIN		  100
+SYS_UID_MAX		  499
+# Extra per user uids
+SUB_UID_MIN		   100000
+SUB_UID_MAX		600100000
+SUB_UID_COUNT		    65536
+
+#
+# Min/max values for automatic gid selection in groupadd(8)
+#
+# SYS_GID_MIN to SYS_GID_MAX inclusive is the range for
+# GIDs for dynamically allocated administrative and system groups.
+# GID_MIN to GID_MAX inclusive is the range of GIDs of dynamically
+# allocated groups.
+#
+GID_MIN			 1000
+GID_MAX			60000
+# System accounts
+SYS_GID_MIN		  100
+SYS_GID_MAX		  499
+# Extra per user group ids
+SUB_GID_MIN		   100000
+SUB_GID_MAX		600100000
+SUB_GID_COUNT		    65536
+
+#
+# Max number of login(1) retries if password is bad
+#
+LOGIN_RETRIES		3
+
+#
+# Max time in seconds for login(1)
+#
+LOGIN_TIMEOUT		60
+
+#
+# Which fields may be changed by regular users using chfn(1) - use
+# any combination of letters "frwh" (full name, room number, work
+# phone, home phone).  If not defined, no changes are allowed.
+# For backward compatibility, "yes" = "rwh" and "no" = "frwh".
+# 
+CHFN_RESTRICT		rwh
+
+#
+# This variable is deprecated. Use ENCRYPT_METHOD instead!
+#
+#MD5_CRYPT_ENAB	DO_NOT_USE
+
+#
+# If set to MD5, MD5-based algorithm will be used for encrypting password
+# If set to SHA256, SHA256-based algorithm will be used for encrypting password
+# If set to SHA512, SHA512-based algorithm will be used for encrypting password
+# If set to DES, DES-based algorithm will be used for encrypting password (default)
+# Overrides the MD5_CRYPT_ENAB option
+#
+# Note: If you use PAM, it is recommended to use a value consistent with
+# the PAM modules configuration.
+#
+ENCRYPT_METHOD SHA512
+
+#
+# Only works if ENCRYPT_METHOD is set to SHA256 or SHA512.
+#
+# Define the number of SHA rounds.
+# With a lot of rounds, it is more difficult to brute-force the password.
+# However, more CPU resources will be needed to authenticate users if
+# this value is increased.
+#
+# If not specified, the libc will choose the default number of rounds (5000).
+# The values must be within the 1000-999999999 range.
+# If only one of the MIN or MAX values is set, then this value will be used.
+# If MIN > MAX, the highest value will be used.
+#
+#SHA_CRYPT_MIN_ROUNDS 5000
+#SHA_CRYPT_MAX_ROUNDS 5000
+
+#
+# Should login be allowed if we can't cd to the home directory?
+# Default is no.
+#
+DEFAULT_HOME	yes
+
+#
+# If defined, this command is run when adding a user.
+# It should rebuild any NIS database etc. to add the
+# new created account.
+#
+USERADD_CMD             /usr/sbin/useradd.local
+
+#
+# If defined, this command is run when removing a user.
+# It should remove any at/cron/print jobs etc. owned by
+# the user to be removed (passed as the first argument).
+#
+# See also USERDEL_PRECMD and USERDEL_POSTCMD below.
+#
+#USERDEL_CMD	/usr/sbin/userdel_local
+
+#
+# If defined, this command is run before removing a user.
+# It should remove any at/cron/print jobs etc. owned by
+# the user to be removed.
+#
+USERDEL_PRECMD          /usr/sbin/userdel-pre.local
+
+#
+# If defined, this command is run after removing a user.
+# It should rebuild any NIS database etc. to remove the
+# account from it.
+#
+USERDEL_POSTCMD         /usr/sbin/userdel-post.local
+
+#
+# Enable setting of the umask group bits to be the same as owner bits
+# (examples: 022 -> 002, 077 -> 007) for non-root users, if the uid is
+# the same as gid, and username is the same as the primary group name.
+#
+# This also enables userdel(8) to remove user groups if no members exist.
+#
+USERGROUPS_ENAB no
+
+#
+# If set to a non-zero number, the shadow utilities will make sure that
+# groups never have more than this number of users on one line.
+# This permits to support split groups (groups split into multiple lines,
+# with the same group ID, to avoid limitation of the line length in the
+# group file).
+#
+# 0 is the default value and disables this feature.
+#
+#MAX_MEMBERS_PER_GROUP	0
+
+#
+# If useradd(8) should create home directories for users by default (non
+# system users only).
+# This option is overridden with the -M or -m flags on the useradd(8)
+# command-line.
+#
+CREATE_HOME     no
+
+#
+# Force use shadow, even if shadow passwd & shadow group files are
+# missing.
+#
+FORCE_SHADOW    no
+
+#
+# User/group names must match the following regex expression.
+# The default is [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?,
+# but be aware that the result could depend on the locale settings.
+#
+#CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?
+CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$-]\?

--- a/library/general/test/data/login.defs/vendor/usr/etc/login.defs
+++ b/library/general/test/data/login.defs/vendor/usr/etc/login.defs
@@ -1,0 +1,300 @@
+#
+# /etc/login.defs - Configuration control definitions for the shadow package.
+# Some variables are used by login(1), su(1) and runuser(1) from util-linux
+# package as well pam pam_unix(8) from pam package.
+#
+# For more, see login.defs(5). Please note that SUSE supports only variables
+# listed here! Not listed variables from login.defs(5) have no effect.
+#
+
+#
+# Delay in seconds before being allowed another attempt after a login failure
+# Note: When PAM is used, some modules may enforce a minimum delay (e.g.
+#       pam_unix(8) enforces a 2s delay)
+#
+FAIL_DELAY		3
+
+#
+# Enable display of unknown usernames when login(1) failures are recorded.
+#
+LOG_UNKFAIL_ENAB	no
+
+#
+# Enable "syslog" logging of  newgrp(1) and sg(1) activity.
+#
+SYSLOG_SG_ENAB		yes
+
+#
+# If defined, either full pathname of a file containing device names or
+# a ":" delimited list of device names.  Root logins will be allowed only
+# from these devices.
+#
+CONSOLE		/etc/securetty
+#CONSOLE	console:tty01:tty02:tty03:tty04
+
+#
+# Limit the highest user ID number for which the lastlog entries should
+# be updated.
+#
+# No LASTLOG_UID_MAX means that there is no user ID limit for writing
+# lastlog entries.
+#
+#LASTLOG_UID_MAX
+
+#
+# If defined, all su(1) activity is logged to this file.
+#
+#SULOG_FILE	/var/log/sulog
+
+#
+# If defined, ":" delimited list of "message of the day" files to
+# be displayed upon login.
+#
+#MOTD_FILE	/etc/motd:/usr/share/misc/motd
+
+#
+# If defined, file which maps tty line to TERM environment parameter.
+# Each line of the file is in a format similar to "vt100  tty01".
+#
+#TTYTYPE_FILE	/etc/ttytype
+
+#
+# If defined, file which inhibits all the usual chatter during the login
+# sequence.  If a full pathname, then hushed mode will be enabled if the
+# user's name or shell are found in the file.  If not a full pathname, then
+# hushed mode will be enabled if the file exists in the user's home directory.
+#
+#HUSHLOGIN_FILE	.hushlogin
+HUSHLOGIN_FILE	/etc/hushlogins
+
+# If this variable is set to "yes", hostname will be suppressed in the
+# login: prompt.
+#LOGIN_PLAIN_PROMPT	no
+
+#
+# *REQUIRED*  The default PATH settings, for superuser and normal users.
+#
+# (they are minimal, add the rest in the shell startup files)
+#
+# ENV_PATH: The default PATH settings for non-root.
+#
+# ENV_ROOTPATH: The default PATH settings for root
+# (used by login, su and runuser).
+#
+# ENV_SUPATH is an ENV_ROOTPATH override for su and runuser
+# (and falback for login).
+#
+ENV_PATH	/usr/local/bin:/bin:/usr/bin
+ENV_ROOTPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+#ENV_SUPATH	/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+# If this variable is set to "yes" (default is "no"), su will always set
+# path. every su call will overwrite the PATH variable.
+#
+# Per default, only "su -" will set a new PATH.
+#
+# The recommended value is "yes". The default "no" behavior could have
+# a security implication in applications that use commands without path.
+#
+ALWAYS_SET_PATH	yes
+
+#
+# Terminal permissions
+#
+#	TTYGROUP	Login tty will be assigned this group ownership.
+#	TTYPERM		Login tty will be set to this permission.
+#
+# If you have a write(1) program which is "setgid" to a special group
+# which owns the terminals, define TTYGROUP as the number of such group
+# and TTYPERM as 0620.  Otherwise leave TTYGROUP commented out and
+# set TTYPERM to either 622 or 600.
+#
+TTYGROUP	tty
+TTYPERM		0620
+
+# Default initial "umask" value used by login(1) on non-PAM enabled systems.
+# Default "umask" value for pam_umask(8) on PAM enabled systems.
+# UMASK is also used by useradd(8) and newusers(8) to set the mode for new
+# home directories.
+# 022 is the default value, but 027, or even 077, could be considered
+# for increased privacy. There is no One True Answer here: each sysadmin
+# must make up their mind.
+UMASK		022
+
+#
+# Password aging controls:
+#
+#	PASS_MAX_DAYS	Maximum number of days a password may be used.
+#	PASS_MIN_DAYS	Minimum number of days allowed between password changes.
+#	PASS_WARN_AGE	Number of days warning given before a password expires.
+#
+PASS_MAX_DAYS	99999
+PASS_MIN_DAYS	0
+PASS_WARN_AGE	7
+
+#
+# Min/max values for automatic uid selection in useradd(8)
+#
+# SYS_UID_MIN to SYS_UID_MAX inclusive is the range for
+# UIDs for dynamically allocated administrative and system accounts.
+# UID_MIN to UID_MAX inclusive is the range of UIDs of dynamically
+# allocated user accounts.
+#
+UID_MIN			 1000
+UID_MAX			60000
+# System accounts
+SYS_UID_MIN		  100
+SYS_UID_MAX		  499
+# Extra per user uids
+SUB_UID_MIN		   100000
+SUB_UID_MAX		600100000
+SUB_UID_COUNT		    65536
+
+#
+# Min/max values for automatic gid selection in groupadd(8)
+#
+# SYS_GID_MIN to SYS_GID_MAX inclusive is the range for
+# GIDs for dynamically allocated administrative and system groups.
+# GID_MIN to GID_MAX inclusive is the range of GIDs of dynamically
+# allocated groups.
+#
+GID_MIN			 1000
+GID_MAX			60000
+# System accounts
+SYS_GID_MIN		  100
+SYS_GID_MAX		  499
+# Extra per user group ids
+SUB_GID_MIN		   100000
+SUB_GID_MAX		600100000
+SUB_GID_COUNT		    65536
+
+#
+# Max number of login(1) retries if password is bad
+#
+LOGIN_RETRIES		3
+
+#
+# Max time in seconds for login(1)
+#
+LOGIN_TIMEOUT		60
+
+#
+# Which fields may be changed by regular users using chfn(1) - use
+# any combination of letters "frwh" (full name, room number, work
+# phone, home phone).  If not defined, no changes are allowed.
+# For backward compatibility, "yes" = "rwh" and "no" = "frwh".
+# 
+CHFN_RESTRICT		rwh
+
+#
+# This variable is deprecated. Use ENCRYPT_METHOD instead!
+#
+#MD5_CRYPT_ENAB	DO_NOT_USE
+
+#
+# If set to MD5, MD5-based algorithm will be used for encrypting password
+# If set to SHA256, SHA256-based algorithm will be used for encrypting password
+# If set to SHA512, SHA512-based algorithm will be used for encrypting password
+# If set to DES, DES-based algorithm will be used for encrypting password (default)
+# Overrides the MD5_CRYPT_ENAB option
+#
+# Note: If you use PAM, it is recommended to use a value consistent with
+# the PAM modules configuration.
+#
+ENCRYPT_METHOD SHA512
+
+#
+# Only works if ENCRYPT_METHOD is set to SHA256 or SHA512.
+#
+# Define the number of SHA rounds.
+# With a lot of rounds, it is more difficult to brute-force the password.
+# However, more CPU resources will be needed to authenticate users if
+# this value is increased.
+#
+# If not specified, the libc will choose the default number of rounds (5000).
+# The values must be within the 1000-999999999 range.
+# If only one of the MIN or MAX values is set, then this value will be used.
+# If MIN > MAX, the highest value will be used.
+#
+#SHA_CRYPT_MIN_ROUNDS 5000
+#SHA_CRYPT_MAX_ROUNDS 5000
+
+#
+# Should login be allowed if we can't cd to the home directory?
+# Default is no.
+#
+DEFAULT_HOME	yes
+
+#
+# If defined, this command is run when adding a user.
+# It should rebuild any NIS database etc. to add the
+# new created account.
+#
+USERADD_CMD             /usr/sbin/useradd.local
+
+#
+# If defined, this command is run when removing a user.
+# It should remove any at/cron/print jobs etc. owned by
+# the user to be removed (passed as the first argument).
+#
+# See also USERDEL_PRECMD and USERDEL_POSTCMD below.
+#
+#USERDEL_CMD	/usr/sbin/userdel_local
+
+#
+# If defined, this command is run before removing a user.
+# It should remove any at/cron/print jobs etc. owned by
+# the user to be removed.
+#
+USERDEL_PRECMD          /usr/sbin/userdel-pre.local
+
+#
+# If defined, this command is run after removing a user.
+# It should rebuild any NIS database etc. to remove the
+# account from it.
+#
+USERDEL_POSTCMD         /usr/sbin/userdel-post.local
+
+#
+# Enable setting of the umask group bits to be the same as owner bits
+# (examples: 022 -> 002, 077 -> 007) for non-root users, if the uid is
+# the same as gid, and username is the same as the primary group name.
+#
+# This also enables userdel(8) to remove user groups if no members exist.
+#
+USERGROUPS_ENAB no
+
+#
+# If set to a non-zero number, the shadow utilities will make sure that
+# groups never have more than this number of users on one line.
+# This permits to support split groups (groups split into multiple lines,
+# with the same group ID, to avoid limitation of the line length in the
+# group file).
+#
+# 0 is the default value and disables this feature.
+#
+#MAX_MEMBERS_PER_GROUP	0
+
+#
+# If useradd(8) should create home directories for users by default (non
+# system users only).
+# This option is overridden with the -M or -m flags on the useradd(8)
+# command-line.
+#
+CREATE_HOME     no
+
+#
+# Force use shadow, even if shadow passwd & shadow group files are
+# missing.
+#
+FORCE_SHADOW    no
+
+#
+# User/group names must match the following regex expression.
+# The default is [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?,
+# but be aware that the result could depend on the locale settings.
+#
+#CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?
+CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$-]\?
+
+GROUPADD_CMD            /usr/sbin/groupadd.local

--- a/library/general/test/login_defs_config_test.rb
+++ b/library/general/test/login_defs_config_test.rb
@@ -1,0 +1,82 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "LoginDefsConfig"
+
+describe Yast::LoginDefsConfig do
+  subject { Yast::LoginDefsConfig }
+  let(:config_path) do
+    File.join(GENERAL_DATA_PATH, "login.defs", "vendor")
+  end
+
+  before { subject.main }
+
+  around do |example|
+    change_scr_root(config_path, &example)
+  end
+
+  describe "#fetch" do
+    context "when the value is defined" do
+      it "returns the value for the given attribute" do
+        expect(subject.fetch(:encrypt_method)).to eq("SHA512")
+      end
+    end
+
+    context "when the value is unknown" do
+      it "raises an exception" do
+        expect { subject.fetch(:unknown) }
+          .to raise_error(Yast::LoginDefsConfigClass::UnknownAttributeError)
+      end
+    end
+  end
+
+  describe "#set" do
+    context "when the value is defined" do
+      it "sets the attribute to the given value" do
+        expect { subject.set(:encrypt_method, "SHA256") }
+          .to change { subject.fetch(:encrypt_method) }
+          .from("SHA512").to("SHA256")
+      end
+    end
+
+    context "when the value is unknown" do
+      it "raises an exception" do
+        expect { subject.set(:unknown, "unknown") }
+          .to raise_error(Yast::LoginDefsConfigClass::UnknownAttributeError)
+      end
+    end
+  end
+
+  describe "#write" do
+    let(:login_defs_config) { CFA::LoginDefsConfig.new }
+
+    before do
+      allow(CFA::LoginDefsConfig).to receive(:new)
+        .and_return(login_defs_config)
+      subject.reset
+    end
+
+    it "saves the changes" do
+      expect(login_defs_config).to receive(:save)
+      subject.write
+    end
+  end
+end

--- a/library/general/test/login_defs_config_test.rb
+++ b/library/general/test/login_defs_config_test.rb
@@ -19,13 +19,11 @@
 
 require_relative "test_helper"
 
-Yast.import "LoginDefsConfig"
+Yast.import "ShadowConfig"
 
-describe Yast::LoginDefsConfig do
-  subject { Yast::LoginDefsConfig }
-  let(:config_path) do
-    File.join(GENERAL_DATA_PATH, "login.defs", "vendor")
-  end
+describe Yast::ShadowConfig do
+  subject { Yast::ShadowConfig }
+  let(:config_path) { File.join(GENERAL_DATA_PATH, "login.defs", "vendor") }
 
   before { subject.main }
 
@@ -43,7 +41,7 @@ describe Yast::LoginDefsConfig do
     context "when the value is unknown" do
       it "raises an exception" do
         expect { subject.fetch(:unknown) }
-          .to raise_error(Yast::LoginDefsConfigClass::UnknownAttributeError)
+          .to raise_error(Yast::ShadowConfigClass::UnknownAttributeError)
       end
     end
   end
@@ -60,22 +58,22 @@ describe Yast::LoginDefsConfig do
     context "when the value is unknown" do
       it "raises an exception" do
         expect { subject.set(:unknown, "unknown") }
-          .to raise_error(Yast::LoginDefsConfigClass::UnknownAttributeError)
+          .to raise_error(Yast::ShadowConfigClass::UnknownAttributeError)
       end
     end
   end
 
   describe "#write" do
-    let(:login_defs_config) { CFA::LoginDefsConfig.new }
+    let(:shadow_config) { CFA::ShadowConfig.new }
 
     before do
-      allow(CFA::LoginDefsConfig).to receive(:new)
-        .and_return(login_defs_config)
+      allow(CFA::ShadowConfig).to receive(:new)
+        .and_return(shadow_config)
       subject.reset
     end
 
     it "saves the changes" do
-      expect(login_defs_config).to receive(:save)
+      expect(shadow_config).to receive(:save)
       subject.write
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Nov 25 11:07:11 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- bsc#1155735, bsc#1157541:
+  - Read /usr/etc/login.defs.
+  - Write login.defs configuration to /etc/login.defs.d/.
+- 4.2.39
+
+-------------------------------------------------------------------
 Fri Nov 22 09:19:32 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1157532

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.38
+Version:        4.2.39
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

As reported in [bsc#1155735](https://bugzilla.suse.com/show_bug.cgi?id=1155735), the `login.defs` file now lives in `/usr/etc/login.defs`. However, YaST still tries to read its settings from `/etc/login.defs`. 

## Solution

Instead of using the old `.etc.login_defs` agent, YaST will use a CFA based API. However, as the configuration can be now scattered through several files (`/usr/etc/login.defs`, `/usr/etc/login.defs.d/*`, `/etc/login.defs` and `/etc/login.defs.d`), this PR introduces a `ShadowConfig` class that takes care of those details. It is named `ShadowConfig` because it refers to the *shadow suite*  configuration (referring to the manpage).

As we expect many changes like this in the future, we have extracted the common behavior to a `MultiFileConfig` class (a better name is welcome). Let's say that we have a Foo service which configuration is split between `/etc` and `/usr/etc`. The code could be something like:

```ruby
class FooConfig < MultiFileConfig
  self.file_name = "foo.conf"
  self.yast_file_name = "70-yast.conf"
  self.file_class = CFA::Foo # each individual file still uses a CFA::BaseModel class.
end

config = FooConfig.load
config.some_param = "some_value1"
config.save
```

Additionally, the class offers a `#conflicts` method which is able to detect whether a YaST setting (which are written to `/etc/foo.conf.d/70-yast.conf`) is overridden by a latter file (like `99-local.conf`):

```ruby
config.conflicts = [:conflicting_param]
```

For the time being, I have decided to just the conflict to the log, but we could decide to report it to the user.

## Pending (for another PR)

- [x] Adapt yast2-security. See https://github.com/yast/yast-security/pull/62.
- [x] Adapt yast2-users. See https://github.com/yast/yast-users/pull/220.
- [ ] Extract BaseModel additions to a mixin
- [ ] Conflicts reporting (apart from logging it).
- [ ] Improve conflicts detection and report in which file exactly it is redefined.

## Screencasts

<details>
<summary>Reading settings from `/usr/etc/login.defs`</summary>

![reading-usr-etc-login-defs](https://user-images.githubusercontent.com/15836/69624663-0d469380-103d-11ea-9f99-da1f1ff7c8c7.gif)
</details>

<details>
<summary>Write YaST related settings to `/etc/login.defs.d/70-yast.conf`</summary>

![write-yast-settings](https://user-images.githubusercontent.com/15836/69625218-0cfac800-103e-11ea-9eff-438325ff757b.gif)
</details>


---

Trello card: https://trello.com/c/AoT1lQCC/1434-8-feature-reading-usr-etc-logindefs