### PR TITLE
Propagate an error status when a CommandLine module gets an   unknown command

### DIFF
--- a/library/commandline/src/modules/CommandLine.rb
+++ b/library/commandline/src/modules/CommandLine.rb
@@ -360,7 +360,7 @@ module Yast
         # translators: error message in command line interface
         Error(Builtins.sformat(_("Unknown Command: %1"), command))
 
-        return { "command" => command }
+        return {}
       end
 
       # build the list of options for the command

--- a/library/commandline/test/commandline_test.rb
+++ b/library/commandline/test/commandline_test.rb
@@ -4,6 +4,10 @@ require_relative "test_helper"
 
 Yast.import "CommandLine"
 
+# If these test fail (or succeed) in mysterious ways then it may be
+# wfm.rb eagerly rescuing a RSpec::Mocks::MockExpectationError
+# (fixed meanwhile in ruby-bindings). In such cases see the y2log.
+
 describe Yast::CommandLine do
   # restore the original modes to not accidentally influence the other tests
   # (these tests change the UI mode to "commandline")
@@ -37,5 +41,12 @@ describe Yast::CommandLine do
     expect($stdout).to_not receive(:puts).with("Finish called")
 
     Yast::WFM.CallFunction("dummy_cmdline", ["crash"])
+  end
+
+  it "complains about unknown commands and returns false" do
+    expect(Yast::CommandLine).to receive(:Print).with(/Unknown Command:/)
+    expect(Yast::CommandLine).to receive(:Print).with(/Use.*help.*available commands/)
+
+    expect(Yast::WFM.CallFunction("dummy_cmdline", ["unknowncommand"])).to eq false
   end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 10 09:04:16 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Propagate an error status when a CommandLine module gets an
+  unknown command (related to bsc#1144351).
+- 4.2.52
+
+-------------------------------------------------------------------
 Wed Jan  8 16:27:59 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fix an exception in the live installation caused by a missing

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
prompted by the testing discussion in https://github.com/yast/yast-ruby-bindings/pull/237
because I wanted to test that fix with `yast2 lan unknowncommand` and it still did not work