### PR TITLE
Do not refresh package installation overview if the medium has changed.

### DIFF
--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -743,7 +743,7 @@ module Yast
         end
 
         # Don't override explicit user request!
-        SwitchToSlideView() if !(@user_switched_to == :details)
+        SwitchToSlideView() if @user_switched_to != :details
       elsif !ShowingDetails()
         # (true) : Showing release tab if needed
         RebuildDialog(true)

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -110,6 +110,8 @@ module Yast
   class SlideShowClass < Module
     include Yast::Logger
 
+    attr_accessor :user_switched_to
+
     module UI_ID
       TOTAL_PROGRESS = :progressTotal
       CURRENT_PACKAGE = :progressCurrentPackage
@@ -741,7 +743,7 @@ module Yast
         end
 
         # Don't override explicit user request!
-        SwitchToSlideView() if !@user_switched_to == :details
+        SwitchToSlideView() if !(@user_switched_to == :details)
       elsif !ShowingDetails()
         # (true) : Showing release tab if needed
         RebuildDialog(true)

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -805,11 +805,12 @@ module Yast
       elsif button == :showSlide && !ShowingSlide()
         if Slides.HaveSlides
           if @user_switched_to == :release_notes
-            # The user is switching from release notes to slide show.
-            # In order to not disturb the user while reading the release notes
-            # we are not updatding the tabs although the slide show has been
-            # changed meanwhile. So we are updating it now before switching to
-            # slide show.
+            # The user is currently in the release notes tab.
+            # In order to not disturb him while reading the release notes
+            # we are not updating the tabs although the slide show has been
+            # changed in the background.
+            # Now the user is switching from release notes to slide show
+            # and we are updating the slide show now.
             RebuildDialog(true) # true: showing the release tab
           end
           SwitchToSlideView()

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -806,7 +806,7 @@ module Yast
         if Slides.HaveSlides
           if @user_switched_to == :release_notes
             # The user is switching from release notes to slide show.
-            # In order to not disturbe the user while reading the release notes
+            # In order to not disturb the user while reading the release notes
             # we are not updatding the tabs although the slide show has been
             # changed meanwhile. So we are updating it now before switching to
             # slide show.

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -805,7 +805,7 @@ module Yast
       elsif button == :showSlide && !ShowingSlide()
         if Slides.HaveSlides
           if @user_switched_to == :release_notes
-            # The user is switching from realease notes to slide show.
+            # The user is switching from release notes to slide show.
             # In order to not disturbe the user while reading the release notes
             # we are not updatding the tabs although the slide show has been
             # changed meanwhile. So we are updating it now before switching to

--- a/library/packages/test/slide_show_test.rb
+++ b/library/packages/test/slide_show_test.rb
@@ -3,6 +3,7 @@
 require_relative "test_helper"
 
 Yast.import "SlideShow"
+Yast.import "Slides"
 Yast.import "UI"
 
 describe "Yast::SlideShow" do
@@ -144,6 +145,40 @@ describe "Yast::SlideShow" do
       Yast::SlideShow.Setup(stages)
       total_size = Yast::SlideShow.GetSetup.values.reduce(0) { |a, e| a + e["size"] }
       expect(total_size).to eq(100)
+    end
+  end
+
+  describe "#Redraw" do
+    before do
+      allow(Yast::SlideShow).to receive(:CheckForSlides)
+    end
+    context "user is reading release notes" do
+      it "does not redraw the page" do
+        Yast::SlideShow.user_switched_to = :release_notes
+        expect(Yast::SlideShow).not_to receive(:RebuildDialog)
+        Yast::SlideShow.Redraw()
+      end
+    end
+    context "no user input" do
+      before do
+        Yast::SlideShow.user_switched_to = :none
+      end
+      context "slideshow is available" do
+        before do
+          allow(Yast::Slides).to receive(:HaveSlides).and_return(true)
+          allow(Yast::Slides).to receive(:HaveSlideSupport).and_return(true)
+        end
+        it "shows slideshow" do
+          expect(Yast::SlideShow).to receive(:SwitchToSlideView)
+          Yast::SlideShow.Redraw()
+        end
+      end
+      context "slideshow is not available" do
+        it "redraws the page" do
+          expect(Yast::SlideShow).to receive(:RebuildDialog)
+          Yast::SlideShow.Redraw()
+        end
+      end
     end
   end
 end

--- a/library/packages/test/slide_show_test.rb
+++ b/library/packages/test/slide_show_test.rb
@@ -181,4 +181,73 @@ describe "Yast::SlideShow" do
       end
     end
   end
+
+  describe "#HandleInput" do
+    before do
+    end
+    context "switching to details" do
+      before do
+        allow(Yast::SlideShow).to receive(:ShowingDetails).and_return(false)
+      end
+      it "switches to detail view" do
+        expect(Yast::SlideShow).to receive(:SwitchToDetailsView)
+        Yast::SlideShow.HandleInput(:showDetails)
+      end
+      it "saves user selection" do
+        Yast::SlideShow.HandleInput(:showDetails)
+        expect(Yast::SlideShow.user_switched_to).to eq(:details)
+      end
+    end
+    context "switching to slide show" do
+      before do
+        allow(Yast::SlideShow).to receive(:ShowingSlide).and_return(false)
+        allow(Yast::Slides).to receive(:HaveSlides).and_return(true)
+      end
+      context "release notes have been selected before" do
+        before do
+          Yast::SlideShow.user_switched_to = :release_notes
+        end
+        it "redraws the page" do
+          expect(Yast::SlideShow).to receive(:RebuildDialog)
+          Yast::SlideShow.HandleInput(:showSlide)
+        end
+        it "switches to slide show" do
+          expect(Yast::SlideShow).to receive(:SwitchToSlideView)
+          Yast::SlideShow.HandleInput(:showSlide)
+        end
+      end
+      context "release notes have NOT been selected before" do
+        before do
+          Yast::SlideShow.user_switched_to = :none
+        end
+        it "does not redraw the page" do
+          expect(Yast::SlideShow).not_to receive(:RebuildDialog)
+          Yast::SlideShow.HandleInput(:showSlide)
+        end
+        it "switches to slide show" do
+          expect(Yast::SlideShow).to receive(:SwitchToSlideView)
+          Yast::SlideShow.HandleInput(:showSlide)
+        end
+      end
+      it "saves user selection" do
+        Yast::SlideShow.HandleInput(:showSlide)
+        expect(Yast::SlideShow.user_switched_to).to eq(:slides)
+      end
+    end
+    context "switching to release notes" do
+      before do
+        allow(Yast::SlideShow).to receive(:ShowingRelNotes).and_return(false)
+        Yast::SlideShow.add_relnotes_for_product("Foo", :releaseNotesFoo, [])
+      end
+      it "switches to realease notes view" do
+        expect(Yast::SlideShow).to receive(:SwitchToReleaseNotesView)
+        Yast::SlideShow.HandleInput(:rn_Foo)
+      end
+      it "saves user selection" do
+        Yast::SlideShow.HandleInput(:rn_Foo)
+        expect(Yast::SlideShow.user_switched_to).to eq(:release_notes)
+      end
+    end
+  end
+
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan  9 16:57:33 CET 2020 - schubi@suse.de
+
+- Do not refresh package installation overview if the medium has
+  been changed and the user has switched to the release notes tab.
+  (bsc#1129426, bsc#1159367)
+- 4.2.52
+
+-------------------------------------------------------------------
 Wed Jan  8 16:27:59 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Fix an exception in the live installation caused by a missing

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.51
+Version:        4.2.52
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -117,8 +117,8 @@ Conflicts:      yast2-dns-server < 3.1.17
 Conflicts:      yast2-installation < 4.2.9
 # moved cfg_mail.scr
 Conflicts:      yast2-mail < 3.1.7
-# Older packager use removed API
-Conflicts:      yast2-packager < 4.0.33
+# Older packager use removed API e.g. user_switched_to_details
+Conflicts:      yast2-packager < 4.2.44
 # Older snapper does not provide machine-readable output
 Conflicts:	snapper < 0.8.6
 


### PR DESCRIPTION
**Problem**
Reading Release Notes during installation is impossible because the installation switch to the
"Details" tab when the medium has been changed.
**Solution**
Do not refresh package installation overview if the medium has been changed and the user has switched to the release notes tab.