### PR TITLE
Fix syntax for Ruby 2.5

### DIFF
--- a/library/general/src/lib/cfa/multi_file_config.rb
+++ b/library/general/src/lib/cfa/multi_file_config.rb
@@ -206,7 +206,7 @@ module CFA
       return @higher_precedence_files if @higher_precedence_files
 
       yast_config_file_idx = files.find_index { |f| f == yast_config_file }
-      @higher_precedence_files ||= files[yast_config_file_idx + 1..]
+      @higher_precedence_files ||= files[yast_config_file_idx + 1..-1]
     end
 
     # Path to the YaST override file


### PR DESCRIPTION
Omitting the end of the range works in Ruby 2.6 but it looks like it is not allowed in 2.5.