### PR TITLE
New classes for storing the old repositories (bsc#1159433)

### DIFF
--- a/library/packages/src/lib/y2packager/original_repository_setup.rb
+++ b/library/packages/src/lib/y2packager/original_repository_setup.rb
@@ -1,0 +1,61 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 SUSE LINUX GmbH, Nuremberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "singleton"
+
+require "yast"
+require "yast/logger"
+require "y2packager/repository"
+require "y2packager/service"
+
+module Y2Packager
+  #
+  # This class remembers the current repository setup. This is useful
+  # during upgrade when we need to know which repositories/services
+  # were already present in the original system and which are the new
+  # repositories used for migration.
+  #
+  # @since 4.2.60
+  class OriginalRepositorySetup
+    include Yast::Logger
+    include Singleton
+
+    attr_reader :repositories, :services
+
+    # constructor, initialize the stored lists to empty lists
+    def initialize
+      @repositories = []
+      @services = []
+    end
+
+    # Read and store the current repository/service setup.
+    def read
+      @repositories = Repository.all
+      @services = Service.all
+      log.info("Found #{repositories.size} repositories and #{services.size} services")
+    end
+
+    # Is the service present in the stored list?
+    #
+    # @param [String] service_alias Alias of the service
+    def service?(service_alias)
+      services.any? { |s| s.alias == service_alias }
+    end
+
+    # Is the repository present in the stored list?
+    #
+    # @param [String] service_alias Alias of the service
+    def repository?(repository_alias)
+      repositories.any? { |r| r.alias == repository_alias }
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/repository.rb
+++ b/library/packages/src/lib/y2packager/repository.rb
@@ -1,0 +1,257 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "uri"
+require "y2packager/product"
+require "y2packager/resolvable"
+
+module Y2Packager
+  # This class represents a libzypp repository
+  #
+  # It offers a simple API to list them, query basic attributes,
+  # find out the products they offer and enabling/disabling them.
+  #
+  # @example Get all repositories
+  #   all_repos = Y2Packager::Repository.all     #=> [#<Y2Packager::Repository>, ...]
+  #   enabled = Y2Packager::Repository.enabled   #=> [#<Y2Packager::Repository>]
+  #
+  # @example Get a repository using a repo ID
+  #   repo = Y2Packager::Repository.find(1) #=> #<Y2Packager::Repository>
+  #   repo.autorefresh?                   #=> true
+  #   repo.url                            #=> "http://download.opensuse.org..."
+  #
+  # @example Disabling a repository
+  #   repo = Y2Packager::Repository.find(1) #=> #<Y2Packager::Repository>
+  #   repo.enabled?                       #=> true
+  #   repo.disabled!
+  #   repo.enabled?                       #=> false
+  class Repository
+    Yast.import "Pkg"
+
+    # Repository schemes considered local (see #local?)
+    # https://github.com/openSUSE/libzypp/blob/a7a038aeda1ad6d9e441e7d3755612aa83320dce/zypp/Url.cc#L458
+    LOCAL_SCHEMES = [:cd, :dvd, :dir, :hd, :iso, :file].freeze
+
+    # @return [Fixnum] Repository ID
+    attr_reader :repo_id
+    # @return [String] Repository name
+    attr_reader :name
+    # @return [URI::Generic] Repository URL (expanded)
+    attr_reader :url
+    # @return [URI::Generic] Raw repository URL (unexpanded)
+    attr_reader :raw_url
+    # @return [String] Product directory
+    attr_reader :product_dir
+    # @return [String] Repository alias
+    attr_reader :repo_alias
+
+    attr_writer :enabled
+    private :enabled=
+
+    # Repository was not found
+    class NotFound < StandardError; end
+
+    class << self
+      # Return all registered repositories
+      #
+      # @param enabled_only [Boolean] Returns only enabled repositories
+      # @return [Array<Repository>] Array containing all repositories
+      #
+      # @see Yast::Pkg.SourceGetCurrent
+      # @see Y2Packager::Repository.find
+      def all(enabled_only: false)
+        Yast::Pkg.SourceGetCurrent(enabled_only).map do |repo_id|
+          find(repo_id)
+        end
+      end
+
+      # Return only enabled repositories
+      #
+      # @return [Array<Repository>] Array containing enabled repositories
+      def enabled
+        all.select(&:enabled?)
+      end
+
+      # Return only disabled repositories
+      #
+      # @return [Array<Repository>] Array containing disabled repositories
+      def disabled
+        all.reject(&:enabled?)
+      end
+
+      # Return a repository with the given repo_id
+      #
+      # @param repo_id [Fixnum] Repository ID
+      # @return [Y2Packager::Repository] Repository instance
+      #
+      # @raise NotFound
+      def find(repo_id)
+        repo_data = Yast::Pkg.SourceGeneralData(repo_id)
+        raise NotFound if repo_data.nil?
+
+        new(repo_id: repo_id, repo_alias: repo_data["alias"], enabled: repo_data["enabled"],
+          name: repo_data["name"], autorefresh: repo_data["autorefresh"],
+          url: URI(repo_data["url"]), raw_url: URI(repo_data["raw_url"]),
+          product_dir: repo_data["product_dir"])
+      end
+
+      # Add a repository
+      #
+      # @param name        [String]       Name
+      # @param url         [URI::Generic] Repository URL
+      # @param product_dir [String]       Product directory
+      # @param enabled     [Boolean]      Is the repository enabled?
+      # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
+      # @return [Y2Packager::Repository,nil] New repository or nil if creation failed
+      def create(name:, url:, product_dir: "", enabled: true, autorefresh: true)
+        repo_id = Yast::Pkg.RepositoryAdd(
+          "name" => name, "base_urls" => [url], "enabled" => enabled, "autorefresh" => autorefresh,
+          "prod_dir" => product_dir
+        )
+
+        repo_id ? find(repo_id) : nil
+      end
+    end
+
+    # Constructor
+    #
+    # @param repo_alias  [String]       Repository alias (unique identifier)
+    # @param repo_id     [Fixnum]       Repository ID
+    # @param name        [String]       Name
+    # @param url         [URI::Generic] Repository URL (expanded)
+    # @param raw_url     [URI::Generic] Optional raw repository URL (unexpanded)
+    # @param product_dir [String]       Product directory
+    # @param enabled     [Boolean]      Is the repository enabled?
+    # @param autorefresh [Boolean]      Is auto-refresh enabled for this repository?
+    def initialize(repo_id:, repo_alias:, name:, url:, raw_url: nil, product_dir: "", enabled:, autorefresh:)
+      @repo_id = repo_id
+      @repo_alias = repo_alias
+      @name    = name
+      @enabled = enabled
+      @autorefresh = autorefresh
+      @url = url
+      @raw_url = raw_url || url
+      @product_dir = product_dir
+    end
+
+    # Return repository scheme
+    #
+    # The scheme is determined using the URL
+    #
+    # @return [Symbol,nil] URL scheme
+    def scheme
+      url.scheme ? url.scheme.to_sym : nil
+    end
+
+    # Return products contained in the repository
+    #
+    # @return [Array<Y2Packager::Product>] Products in the repository
+    #
+    # @see Y2Packager::Product
+    def products
+      return @products unless @products.nil?
+
+      # Filter products from this repository
+      candidates = Y2Packager::Resolvable.find(kind: :product, source: repo_id)
+
+      # Build an array of Y2Packager::Product objects
+      @products = candidates.map do |data|
+        Y2Packager::Product.new(name: data.name, version: data.version,
+          arch: data.arch, category: data.category, vendor: data.vendor)
+      end
+    end
+
+    # Determine if the repository is local
+    #
+    # @return [Boolean] true if the repository is considered local; false otherwise
+    def local?
+      LOCAL_SCHEMES.include?(scheme)
+    end
+
+    # Determine if the repository is enabled
+    #
+    # @return [Boolean] true if repository is enabled; false otherwise
+    def enabled?
+      @enabled
+    end
+
+    # Determine if auto-refresh is enabled for the repository
+    #
+    # @return [Boolean] true if auto-refresh is enabled; false otherwise
+    def autorefresh?
+      @autorefresh
+    end
+
+    # Return addons in the repository
+    #
+    # @return [Array<Y2Packager::Product>] Addons in the repository
+    #
+    # @see #products
+    def addons
+      products.select { |p| p.category == :addon }
+    end
+
+    # Enable the repository
+    #
+    # The repository status will be stored only in memory. Calling to
+    # Yast::Pkg.SourceSaveAll will make it persistent.
+    #
+    # @see Yast::Pkg.SourceSetEnabled
+    # @see Yast::Pkg.SourceSaveAll
+    def enable!
+      success = Yast::Pkg.SourceSetEnabled(repo_id, true)
+      success && self.enabled = true
+    end
+
+    # Disable the repository
+    #
+    # The repository status will be stored only in memory. Calling to
+    # Yast::Pkg.SourceSaveAll will make it persistent.
+    #
+    # @see Yast::Pkg.SourceSetEnabled
+    # @see Yast::Pkg.SourceSaveAll
+    def disable!
+      success = Yast::Pkg.SourceSetEnabled(repo_id, false)
+      success && self.enabled = false
+    end
+
+    # Remove the repository
+    #
+    # The repository will be removed only in memory. Calling to
+    # Yast::Pkg.SourceSaveAll will make the removal persistent.
+    #
+    # @see Yast::Pkg.SourceDelete
+    # @see Yast::Pkg.SourceSaveAll
+    def delete!
+      @repo_id = nil if Yast::Pkg.SourceDelete(repo_id)
+    end
+
+    # Change the repository URL
+    #
+    # The URL will be changed only in memory. Calling to
+    # Yast::Pkg.SourceSaveAll will make the removal persistent.
+    #
+    # @param new_url [String,URI] the new URL (with unexpanded variables,
+    #   it sets the `raw_url` value, the `url` attribute will
+    #   be evaluated automatically)
+    #
+    # @see Yast::Pkg.SourceDelete
+    # @see Yast::Pkg.SourceSaveAll
+    def url=(new_url)
+      return unless Yast::Pkg.SourceChangeUrl(repo_id, new_url.to_s)
+
+      # its safe to call URI() on URI object
+      @raw_url = URI(new_url)
+      @url = URI(Yast::Pkg.ExpandedUrl(new_url.to_s))
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/repository.rb
+++ b/library/packages/src/lib/y2packager/repository.rb
@@ -147,7 +147,7 @@ module Y2Packager
     #
     # The scheme is determined using the URL
     #
-    # @return [Symbol,nil] URL scheme
+    # @return [Symbol,nil] URL scheme, nil if the URL is not defined
     def scheme
       url.scheme ? url.scheme.to_sym : nil
     end
@@ -158,7 +158,7 @@ module Y2Packager
     #
     # @see Y2Packager::Product
     def products
-      return @products unless @products.nil?
+      return @products if @products
 
       # Filter products from this repository
       candidates = Y2Packager::Resolvable.find(kind: :product, source: repo_id)
@@ -205,11 +205,14 @@ module Y2Packager
     # The repository status will be stored only in memory. Calling to
     # Yast::Pkg.SourceSaveAll will make it persistent.
     #
+    # @return [Boolean] true on success, false otherwise
+    #
     # @see Yast::Pkg.SourceSetEnabled
     # @see Yast::Pkg.SourceSaveAll
     def enable!
-      success = Yast::Pkg.SourceSetEnabled(repo_id, true)
-      success && self.enabled = true
+      return false unless Yast::Pkg.SourceSetEnabled(repo_id, true)
+      self.enabled = true
+      true
     end
 
     # Disable the repository
@@ -217,22 +220,29 @@ module Y2Packager
     # The repository status will be stored only in memory. Calling to
     # Yast::Pkg.SourceSaveAll will make it persistent.
     #
+    # @return [Boolean] true on success, false otherwise
+    #
     # @see Yast::Pkg.SourceSetEnabled
     # @see Yast::Pkg.SourceSaveAll
     def disable!
-      success = Yast::Pkg.SourceSetEnabled(repo_id, false)
-      success && self.enabled = false
+      return false unless Yast::Pkg.SourceSetEnabled(repo_id, false)
+      self.enabled = false
+      true
     end
 
-    # Remove the repository
+    # Remove the repository, the repo_id is set to `nil` after removal.
     #
     # The repository will be removed only in memory. Calling to
     # Yast::Pkg.SourceSaveAll will make the removal persistent.
     #
+    # @return [Boolean] true on success, false otherwise
+    #
     # @see Yast::Pkg.SourceDelete
     # @see Yast::Pkg.SourceSaveAll
     def delete!
-      @repo_id = nil if Yast::Pkg.SourceDelete(repo_id)
+      return false unless Yast::Pkg.SourceDelete(repo_id)
+      @repo_id = nil
+      true
     end
 
     # Change the repository URL

--- a/library/packages/src/lib/y2packager/repository.rb
+++ b/library/packages/src/lib/y2packager/repository.rb
@@ -211,6 +211,7 @@ module Y2Packager
     # @see Yast::Pkg.SourceSaveAll
     def enable!
       return false unless Yast::Pkg.SourceSetEnabled(repo_id, true)
+
       self.enabled = true
       true
     end
@@ -226,6 +227,7 @@ module Y2Packager
     # @see Yast::Pkg.SourceSaveAll
     def disable!
       return false unless Yast::Pkg.SourceSetEnabled(repo_id, false)
+
       self.enabled = false
       true
     end
@@ -241,6 +243,7 @@ module Y2Packager
     # @see Yast::Pkg.SourceSaveAll
     def delete!
       return false unless Yast::Pkg.SourceDelete(repo_id)
+
       @repo_id = nil
       true
     end

--- a/library/packages/src/lib/y2packager/service.rb
+++ b/library/packages/src/lib/y2packager/service.rb
@@ -1,0 +1,65 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020 SUSE LINUX GmbH, Nuremberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+require "yast/logger"
+
+Yast.import "Pkg"
+
+module Y2Packager
+  #
+  # This class represents a libzypp service.
+  #
+  # @since 4.2.60
+  class Service
+    include Yast::Logger
+
+    attr_reader :alias, :url, :enabled, :auto_refresh, :file, :type,
+      :repos_to_enable, :repos_to_disable, :name
+
+    def initialize(service_alias:, auto_refresh: nil, enabled: nil, file: nil, name: "",
+      repos_to_disable: [], repos_to_enable: [], type: nil, url: nil)
+
+      @alias = service_alias
+      @auto_refresh = auto_refresh
+      @enabled = enabled
+      @file = file
+      @name = name
+      @repos_to_disable = repos_to_disable
+      @repos_to_enable = repos_to_enable
+      @type = type
+      @url = url
+    end
+
+    def self.all
+      aliases = Yast::Pkg.ServiceAliases
+      services = aliases.map do |a|
+        srv = Yast::Pkg.ServiceGet(a)
+        new(
+          service_alias:    a,
+          auto_refresh:     srv["autorefresh"],
+          enabled:          srv["enabled"],
+          file:             srv["file"],
+          name:             srv["name"],
+          repos_to_disable: srv["repos_to_disable"] || [],
+          repos_to_enable:  srv["repos_to_enable"] || [],
+          type:             srv["type"],
+          url:              srv["url"]
+        )
+      end
+
+      log.info("Found #{services.size} services (#{services.map(&:alias).inspect})")
+
+      services
+    end
+  end
+end

--- a/library/packages/test/product_factory.rb
+++ b/library/packages/test/product_factory.rb
@@ -1,0 +1,99 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2016 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+#
+
+# A factory which creates random libzypp products for testing.
+class ProductFactory
+  # Create a product, the default random attributes can be customized via arguments.
+  # @return [Hash] product hash as returned by the Pkg.ResolvableProperties
+  #   and Pkg.ResolvableDependencies functions
+  def self.create_product(attrs = {})
+    product = {}
+
+    # generate 12 random characters from a-z
+    charset = ("a".."z").to_a
+    name = (1..12).map { charset[rand(charset.size)] }.join
+
+    # construct a "human readable" product name
+    product_name = name.capitalize
+    # construct the internal product ID
+    product_id = name[0..4]
+    # service pack level
+    sp = rand(1..4)
+
+    product["kind"] = :product
+    product["arch"] = attrs["arch"] || "x86_64"
+    product["category"] = attrs["category"] || "addon"
+    product["description"] = attrs["description"] || "SUSE Linux Enterprise #{product_name}."
+    product["display_name"] = attrs["display_name"] || "SUSE Linux Enterprise #{product_name}"
+    product["download_size"] = attrs["download_size"] || 0
+    # default: 2024-10-31
+    product["eol"] = attrs["eol"] || 1730332800
+    product["flags"] = attrs["flags"] || []
+    product["flavor"] = attrs["flavor"] || "POOL"
+    product["inst_size"] = attrs["inst_size"] || 0
+    product["locked"] = attrs.fetch("locked", false)
+    product["medium_nr"] = attrs["medium_nr"] || 0
+    product["name"] = attrs["name"] || "sle-#{product_id}"
+    product["on_system_by_user"] = attrs.fetch("on_system_by_user", false)
+    product["product_file"] = attrs["product_file"] || "sle-#{product_id}.prod"
+    product["product_line"] = attrs["product_line"] || ""
+    product["product_package"] = attrs.fetch("product_package", "sle-#{product_id}-release")
+    product["register_release"] = attrs["register_release"] || ""
+    product["register_target"] = attrs["register_target"] || "sle-12-x86_64"
+    product["relnotes_url"] = attrs["relnotes_url"] ||
+      "https://www.suse.com/releasenotes/#{product["arch"]}/SLE-#{product_id}/12-SP#{sp}/" \
+        "release-notes-#{product_id}.rpm"
+    product["relnotes_urls"] = attrs["relnotes_urls"] || [product["relnotes_url"]]
+    product["short_name"] = attrs["short_name"] || "SLE#{product_id.upcase}12-SP#{sp}"
+    product["source"] = attrs["source"] || rand(10)
+    product["status"] = attrs["status"] || :available
+    product["summary"] = attrs["summary"] || "SUSE Linux Enterprise #{product_name}"
+    product["transact_by"] = attrs["transact_by"] || :solver
+    product["type"] = attrs["type"] || "addon"
+    product["update_urls"] = attrs["update_urls"] || []
+    product["vendor"] = attrs["vendor"] || "SUSE LLC <https://www.suse.com/>"
+    product["version"] = attrs["version"] || "12.#{sp}-0"
+    product["version_epoch"] = attrs["version_epoch"] || nil
+    product["version_release"] = attrs["version_release"] || "0"
+    product["version_version"] = attrs["version_version"] || "12.#{sp}"
+
+    # add optional dependencies (returned only by ResolvableDependencies)
+    product["deps"] = attrs["deps"] if attrs.key?("deps")
+
+    product
+  end
+
+  # create product packages for testing
+  # @param [String] product_name name of the product_line
+  # @param [Fixnum,nil] src repository ID providing the product
+  # @return [Array] created product data: the default pattern name,
+  #   the release package name, the release package status,
+  #   the product status
+  def self.create_product_packages(product_name: "product", src: nil)
+    pattern_name = "#{product_name}_pattern"
+    package_name = "#{product_name}-release"
+    package = Y2Packager::Resolvable.new(
+      "kind" => :package,
+       "name" => package_name, "status" => :selected,
+       "deps" => [{ "requires" => "foo" }, { "provides" => "bar" },
+                  { "provides" => "defaultpattern(#{pattern_name})" }]
+    )
+    product = Y2Packager::Resolvable.new(
+      ProductFactory.create_product("status" => :selected,
+      "source" => src, "product_package" => package_name)
+    )
+
+    [pattern_name, package_name, package, product]
+  end
+end

--- a/library/packages/test/repository_test.rb
+++ b/library/packages/test/repository_test.rb
@@ -1,0 +1,289 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+require "y2packager/repository"
+require_relative "product_factory"
+require "uri"
+
+describe Y2Packager::Repository do
+  Yast.import "Pkg"
+
+  let(:repo_id) { 1 }
+  let(:enabled) { true }
+  let(:autorefresh) { true }
+  let(:repo_url) { URI("http://download.opensuse.org/update/leap/42.1/oss") }
+
+  subject(:repo) do
+    Y2Packager::Repository.new(repo_id: repo_id, name: "repo-oss", enabled: enabled,
+      autorefresh: autorefresh, url: repo_url, raw_url: repo_url, repo_alias: "repo#{repo_id}")
+  end
+
+  let(:disabled) do
+    Y2Packager::Repository.new(repo_id: repo_id + 1, name: "disabled-repo", enabled: false,
+      autorefresh: false, url: repo_url, raw_url: repo_url, repo_alias: "repo#{repo_id}")
+  end
+
+  describe ".all" do
+    before do
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return(repo_ids)
+    end
+
+    context "when no repository exist" do
+      let(:repo_ids) { [] }
+
+      it "returns a empty array" do
+        expect(described_class.all).to eq([])
+      end
+    end
+
+    context "when a repository exist" do
+      let(:repo_ids) { [repo_id] }
+      let(:repo) { double("repo") }
+
+      it "returns an array containing existing repositories" do
+        expect(described_class).to receive(:find).with(repo_id).and_return(repo)
+        expect(described_class.all).to eq([repo])
+      end
+    end
+
+    context "when asked only for enabled repositories" do
+      let(:repo_ids) { [repo_id] }
+      let(:repo) { double("repo") }
+
+      before do
+        allow(described_class).to receive(:find).with(repo_id).and_return(repo)
+      end
+
+      it "returns only enabled repositories" do
+        expect(Yast::Pkg).to receive(:SourceGetCurrent).with(true).and_return(repo_ids)
+        described_class.all(enabled_only: true)
+      end
+    end
+  end
+
+  describe ".enabled" do
+    before do
+      allow(Y2Packager::Repository).to receive(:all).and_return([repo, disabled])
+    end
+
+    it "returns enabled repositories" do
+      expect(Y2Packager::Repository.enabled).to eq([repo])
+    end
+  end
+
+  describe ".disabled" do
+    before do
+      allow(Y2Packager::Repository).to receive(:all).and_return([repo, disabled])
+    end
+
+    it "returns disabled repositories" do
+      expect(Y2Packager::Repository.disabled).to eq([disabled])
+    end
+  end
+
+  describe ".find" do
+    before do
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(repo_id).and_return(repo_data)
+    end
+
+    context "when a valid repo_id is given" do
+      let(:repo_data) do
+        { "enabled" => true, "autorefresh" => true, "url" => repo_url, "raw_url" => repo_url,
+          "name" => "Repo #1", "product_dir" => "/product", "repo_alias" => "alias" }
+      end
+
+      it "returns a repository with the given repo_id" do
+        repo = described_class.find(repo_id)
+        expect(repo.repo_id).to eq(repo_id)
+        expect(repo.enabled?).to eq(repo_data["enabled"])
+        expect(repo.url).to eq(URI(repo_data["url"]))
+        expect(repo.product_dir).to eq("/product")
+      end
+    end
+
+    context "when an invalid repo_id is given" do
+      let(:repo_data) { nil }
+
+      it "raises a RepositoryNotFound error" do
+        expect { described_class.find(repo_id) }.to raise_error(Y2Packager::Repository::NotFound)
+      end
+    end
+  end
+
+  describe "#scheme" do
+    context "when URL contains a scheme" do
+      let(:repo_url) { URI("cd://dev/sr1") }
+
+      it "returns the repository scheme" do
+        expect(repo.scheme).to eq(:cd)
+      end
+    end
+
+    context "when URL does not contain a scheme" do
+      let(:repo_url) { URI("/home/user/myrepo") }
+
+      it "returns nil" do
+        expect(repo.scheme).to be_nil
+      end
+    end
+  end
+
+  describe "#local" do
+    before do
+      allow(repo).to receive(:scheme).and_return(scheme)
+    end
+
+    context "when scheme is :cd" do
+      let(:scheme) { :cd }
+
+      it "returns true" do
+        expect(repo).to be_local
+      end
+    end
+
+    context "when scheme is :dvd" do
+      let(:scheme) { :dvd }
+
+      it "returns true" do
+        expect(repo).to be_local
+      end
+    end
+
+    context "when scheme is :dir" do
+      let(:scheme) { :dir }
+
+      it "returns true" do
+        expect(repo).to be_local
+      end
+    end
+
+    context "when scheme is :hd" do
+      let(:scheme) { :hd }
+
+      it "returns true" do
+        expect(repo).to be_local
+      end
+    end
+
+    context "when scheme is :iso" do
+      let(:scheme) { :iso }
+
+      it "returns true" do
+        expect(repo).to be_local
+      end
+    end
+
+    context "when scheme is :file" do
+      let(:scheme) { :file }
+
+      it "returns true" do
+        expect(repo).to be_local
+      end
+    end
+
+    context "when scheme is other than local ones" do
+      let(:scheme) { :http }
+
+      it "returns false" do
+        expect(repo).to_not be_local
+      end
+    end
+  end
+
+  describe "#enabled?" do
+    context "when the repo is enabled" do
+      let(:enabled) { true }
+
+      it "returns true" do
+        expect(repo).to be_enabled
+      end
+    end
+
+    context "when the repo is not enabled" do
+      let(:enabled) { false }
+
+      it "returns false" do
+        expect(repo).to_not be_enabled
+      end
+    end
+  end
+
+  describe "#autorefresh?" do
+    context "when the repo is autorefresh" do
+      let(:autorefresh) { true }
+
+      it "returns true" do
+        expect(repo).to be_autorefresh
+      end
+    end
+
+    context "when the repo is not autorefresh" do
+      let(:autorefresh) { false }
+
+      it "returns false" do
+        expect(repo).to_not be_autorefresh
+      end
+    end
+  end
+
+  describe "#products" do
+    let(:products_data) { [product] }
+    let(:product) do
+      Y2Packager::Resolvable.new(
+        ProductFactory.create_product(
+          "arch" => "x86_64", "name" => "openSUSE", "category" => "addon",
+          "status" => :available, "source" => repo_id, "vendor" => "openSUSE"
+        )
+      )
+    end
+
+    it "returns products available in the repository" do
+      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: repo_id)
+        .and_return(products_data)
+      product = repo.products.first
+      expect(product.name).to eq("openSUSE")
+    end
+  end
+
+  describe "#enable!" do
+    it "enables the repository" do
+      expect(Yast::Pkg).to receive(:SourceSetEnabled).with(disabled.repo_id, true)
+        .and_return(true)
+      expect { disabled.enable! }.to change { disabled.enabled? }.from(false).to(true)
+    end
+  end
+
+  describe "#disable!" do
+    it "disables the repository" do
+      expect(Yast::Pkg).to receive(:SourceSetEnabled).with(repo.repo_id, false)
+        .and_return(true)
+      expect { repo.disable! }.to change { repo.enabled? }.from(true).to(false)
+    end
+  end
+
+  describe "#delete!" do
+    it "deletes the repository" do
+      expect(Yast::Pkg).to receive(:SourceDelete).with(repo.repo_id).and_return(true)
+      repo.delete!
+    end
+
+    it "changes the repo_id to nil" do
+      allow(Yast::Pkg).to receive(:SourceDelete).with(repo.repo_id).and_return(true)
+      expect { repo.delete! }.to change { repo.repo_id }.from(repo.repo_id).to(nil)
+    end
+  end
+
+  describe "#url=!" do
+    it "changes the repository URL" do
+      new_url = "https://example.com/new_repo"
+      expect(Yast::Pkg).to receive(:SourceChangeUrl).with(repo.repo_id, new_url).and_return(true)
+      expect { repo.url = new_url }.to change { repo.url.to_s }.from(repo.url.to_s).to(new_url)
+    end
+
+    it "allows using an URI class parameter" do
+      new_url = URI("https://example.com/new_repo")
+      expect(Yast::Pkg).to receive(:SourceChangeUrl).with(repo.repo_id, new_url.to_s).and_return(true)
+      expect { repo.url = new_url }.to change { repo.url }.from(repo.url).to(new_url)
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 28 08:42:45 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added classes for handling the old repository setup during
+  upgrade (related to bsc#1159433)
+- 4.2.60
+
+-------------------------------------------------------------------
 Thu Jan 23 14:29:49 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add an option to enable the online search in the package

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.59
+Version:        4.2.60
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only
@@ -117,8 +117,8 @@ Conflicts:      yast2-dns-server < 3.1.17
 Conflicts:      yast2-installation < 4.2.9
 # moved cfg_mail.scr
 Conflicts:      yast2-mail < 3.1.7
-# Older packager use removed API e.g. user_switched_to_details
-Conflicts:      yast2-packager < 4.2.44
+# y2packager/repository.rb has been moved here
+Conflicts:      yast2-packager < 4.2.46
 # Older snapper does not provide machine-readable output
 Conflicts:	snapper < 0.8.6
 


### PR DESCRIPTION
## Details

- Related to https://bugzilla.suse.com/show_bug.cgi?id=1159433
- We need to remember the original repositories just after mounting the partition selected to upgrade. This will allow us later to distinguish the new SP2 repositories from the old ones and do not display them in the "Previously used repositories" dialog.
- The old repository setup will be saved in the `yast2-update` package and used in `yast2-installation`, this just prepares the infrastructure for that.
- The second part of the move is in this PR: https://github.com/yast/yast-packager/pull/502

### Notes

- New classes:
  - The `OriginalRepositorySetup` is a singleton object holding the original configuration, then we can compare the original and the current repositories to find the old ones.
  - The new `Y2Packager::Service` is similar to the already existing `Y2Packager::Repository`
- Other updates:
  - The `Y2Packager::Repository` class has been moved from `yast2-packager` here and extended a bit (added `repo_alias` attribute, added `url=` and `delete!` methods)
  - Also it's unit test has been moved
- Moved files (do not need detailed review):
  - `library/packages/src/lib/y2packager/repository.rb`
  - `library/packages/test/repository_test.rb`
  - `library/packages/test/product_factory.rb`