### PR TITLE
Use 70-yast.conf instead of 30-yast.conf

### DIFF
--- a/doc/etc-and-usr-etc.md
+++ b/doc/etc-and-usr-etc.md
@@ -37,7 +37,7 @@ In a nutshell, jsc#SLE-9077 states that `/etc/sysctl.conf` should not be modifie
 to modify any `sysctl` setting, you should drop a file in `/etc/sysctl.d` containing the new values.
 
 As a first step, we have added a {Yast2::CFA::Sysctl} class which offers an API to sysctl settings.
-This new class uses `/etc/sysctl.d/30-yast.conf` instead of `/etc/sysctl.conf` to write the configuration.
+This new class uses `/etc/sysctl.d/70-yast.conf` instead of `/etc/sysctl.conf` to write the configuration.
 Moreover, it updates known keys that are present in the original `/etc/sysctl.conf` to avoid confusion.
 
 ## An Elaborated Proposal

--- a/library/general/src/lib/cfa/sysctl.rb
+++ b/library/general/src/lib/cfa/sysctl.rb
@@ -49,7 +49,7 @@ module CFA
     Yast.import "Stage"
 
     PARSER = AugeasParser.new("sysctl.lns")
-    PATH = "/etc/sysctl.d/30-yast.conf".freeze
+    PATH = "/etc/sysctl.d/70-yast.conf".freeze
 
     class << self
       # Modifies default CFA methods to handle boolean values

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec  2 16:27:25 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use 70-yast.conf instead of 30-yast.conf to write YaST settings
+  under /etc/sysctl.d (related to jsc#SLE-9077).
+- 4.2.46
+
+-------------------------------------------------------------------
 Fri Nov 29 13:42:50 CET 2019 - schubi@suse.de
 
 - Do not crash while reading the product info (related to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.45
+Version:        4.2.46
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -177,6 +177,14 @@ mkdir -p %{buildroot}%{_sysconfdir}/YaST2
 %post
 %{fillup_only -n yast2}
 
+if [ -f "/etc/sysctl.d/30-yast.conf" ]; then
+    if [ -f "/etc/sysctl.d/70-yast.conf" ]; then
+        rm /etc/sysctl.d/30-yast.conf
+    else
+        mv /etc/sysctl.d/30-yast.conf /etc/sysctl.d/70-yast.conf
+    fi
+fi
+
 %files
 
 # basic directory structure


### PR DESCRIPTION
When writing sysctl related settings, YaST will use `70-yast.conf` instead of `30-yast.conf` to reduce the chance of getting its values overridden.

During the installation/upgrade of `yast2.rpm`, if a `30-yast.conf` is found, it will be renamed to `70-yast.conf`. If the `70-yast.conf` already exists, the `30-yast.conf` will be simply removed (this case should not happen).