### PR TITLE
Avoid a potential crash when calling Y2Packager::Resolvable#deps

### DIFF
--- a/library/packages/src/lib/y2packager/resolvable.rb
+++ b/library/packages/src/lib/y2packager/resolvable.rb
@@ -77,6 +77,7 @@ module Y2Packager
     #
     # @param hash [Hash<Symbol,Object>] A pkg-bindings resolvable hash.
     def initialize(hash)
+      @deps = []
       from_hash(hash)
     end
 

--- a/library/packages/test/y2packager/resolvable_test.rb
+++ b/library/packages/test/y2packager/resolvable_test.rb
@@ -106,4 +106,26 @@ describe Y2Packager::Resolvable do
       expect { res.vendor("dummy") }.to raise_error(ArgumentError)
     end
   end
+
+  describe "#deps" do
+    subject(:resolvable) { Y2Packager::Resolvable.new(pkg_data) }
+
+    let(:pkg_data) do
+      { "name" => "foobar", "deps" => [{ "provides" => "foo" }] }
+    end
+
+    it "returns the dependencies" do
+      expect(resolvable.deps).to eq([{ "provides" => "foo" }])
+    end
+
+    context "when dependencies are missing" do
+      let(:pkg_data) do
+        { "name" => "foobar" }
+      end
+
+      it "returns an empty array" do
+        expect(resolvable.deps).to eq([])
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 12 14:27:27 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Avoid a potential crash when pkg-bindings did not report
+  dependencies information (bsc#1159120).
+- 4.2.48
+
+-------------------------------------------------------------------
 Wed Dec  4 14:26:35 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Add backward compatible hash accessors to Resolvable which solve

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.47
+Version:        4.2.48
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
This problem was spotted while running the test suite. Perhaps it won't happen in a real scenario, but I prefer to prevent such a crash.

```ruby
resolvable = Y2Package::Resolvable.new("name" => "foobar")
resolvable.deps #=> RuntimeError (Missing attributes for identifying the resolvable.)
```

Why am I fixing just the `#deps` case and not doing anything about `#name` or `#arch`? Well, the reason is that reading the `yast-pkg-bindings` code I guess [dependencies can be missing](https://github.com/yast/yast-pkg-bindings/blob/6abebc1ed823ccd06495ad39a19a4f5b89279bcb/src/Resolvable_Properties.cc#L529). But I would expect the name or the arch to be present always.

However, I would prefer to rethink the whole approach behind the `Resolvable` class. I prefer to have real instance methods to rely on `#method_missing`. If desired, we could even use metaprogramming to reduce the overhead (and setting default values like the `#deps` case) when creating those methods. But that's out of scope.