### PR TITLE
Service widget default

### DIFF
--- a/library/cwm/src/lib/cwm/service_widget.rb
+++ b/library/cwm/src/lib/cwm/service_widget.rb
@@ -23,6 +23,8 @@ require "cwm/custom_widget"
 module CWM
   # CWM wrapper for Yast2::ServiceWidget
   class ServiceWidget < CustomWidget
+    extend Forwardable
+
     # creates new widget instance for given service
     # @param service [Yast2::SystemService,Yast2::CompoundService] service to be configured
     def initialize(service)
@@ -30,16 +32,10 @@ module CWM
       self.handle_all_events = true
     end
 
-    def default_action=(value)
-      @service_widget.default_action=(value)
-    end
+    def_delegators :@service_widget, :refresh, :store, :help, :default_action=
 
     def contents
       @service_widget.content
-    end
-
-    def refresh
-      @service_widget.refresh
     end
 
     def handle(event)
@@ -49,18 +45,10 @@ module CWM
       @service_widget.handle_input(event["ID"])
     end
 
-    def store
-      @service_widget.store
-    end
-
     # The widget needs to be refreshed each time it is rendered. Otherwise, cached
     # service values would not be selected (e.g., when switching in a DialogTree)
     def init
       refresh
-    end
-
-    def help
-      @service_widget.help
     end
   end
 end

--- a/library/cwm/src/lib/cwm/service_widget.rb
+++ b/library/cwm/src/lib/cwm/service_widget.rb
@@ -30,6 +30,10 @@ module CWM
       self.handle_all_events = true
     end
 
+    def default_action=(value)
+      @service_widget.default_action=(value)
+    end
+
     def contents
       @service_widget.content
     end

--- a/library/systemd/src/lib/yast2/service_widget.rb
+++ b/library/systemd/src/lib/yast2/service_widget.rb
@@ -86,9 +86,12 @@ module Yast2
       init_default_action
     end
 
-    # Set the given action as the current action selected by the widget
+    # Set the given action as the current action selected by the widget, when
+    # no action is given it will not touch the service unless modified in the
+    # selection list
     #
-    # @param value [Symbol, nil]
+    # @param value [Symbol, nil] uses :nothing in case of no action given
+    # @see Yast2::SystemService#action
     def default_action=(value)
       @current_action = value || :nothing
     end
@@ -197,6 +200,8 @@ module Yast2
       # option was :reload or :restart it will be the same after applying the
       # changes and refreshing
       @current_action = action
+      # We can return safely without modifying the service action as the
+      # service should be reset before calling this method
       return if action == :nothing
 
       service.public_send(action)

--- a/library/systemd/src/lib/yast2/service_widget.rb
+++ b/library/systemd/src/lib/yast2/service_widget.rb
@@ -34,12 +34,17 @@ module Yast2
   #     end
   #
   #     def propose
-  #       @service.action = :restart
+  #       # The default service widget action can be proposed by the current
+  #       # service action
+  #       @service.restart
   #       @service.start_mode = :on_demand
   #     end
   #
   #     def show_dialog
   #       service_widget = ServiceWidget.new(@service)
+  #       # Or can be set by the service_widget
+  #       service_widget.default_action = :reload if service.running?
+  #
   #       content = VBox(
   #         ...,
   #         service_widget.content
@@ -60,11 +65,16 @@ module Yast2
   # @todo Allow to specify the widget ID. Currently, it uses always the same, so you can not use
   #   more than one instance of this class at the same time.
   class ServiceWidget
+    extend Yast::I18n
     include Yast::I18n
     include Yast::Logger
     include Yast::UIShortcuts
 
-    attr_reader :default_action
+    # It stores the selected service action
+    #
+    # @return [Symbol] service action (:nothing for no action)
+    # @see Yast2::SystemService#action
+    attr_reader :current_action
 
     # creates new widget instance for given service
     # @param service [Yast2::SystemService,Yast2::CompoundService] service
@@ -76,9 +86,11 @@ module Yast2
       init_default_action
     end
 
+    # Set the given action as the current action selected by the widget
+    #
+    # @param value [Symbol, nil]
     def default_action=(value)
-      @default_action = value
-      service.public_send(default_action) if valid_action?(value)
+      @current_action = value || :nothing
     end
 
     # gets widget term
@@ -106,7 +118,6 @@ module Yast2
     #
     # @return [nil]
     def refresh
-      service.public_send(default_action) if valid_action?(default_action)
       Yast::UI.ChangeWidget(Id(:service_widget_status), :Value, status)
       Yast::UI.ChangeWidget(Id(:service_widget_action), :Items, action_items)
       Yast::UI.ChangeWidget(Id(:service_widget_autostart), :Items, autostart_items)
@@ -166,19 +177,26 @@ module Yast2
 
     attr_reader :service
 
+    # Initialize the default option for the service widget. It tries to use the
+    # action from the service if set, if not, will propose :reload or :restart
+    # when the service is active or do nothing in case of inactive.
     def init_default_action
-      return unless service.currently_active?
+      # For being compatible with the default action proposed by the service
+      return self.default_action = service.action if service.action
+      return self.default_action = :nothing unless service.currently_active?
 
-      default_action = service.support_reload? ? :reload : :restart
+      self.default_action = service.support_reload? ? :reload : :restart
     end
-
-
 
     def store_action
       action = Yast::UI.QueryWidget(Id(:service_widget_action), :Value)
       return unless action
 
       action = action.to_s.sub(/^service_widget_action_/, "").to_sym
+      # Remember the selected option in case of refresh, specially if the
+      # option was :reload or :restart it will be the same after applying the
+      # changes and refreshing
+      @current_action = action
       return if action == :nothing
 
       service.public_send(action)
@@ -218,22 +236,64 @@ module Yast2
       )
     end
 
+    ACTION_LABEL =
+      {
+        start:   N_("Start"),
+        stop:    N_("Stop"),
+        reload:  N_("Reload"),
+        restart: N_("Restart"),
+        nothing: N_("Keep current state")
+      }.freeze
+
+    # Return whether the option given is supported and a valid one according
+    # to the service status.
+    #
+    # @param value [Symbol] the current_action selected
     def valid_action?(value)
-      actions = service.currently_active? ? [:stop, :restart] : [:start]
-      actions << :reload if service.currently_active? && service.support_reload?
       actions.include?(value)
     end
 
-    def action_items
-      current_action = service.action
-      res = []
-      res << Item(Id(:service_widget_action_start), _("Start"), current_action == :start) if service.currently_active? != true
-      res << Item(Id(:service_widget_action_stop), _("Stop"), current_action == :stop) if service.currently_active? != false
-      res << Item(Id(:service_widget_action_restart), _("Restart"), current_action == :restart) if service.currently_active? != false
-      res << Item(Id(:service_widget_action_reload), _("Reload"), current_action == :reload) if service.currently_active? != false && service.support_reload?
-      res << Item(Id(:service_widget_action_nothing), _("Keep current state"), current_action.nil?)
+    # Return the list of actions permitted and supported depending on the
+    # current service status.
+    def actions
+      actions = service.currently_active? ? [:stop, :restart] : [:start]
+      actions << :reload if service.currently_active? && service.support_reload?
+      actions << :nothing
+    end
 
-      res
+    # @param value [Symbol]
+    def action_item_id(value)
+      Id("service_widget_action_#{value}".to_sym)
+    end
+
+    # @param value [Symbol]
+    def action_label(value)
+      _(ACTION_LABEL[value])
+    end
+
+    # When the cached action is valid, it returns if the current action is the
+    # given action. If the cached option is invalid, then return true only if
+    # the given action is for not touching the service
+    #
+    # @see valid_action?
+    # @param value [Symbol]
+    def selected_item?(value)
+      if !valid_action?(current_action)
+        value == :nothing
+      else
+        current_action == value
+      end
+    end
+
+    # @param value [Symbol]
+    # @return [Yast::Term] action Item
+    def action_item(value)
+      Item(action_item_id(value), action_label(value), selected_item?(value))
+    end
+
+    # @return [Array<Yast::Term>] list of action items
+    def action_items
+      actions.map { |a| action_item(a) }
     end
 
     def autostart_widget

--- a/library/systemd/src/lib/yast2/service_widget.rb
+++ b/library/systemd/src/lib/yast2/service_widget.rb
@@ -69,6 +69,9 @@ module Yast2
     def initialize(service)
       textdomain "base"
       @service = service
+      # When the service is active, by default, propose to reload or restart
+      # it after writting the configuration (bsc#1158946)
+      init_default_action
     end
 
     # gets widget term
@@ -154,6 +157,12 @@ module Yast2
   private
 
     attr_reader :service
+
+    def init_default_action
+      return unless service.currently_active?
+
+      service.support_reload? ? service.reload : service.restart
+    end
 
     def store_action
       action = Yast::UI.QueryWidget(Id(:service_widget_action), :Value)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 19 14:51:23 UTC 2019 - Knut Anderssen <kanderssen@suse.com>
+
+- Yast2::ServiceWidget: By default, propose to reload or restart
+  the service when it is active (bsc#1158946)
+- 4.2.49
+
+-------------------------------------------------------------------
 Thu Dec 19 09:11:35 CET 2019 - aschnell@suse.com
 
 - Added helper to create UI sort-key term (bsc#1140018)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.48
+Version:        4.2.49
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

The new service widget was [introduced]((https://trello.com/c/uAe4i9Ru/107-5-fate319428-allow-socket-activation-widget)) in SLE-15-SP1, and by default, the option **keep_current_state** is selected. Which means that, although the user made same changes in the configuration, the changes were not reflected in the service as the service itself was untouched. 

Reported in: https://bugzilla.suse.com/show_bug.cgi?id=1158946

The main problem is that the option is usually overlooked by the user, and it does not have the same `default` as it had in previous SLE versions. At least it is the case of yast2 dns-server as we can see in the images below.

| **SLE-12-SP4 dns** | **SLE-15-SP1** |
|       :---:                    |      :---:               |
| ![SLE-12-SP4](https://trello-attachments.s3.amazonaws.com/5b2b92a1265a6fc3b05a7d51/5df22142bce86b75b3364143/78e68242593766be7b134ee73e806dad/image.png) |  ![SLE-15-SP1](https://trello-attachments.s3.amazonaws.com/5b2b92a1265a6fc3b05a7d51/5df22142bce86b75b3364143/20fd87bee3d46b4ba3942fd16b8bf46a/Screenshot_from_2019-12-17_16-13-31.png) |

In the SLE-12-SP4 image, we can see that the checkbox for **reloading** the service in case of modified configuration is **checked** by default.

- https://trello.com/c/q5DPg1Vh/1515-sles15-sp1-l3-important-1158946-namedservice-is-not-restarted-after-change-in-yast

## Solution

When the widget is initialized it checks if the service is running or not. 

- In case of `active`, it will set the default action as **reload** when supported or **restart** when not. 
- In case of 'inactive`, it will not propose any action per default, that is, the option selected will continue being the **keep_current_state** one.

Also, as applying the changes will modify the action items, the widget will try to select the default action when refreshing if the action is available. **UPDATE:** As this could be problematic (changing from restart to reload or other action), this option has been redefined and now the selected option will be remembered.

Last but not least, the option can be modified per module, ie:

```ruby
     # Example modifying the code in dns-server
     def service_widget
       return if @service_widget

       @service_widget = CWM::ServiceWidget.new(service)
       @service_widget.default_action = :restart if service.running?
       @service_widget
     end
```

![DnsServerServiceWidget](https://user-images.githubusercontent.com/7056681/71083236-7461ee80-218a-11ea-9daa-3ad79a9a597e.gif)

This new GIF shows an updated version which uses a default option for initializing the widget but then stores the selected option in case of applying changes. That is not a problem in common dialogs where the refresh method is not called at all.

```ruby
     # Example modifying the code in dns-server
     def service
       return if @service

       @service = CWM::ServiceWidget.new(service)
       @service.restart if service.running?
       @service
     end
```
![DnsServerServiceWidgetRememberAction](https://user-images.githubusercontent.com/7056681/71176273-68952b80-2261-11ea-9822-b4775a1a862d.gif)
