### PR TITLE
Add is_wsl function to detect wsl

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -494,8 +494,11 @@ module Yast
       true
     end
 
+    # Determines whether the system is running on WSL
+    #
+    # @return [Boolean] true if runs on WSL; false otherwise
     def is_wsl
-      Builtins.regexpmatch(SCR.Read(path(".target.string"), "/proc/sys/kernel/osrelease"), "-Microsoft")
+      SCR.Read(path(".target.string"), "/proc/sys/kernel/osrelease").to_s.include?("-Microsoft")
     end
 
     publish function: :architecture, type: "string ()"

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -494,6 +494,10 @@ module Yast
       true
     end
 
+    def is_wsl
+      Builtins.regexpmatch(SCR.Read(path(".target.string"), "/proc/sys/kernel/osrelease"), "-Microsoft")
+    end
+
     publish function: :architecture, type: "string ()"
     publish function: :i386, type: "boolean ()"
     publish function: :sparc32, type: "boolean ()"
@@ -528,6 +532,7 @@ module Yast
     publish function: :is_zkvm, type: "boolean ()"
     publish function: :has_smp, type: "boolean ()"
     publish function: :x11_setup_needed, type: "boolean ()"
+    publish function: :is_wsl, type: "boolean ()"
   end
 
   Arch = ArchClass.new

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -60,7 +60,7 @@ describe Yast::Arch do
       end
     end
 
-    context "when it does not run on a Microsoft" do
+    context "when it does not run on a Microsoft kernel" do
       let(:osrelease) { "5.3.11-default" }
 
       it "returns false" do

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -44,4 +44,28 @@ describe Yast::Arch do
       expect(is_zkvm).to eq(false)
     end
   end
+
+  describe ".is_wsl" do
+    before do
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast::Path.new(".target.string"), "/proc/sys/kernel/osrelease")
+        .and_return(osrelease)
+    end
+
+    context "when it runs on a Microsoft kernel" do
+      let(:osrelease) { "5.3.11-Microsoft" }
+
+      it "returns true" do
+        expect(Yast::Arch.is_wsl).to eq(true)
+      end
+    end
+
+    context "when it does not run on a Microsoft" do
+      let(:osrelease) { "5.3.11-default" }
+
+      it "returns false" do
+        expect(Yast::Arch.is_wsl).to eq(false)
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,10 +1,16 @@
 -------------------------------------------------------------------
+Thu Nov 22 12:35:59 UTC 2019 - Ludwig Nussel <lnussel@suse.de>
+
+- add is_wsl function to detect wsl (boo#1154962)
+- 4.2.39
+
+-------------------------------------------------------------------
 Fri Nov 22 09:19:32 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1157532
   - do not modify /etc/sysctl.conf in inst-sys as it is on r/o
     filesystem
--4.2.38
+- 4.2.38
 
 -------------------------------------------------------------------
 Thu Nov 21 21:28:58 UTC 2019 - Knut Anderssen <kanderssen@suse.com>

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.38
+Version:        4.2.39
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
This is a rebased and slightly improved version of #985 (it adds some simple unit tests and drops the use of `Builtins`).

The PR adds an `is_wsl` function to detect whether the system is running on WSL. See [boo#1154962](https://bugzilla.suse.com/show_bug.cgi?id=1154962) for further details.