### PR TITLE
Add missing require clause (bsc#1160362)

### DIFF
--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -14,6 +14,7 @@ require "yast"
 require "y2packager/product"
 require "y2packager/product_sorter"
 require "y2packager/resolvable"
+require "y2packager/product_control_product"
 
 Yast.import "Pkg"
 Yast.import "Linuxrc"

--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -242,6 +242,11 @@ describe Y2Packager::ProductReader do
           .with("software", "base_products").and_return([])
       end
 
+      after do
+        # the read products are cached, we need to reset them manually for the next test
+        Y2Packager::ProductControlProduct.instance_variable_set(:@products, nil)
+      end
+
       it "does not crash" do
         expect { subject.all_products }.to_not raise_error
       end

--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -216,6 +216,36 @@ describe Y2Packager::ProductReader do
 
       expect(subject.all_products.size).to eq(1)
     end
+
+    # Smoke test. There was a missing "require" clause in one part of the code.
+    # This context ensures that part is executed in the tests, basically to
+    # make sure the "require" is not forgotten (bsc#1160362). But the tests on
+    # this context do not guarantee the code is working correctly in all cases.
+    # They only test a simplistic case with quite some mocking.
+    context "with the online media and no base product" do
+      # FIXME: needed because MediumType is wrongly located in yast2-packager
+      module Y2Packager
+        class MediumType
+          def self.online?
+            true
+          end
+        end
+      end
+
+      before do
+        allow(Yast::Stage).to receive(:initial).and_return true
+
+        # The tests at test/y2packager/product_control_product_test.rb mock
+        # this to always be an array. Let's copy the most simplistic of those
+        # mocks.
+        allow(Yast::ProductFeatures).to receive(:GetFeature)
+          .with("software", "base_products").and_return([])
+      end
+
+      it "does not crash" do
+        expect { subject.all_products }.to_not raise_error
+      end
+    end
   end
 
   describe ".installation_package_mapping" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan  8 16:27:59 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fix an exception in the live installation caused by a missing
+  "require" clause (bsc#1160362).
+- 4.2.51
+
+-------------------------------------------------------------------
 Mon Jan  6 15:03:45 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Persian is also an RTL language (related to bsc#1156437)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.50
+Version:        4.2.51
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1160362 for details.

Some things have changed in the `ProductReader` class recently. We don't test the Live Installation (is not a supported scenario), but it looks like it follows a different workflow that ends up with an exception because `ProductReader` contains a call to `Y2Packager::ProductControlProduct.products` bit it does not require `y2packager/product_control_product`.

Likely, in the normal workflow it works by pure luck (because some other class requires `y2packager/product_control_product`).

This pull request adds the missing require together with a smoke test to prove it was indeed missing.

If fact, the whole situation is even worse at this moment.  The current code looks like this:

```ruby
if Yast::Stage.initial && Y2Packager::MediumType.online? && !force_repos
  return Y2Packager::ProductControlProduct.products.each_with_object([]) {..}
end
```

Which means that there is another missing "require" for `Y2Packager::MediumType`. But that's harder to fix and, thus, I'm leaving it out of the scope of this pull request. That class lives in yast2-packager, not in yast2.rpm. To achieve a 100% correct solution, the file (and all its dependencies) should be moved. This is currently not failing (again, by pure luck), so we can ignore the problem for the time being.