### PR TITLE
Do not crash when no base product is found

### DIFF
--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -201,7 +201,7 @@ module Y2Packager
       # internal implementation is changed.)
       base = installed_products.find { |p| p.type == "base" }
 
-      log.info("Found installed base product: #{base.name}")
+      log.info("Found installed base product: #{base&.name}")
       base
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 28 17:16:51 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when no base product is found (related to
+  bsc#1132650 and bsc#1140037).
+- 4.2.44
+
+-------------------------------------------------------------------
 Thu Nov 28 11:21:31 UTC 2019 - schubi@suse.de
 
 - Using Y2Packager::Resolvable.any? and Y2Packager::Resolvable.find

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.43
+Version:        4.2.44
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
It causes the yast2-packager test suite to crash.