### PR TITLE
Do not fail during upgrade if `/var/lib/YaST2` is missing (bsc#1159562)

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot_store.rb
+++ b/library/system/src/lib/yast2/fs_snapshot_store.rb
@@ -30,6 +30,12 @@ module Yast2
     # @param[String] purpose of snapshot like "upgrade"
     # @raise[RuntimeError] if writing to file failed
     def self.save(purpose, snapshot_id)
+      # Ensure the directory is there (bsc#1159562)
+      Yast::SCR.Execute(
+        Yast::Path.new(".target.bash"),
+        "/bin/mkdir -p #{snapshot_dir_path}"
+      )
+
       result = Yast::SCR.Write(
         Yast::Path.new(".target.string"),
         snapshot_path(purpose),
@@ -61,7 +67,13 @@ module Yast2
 
     # Path where is stored given purpose
     def self.snapshot_path(purpose)
-      path = "/var/lib/YaST2/pre_snapshot_#{purpose}.id"
+      ::File.join(snapshot_dir_path, "pre_snapshot_#{purpose}.id")
+    end
+    private_class_method :snapshot_path
+
+    # Path of the directory where the ids of the snapshots are stored
+    def self.snapshot_dir_path
+      path = "/var/lib/YaST2"
 
       Yast.import "Stage"
       if Yast::Stage.initial && !Yast::WFM.scr_chrooted?
@@ -71,6 +83,6 @@ module Yast2
 
       path
     end
-    private_class_method :snapshot_path
+    private_class_method :snapshot_dir_path
   end
 end

--- a/library/system/test/fs_snapshot_store_test.rb
+++ b/library/system/test/fs_snapshot_store_test.rb
@@ -6,6 +6,11 @@ require "yast2/fs_snapshot_store"
 describe Yast2::FsSnapshotStore do
   describe ".save" do
     it "stores snapshot id to file identified by purpose" do
+      expect(Yast::SCR).to receive(:Execute).with(
+        path(".target.bash"),
+        "/bin/mkdir -p /var/lib/YaST2"
+      )
+
       expect(Yast::SCR).to receive(:Write).with(
         path(".target.string"),
         "/var/lib/YaST2/pre_snapshot_test.id",
@@ -16,6 +21,8 @@ describe Yast2::FsSnapshotStore do
     end
 
     it "raises exception if writing failed" do
+      allow(Yast::SCR).to receive(:Execute).with(path(".target.bash"), anything)
+
       expect(Yast::SCR).to receive(:Write).with(
         path(".target.string"),
         "/var/lib/YaST2/pre_snapshot_test.id",

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 10 13:43:20 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed error during upgrade if Btrfs is used and '/var/lib/YaST2'
+  is missing (bsc#1159562)
+- 4.2.53
+
+-------------------------------------------------------------------
 Fri Jan 10 09:04:16 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Propagate an error status when a CommandLine module gets an

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.52
+Version:        4.2.53
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1159562 for details.

When upgrading a system, YaST takes a previous snapshot and stores its id in the `/var/lib/YaST2` directory of the system being upgraded. That directory will always be there, as long as YaST is installed in the system being upgraded.

But when using YaST to upgrade a system in which YaST is not installed, the process fails because the directory is not there.

It's debatable whether upgrading a non-YaST system with YaST is a valid scenario, but the small change introduced in this pull request should be enough to make it work.

### Testing

Tested manually. With this patch, the snapshot is correctly created in both situations (with and without a preexisting `/var/lib/YaST2`).