### PR TITLE
Backward compatible resolvable

### DIFF
--- a/library/packages/src/lib/y2packager/resolvable.rb
+++ b/library/packages/src/lib/y2packager/resolvable.rb
@@ -80,6 +80,17 @@ module Y2Packager
       from_hash(hash)
     end
 
+    # Backward compatibility method to access resolvable like hash.
+    def [](key)
+      log.info "Calling [] with #{key}. Deprecated. Use method name directly"
+
+      public_send(key.to_sym)
+    # key not found, so return nil to be compatible
+    rescue NameError
+      log.info "attribute #{key} not defined, returning nil."
+      nil
+    end
+
     #
     # Dynamically load the missing attributes from libzypp.
     #

--- a/library/packages/src/lib/y2packager/resolvable.rb
+++ b/library/packages/src/lib/y2packager/resolvable.rb
@@ -82,12 +82,13 @@ module Y2Packager
 
     # Backward compatibility method to access resolvable like hash.
     def [](key)
-      log.info "Calling [] with #{key}. Deprecated. Use method name directly"
+      log.info "Calling [] with #{key}. It is deprecated. Use method name " \
+        "directly. Called from #{caller(1).first}"
 
       public_send(key.to_sym)
     # key not found, so return nil to be compatible
     rescue NameError
-      log.info "attribute #{key} not defined, returning nil."
+      log.warn "attribute #{key} not defined, returning nil."
       nil
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec  4 14:26:35 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- Add backward compatible hash accessors to Resolvable which solve
+  several crashes ( related to bsc#1132650 and bsc#1140037)
+- 4.2.47
+
+-------------------------------------------------------------------
 Mon Dec  2 16:27:25 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Use 70-yast.conf instead of 30-yast.conf to write YaST settings

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,7 +2,7 @@
 Wed Dec  4 14:26:35 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Add backward compatible hash accessors to Resolvable which solve
-  several crashes ( related to bsc#1132650 and bsc#1140037)
+  several crashes (related to bsc#1132650 and bsc#1140037)
 - 4.2.47
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.46
+Version:        4.2.47
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Related to changes introduced in https://github.com/yast/yast-update/pull/143, which raises the below internal error

![Snímek_obrazovky_2019-12-04_13-56-32](https://user-images.githubusercontent.com/1691872/70158499-428f5900-16af-11ea-9fdd-622da84781b6.png)


Bugzilla: [#1157636](https://bugzilla.suse.com/show_bug.cgi?id=1157636) and [#1158056](https://bugzilla.suse.com/show_bug.cgi?id=1158056)

Trello: https://trello.com/c/pyqFurT6 and https://trello.com/c/Rhvu29XB
