### PR TITLE
Add a new text helper to strip HTML tags

### DIFF
--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -17,160 +17,31 @@
 # current contact information at www.novell.com.
 # ------------------------------------------------------------------------------
 
+require "yast2/refinements/string_manipulations"
+
 module UI
   # Provides a set of methods to manipulate and transform UI text
   module TextHelpers
-    # Default HTML tags replacements
-    #
-    # @see #plain_text
-    # @return [Hash<String, String>]
-    DEFAULT_HTML_TAGS_REPLACEMENTS = {
-      "<br>"  => "\n",
-      "<br/>" => "\n",
-      "<br >" => "\n",
-      "</li>" => "\n",
-      "<ol>"  => "\n\n",
-      "<ul>"  => "\n\n",
-      "</p>"  => "\n\n"
-    }.freeze
+    using ::Yast2::Refinements::StringManipulations
 
-    # Get a new text version after ridding of HTML tags
-    #
-    # By default, a fully plain text will be returned, since some tags (see
-    # {DEFAULT_HTML_TAGS_REPLACEMENTS}) are going to be replaced by line breaks while the rest of
-    # them will be removed.
-    #
-    # The _tags_ param allows specifying which tags should be replaced or removed (keeping the rest
-    # of them untouched).
-    #
-    # Replacements can be provided
-    #   * as  tag => replacement collection via _replacements_ param, or
-    #   * using a block to perform desired changes for each match (more flexible and powerful)
-    #
-    # Note that all matched tags without a replacement are going to be replaced with `nil`. In other
-    # words, they will be deleted.
-    #
-    # @example Remove all HTML tags
-    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
-    #   plain_text(text) #=> "YaST:\n\na powerful installation and configuration tool."
-    #
-    # @example Removing only the <p> tags
-    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
-    #   plain_text(text, tags: ["p"])
-    #   #=> "YaST:\n\na <b>powerful</b> installation and configuration tool."
-    #
-    # @example Using custom replacements via _replacements_ param
-    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
-    #   plain_text(text, replacements: { "<p>" => "\n- ", "<b>" => "*", "</b>" => "*" })
-    #     #=> "- YaST:\n- a *powerful* installation and configuration tool."
-    #
-    # @example Using custom replacements via block (will omit _replacements_ param)
-    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
-    #   plain_text(text) do |tag|
-    #     case tag
-    #     when /<\/?p>/          then "\n"
-    #     when /<\/?em>/         then "_"
-    #     when /<\/?(b|strong)>/ then "*"
-    #     end
-    #   end
-    #   #=> "- YaST:\n\na *powerful* installation and _configuration_ tool."
-    #
-    #   text = "<p>YaST is both" \
-    #     "<ol>" \
-    #     "<li>an extremely flexible installer</li>" \
-    #     "<li>a powerful control center</li>" \
-    #     "</ol>" \
-    #     "</p>"
-    #   plain_text(text) do |tag|
-    #     case tag
-    #     when "<ol>"
-    #       @ordered = true
-    #       @index = 0
-    #       nil
-    #     when "<ul>"
-    #       @ordered = false
-    #       nil
-    #     when "<li>"
-    #       marker = @ordered ? "#{@index += 1}." : "•"
-    #       "\n  #{marker} "
-    #     end
-    #   end
-    #   #=> "YaST is both\n  1. an extremely flexible installer\n  2. a powerful control center"
-    #
-    # @param text [String] text to be processed
-    # @param tags [Array<String>] specific tags to be replaced or deleted
-    # @param replacements [Hash<String, String>] a replacements dictionary, tag => replacement
-    # @param block [Proc] a block in charge to perform the changes (alterntive to _replacements_)
-    #
-    # @return [String] the new version after ridding of undesired tags.
-    def plain_text(text, tags: nil, replacements: nil, &block)
-      regex = tags ? Regexp.union(tags.map { |t| /<[^>]*#{t}[^>]*>/i }) : /<.+?>/
-      replacements ||= DEFAULT_HTML_TAGS_REPLACEMENTS
-
-      result = text.gsub(regex) do |match|
-        tag = match.to_s.downcase
-
-        block ? block.call(tag) : replacements[tag]
-      end
-
-      result.strip
+    # (see StringRefinements#plain_text)
+    def plain_text(text, *args, &block)
+      text.plain_text(*args, &block)
     end
 
-    # Wrap text breaking lines in the first whitespace that does not exceed given line width
-    #
-    # Additionally, it also allows retrieving only an excerpt of the wrapped text according to the
-    # maximum number of lines indicated, adding one more with the cut_text text when it is given.
-    #
-    # @param text [String] text to be wrapped
-    # @param line_width [Integer] max line length
-    # @param n_lines [Integer, nil] the maximum number of lines
-    # @param cut_text [String] the omission text to be used when the text should be cut
-    #
-    # @return [String]
-    def wrap_text(text, line_width = 76, n_lines: nil, cut_text: "")
-      return text if line_width > text.length
-
-      wrapped_text = text.lines.collect! do |line|
-        l = (line.length > line_width) ? line.gsub(/(.{1,#{line_width}})(?:\s+|$)/, "\\1\n") : line
-        l.strip
-      end
-
-      result = wrapped_text.join("\n")
-      result = head(result, n_lines, omission: cut_text) if n_lines
-      result
+    # (see StringRefinements#wrap_text)
+    def wrap_text(text, *args)
+      text.wrap_text(*args)
     end
 
-    # Returns only the first requested lines of the given text
-    #
-    # If the omission param is given, an extra line holding it will be included
-    #
-    # @param text [String]
-    # @param max_lines [Integer]
-    # @param omission [String] the text to be added
-    #
-    # @return [String] the first requested lines if the text has more; full text otherwise
-    def head(text, max_lines, omission: "")
-      lines = text.lines
-
-      return text if lines.length <= max_lines
-
-      result = text.lines[0...max_lines]
-      result << omission unless omission.empty?
-      result.join
+    # (see StringRefinements#head)
+    def head(text, *args)
+      text.head(*args)
     end
 
-    # Wrap a given text in direction markers
-    #
-    # @param [String] text to be wrapped. This text may contain tags and they
-    #   will not be escaped
-    # @param [String] language code (it gets the current one by default)
-    # @return [String] wrapped text
+    # (see StringRefinements#head)
     def div_with_direction(text, lang = nil)
-      Yast.import "Language"
-      lang ||= Yast::Language.language
-      # RTL languages: Arabic, Persian, Hebrew
-      direction = lang.start_with?("ar", "fa", "he") ? "rtl" : "ltr"
-      "<div dir=\"#{direction}\">#{text}</div>"
+      text.div_with_direction(lang)
     end
   end
 end

--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -20,6 +20,59 @@
 module UI
   # Provides a set of methods to manipulate and transform UI text
   module TextHelpers
+    # Default HTML tags replacements
+    #
+    # @see #plain_text
+    # @return [Hash<String, String>]
+    DEFAULT_HTML_TAGS_REPLACEMENTS = {
+      "<br>"  => "\n",
+      "<br/>" => "\n",
+      "<br >" => "\n",
+      "</li>" => "\n",
+      "<ol>"  => "\n\n",
+      "<ul>"  => "\n\n",
+      "</p>"  => "\n\n"
+    }.freeze
+
+    # Get a new text version after ridding of HTML tags
+    #
+    # By default, a fully plain text will be returned, since some tags (see
+    # {DEFAULT_HTML_TAGS_REPLACEMENTS}) are going to be replaced by line breaks while the rest of
+    # them will be removed.
+    #
+    # However, the _tags_ param allows specifying which tags should be replaced
+    # or removed.  Additionally, a collection of tag => replacement can be
+    # provided via the _replacements_ param.
+    #
+    # Note that all matched tags without a replacement are going to be replaced
+    # with `nil`. In other words, they will be deleted.
+    #
+    # @example Remove all HTML tags
+    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+    #   plain_text(text) #=> "YaST:\n\na powerful installation and configuration tool."
+    #
+    # @example Removing only the <p> tags
+    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+    #   plain_text(text, tags: ["p"])
+    #     #=> "YaST:\n\na <b>powerful</b> installation and configuration tool."
+    #
+    # @example Using custom replacements
+    #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+    #   plain_text(text, replacements: { "<p>" => "\n- ", "<b>" => "*", "</b>" => "*" })
+    #     #=> "- YaST:\n- a *powerful* installation and configuration tool."
+    #
+    # @param text [String] text to be processed
+    # @param tags [Array<String>] specific tags to be replaced or deleted
+    # @param replacements [Hash<String, String>] the replacements collection, tag => replacement
+    #
+    # @return [String] the new version after ridding of undesired tags.
+    def plain_text(text, tags: nil, replacements: nil)
+      regex = tags ? Regexp.union(tags.map { |t| /<[^>]*#{t}[^>]*>/i }) : /<.+?>/
+      replacements ||= DEFAULT_HTML_TAGS_REPLACEMENTS
+
+      text.gsub(regex) { |match| replacements[match.to_s.downcase] }.strip
+    end
+
     # Wrap text breaking lines in the first whitespace that does not exceed given line width
     #
     # Additionally, it also allows retrieving only an excerpt of the wrapped text according to the

--- a/library/general/src/lib/yast2/refinements.rb
+++ b/library/general/src/lib/yast2/refinements.rb
@@ -1,0 +1,21 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "yast2/refinements/string_manipulations"

--- a/library/general/src/lib/yast2/refinements/string_manipulations.rb
+++ b/library/general/src/lib/yast2/refinements/string_manipulations.rb
@@ -1,0 +1,184 @@
+# Copyright (c) [2019] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+module Yast2
+  module Refinements
+    # Refinements to make easier some string manipulations
+    #
+    # By using
+    #   "<p>Just an <b>HTML</b> example to be formatted".plain_text.wrap_text
+    # instead the helper alternative
+    #   wrap_text(plain_text("<p>Just an <b>HTML</b> example to be formatted"))
+    module StringManipulations
+      refine String do
+        # Default HTML tags replacements
+        #
+        # @see #plain_text
+        # @return [Hash<String, String>]
+        DEFAULT_HTML_TAGS_REPLACEMENTS = {
+          "<br>"  => "\n",
+          "<br/>" => "\n",
+          "<br >" => "\n",
+          "</li>" => "\n",
+          "<ol>"  => "\n\n",
+          "<ul>"  => "\n\n",
+          "</p>"  => "\n\n"
+        }.freeze
+
+        # Get a new text version after ridding of HTML tags
+        #
+        # By default, a fully plain text will be returned, since some tags (see
+        # {DEFAULT_HTML_TAGS_REPLACEMENTS}) are going to be replaced by line breaks while the rest of
+        # them will be removed.
+        #
+        # The _tags_ param allows specifying which tags should be replaced or removed (keeping the rest
+        # of them untouched).
+        #
+        # Replacements can be provided
+        #   * as  tag => replacement collection via _replacements_ param, or
+        #   * using a block to perform desired changes for each match (more flexible and powerful)
+        #
+        # Note that all matched tags without a replacement are going to be replaced with `nil`. In other
+        # words, they will be deleted.
+        #
+        # @example Remove all HTML tags
+        #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+        #   plain_text(text) #=> "YaST:\n\na powerful installation and configuration tool."
+        #
+        # @example Removing only the <p> tags
+        #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+        #   plain_text(text, tags: ["p"])
+        #   #=> "YaST:\n\na <b>powerful</b> installation and configuration tool."
+        #
+        # @example Using custom replacements via _replacements_ param
+        #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+        #   plain_text(text, replacements: { "<p>" => "\n- ", "<b>" => "*", "</b>" => "*" })
+        #     #=> "- YaST:\n- a *powerful* installation and configuration tool."
+        #
+        # @example Using custom replacements via block (will omit _replacements_ param)
+        #   text = "<p>YaST:</p><p>a <b>powerful</b> installation and configuration tool.</p>"
+        #   plain_text(text) do |tag|
+        #     case tag
+        #     when /<\/?p>/          then "\n"
+        #     when /<\/?em>/         then "_"
+        #     when /<\/?(b|strong)>/ then "*"
+        #     end
+        #   end
+        #   #=> "- YaST:\n\na *powerful* installation and _configuration_ tool."
+        #
+        #   text = "<p>YaST is both" \
+        #     "<ol>" \
+        #     "<li>an extremely flexible installer</li>" \
+        #     "<li>a powerful control center</li>" \
+        #     "</ol>" \
+        #     "</p>"
+        #   plain_text(text) do |tag|
+        #     case tag
+        #     when "<ol>"
+        #       @ordered = true
+        #       @index = 0
+        #       nil
+        #     when "<ul>"
+        #       @ordered = false
+        #       nil
+        #     when "<li>"
+        #       marker = @ordered ? "#{@index += 1}." : "•"
+        #       "\n  #{marker} "
+        #     end
+        #   end
+        #   #=> "YaST is both\n  1. an extremely flexible installer\n  2. a powerful control center"
+        #
+        # @param tags [Array<String>] specific tags to be replaced or deleted
+        # @param replacements [Hash<String, String>] a replacements dictionary, tag => replacement
+        # @param block [Proc] a block in charge to perform the changes (alterntive to _replacements_)
+        #
+        # @return [String] the new version after ridding of undesired tags.
+        def plain_text(tags: nil, replacements: nil, &block)
+          regex = tags ? Regexp.union(tags.map { |t| /<[^>]*#{t}[^>]*>/i }) : /<.+?>/
+          replacements ||= DEFAULT_HTML_TAGS_REPLACEMENTS
+
+          result = gsub(regex) do |match|
+            tag = match.to_s.downcase
+
+            block ? block.call(tag) : replacements[tag]
+          end
+
+          result.strip
+        end
+
+        # Wrap text breaking lines in the first whitespace that does not exceed given line width
+        #
+        # Additionally, it also allows retrieving only an excerpt of the wrapped text according to the
+        # maximum number of lines indicated, adding one more with the cut_text text when it is given.
+        #
+        # @param line_width [Integer] max line length
+        # @param n_lines [Integer, nil] the maximum number of lines
+        # @param cut_text [String] the omission text to be used when the text should be cut
+        #
+        # @return [String]
+        def wrap_text(line_width = 76, n_lines: nil, cut_text: "")
+          return self if line_width > length
+
+          wrapped_text = lines.collect! do |line|
+            l = (line.length > line_width) ? line.gsub(/(.{1,#{line_width}})(?:\s+|$)/, "\\1\n") : line
+            l.strip
+          end
+
+          result = wrapped_text.join("\n")
+          result = result.head(n_lines, omission: cut_text) if n_lines
+          result
+        end
+
+        # Returns only the first requested lines of the given text
+        #
+        # If the omission param is given, an extra line holding it will be included
+        #
+        # @param max_lines [Integer]
+        # @param omission [String] the text to be added
+        #
+        # @return [String] the first requested lines if the text has more; full text otherwise
+        def head(max_lines, omission: "")
+          lines = self.lines
+
+          return self if lines.length <= max_lines
+
+          result = self.lines[0...max_lines]
+          result << omission unless omission.empty?
+          result.join
+        end
+
+        # Wrap a text in direction markers
+        #
+        # The text may contain tags and they will not be escaped.
+        #
+        # @param [String] language code (it gets the current one by default)
+        # @return [String] wrapped text
+        def div_with_direction(lang = nil)
+          Yast.import "Language"
+          lang ||= Yast::Language.language
+          # RTL languages: Arabic, Persian, Hebrew
+          direction = lang.start_with?("ar", "fa", "he") ? "rtl" : "ltr"
+          "<div dir=\"#{direction}\">#{self}</div>"
+        end
+      end
+    end
+  end
+end

--- a/library/general/src/lib/yast2/refinements/string_manipulations.rb
+++ b/library/general/src/lib/yast2/refinements/string_manipulations.rb
@@ -108,7 +108,8 @@ module Yast2
         #
         # @param tags [Array<String>] specific tags to be replaced or deleted
         # @param replacements [Hash<String, String>] a replacements dictionary, tag => replacement
-        # @param block [Proc] a block in charge to perform the changes (alterntive to _replacements_)
+        # @param block [Proc] a block in charge to perform the changes. When given, it does not make
+        #   sense to specify _replacements_ param since the block has precedence over it.
         #
         # @return [String] the new version after ridding of undesired tags.
         def plain_text(tags: nil, replacements: nil, &block)

--- a/library/general/test/text_helpers_test.rb
+++ b/library/general/test/text_helpers_test.rb
@@ -147,4 +147,71 @@ describe ::UI::TextHelpers do
       end
     end
   end
+
+  describe "#plain_text" do
+    let(:text) { "<p>YaST:</p><p>a <b>powerful</b> installation and <em>configuration</em> tool.</p>" }
+
+    context "when neither tags: nor replacements: are given" do
+      it "replaces tags with default replacements" do
+        expect(subject.plain_text(text))
+          .to eq("YaST:\n\na powerful installation and configuration tool.")
+      end
+    end
+
+    context "when the tag list is given" do
+      let(:tags) { ["p", "em"] }
+
+      it "changes only the specified tags" do
+        expect(subject.plain_text(text, tags: tags))
+          .to eq("YaST:\n\na <b>powerful</b> installation and configuration tool.")
+      end
+
+      context "and a list of replacements is provided too" do
+        let(:replacements) do
+          { "<b>" => "*", "</b>" => "*", "<em>" => "_", "</em>" => "_" }
+        end
+
+        it "keeps unmatched tags" do
+          expect(subject.plain_text(text, tags: tags, replacements: replacements))
+            .to match(/a <b>powerful<\/b> installation/)
+        end
+
+        it "deletes matched tags without replacements" do
+          expect(subject.plain_text(text, tags: tags, replacements: replacements))
+            .to_not match(/<p>.*<\/p>/)
+        end
+
+        it "replaces matched tags with replacements" do
+          expect(subject.plain_text(text, tags: tags, replacements: replacements))
+            .to match(/and _configuration_ tool/)
+        end
+      end
+    end
+
+    context "when the list of replacements is given" do
+      let(:replacements) do
+        { "<b>" => "*", "</b>" => "*", "<em>" => "_", "</em>" => "_", "<p>" => "\n> " }
+      end
+
+      it "replaces matched tags using given replacements" do
+        expect(subject.plain_text(text, replacements: replacements))
+          .to eq("> YaST:\n> a *powerful* installation and _configuration_ tool.")
+      end
+
+      context "and a list of tags is provided too" do
+        let(:tags) { ["b"] }
+
+        it "keeps unmatched tags" do
+          expect(subject.plain_text(text, tags: tags, replacements: replacements))
+            .to match(/<p>.*and <em>configuration<\/em> tool.<\/p>/)
+        end
+
+        it "replaces matched tags with replacements" do
+          expect(subject.plain_text(text, tags: tags, replacements: replacements))
+            .to match(/a \*powerful\* installation/)
+        end
+      end
+    end
+  end
+
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 14 16:38:43 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Add a text helper to strip HTML tags (related bsc#1157780)
+- 4.2.55
+
+-------------------------------------------------------------------
 Fri Jan 10 14:43:20 UTC 2020 - schubi@suse.de
 
 - Do not refresh package installation overview if the medium has

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,6 +2,8 @@
 Tue Jan 14 16:38:43 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Add a text helper to strip HTML tags (related bsc#1157780)
+- Moves text helpers to String refinements, keeping backward
+  compatibility.
 - 4.2.55
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.54
+Version:        4.2.55
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

While updating the [addons selection dialog](https://github.com/yast/yast-registration/blob/master/src/lib/registration/ui/addon_selection_registration_dialog.rb) to make use of the new [`CustomStatusItemSelector`](https://github.com/libyui/libyui/pull/152) widget ([bsc#1157780](https://bugzilla.suse.com/show_bug.cgi?id=1157780 )), it was found that their descriptions contain HTML tags, which are

* not compatible with the `#wrap_text` helper, which could break the tags and/or ends with lines of different widths.
* not fully supported by the `CustomStatusItemSelector` since in ncurses they are not _rendered_ but displayed as part of the description.

## Solution

The simple solution would strip the HTML tags before wrapping the text. 

However, before realizing that the HTML was not being rendered in ncurses, the approach was only to replace some of them by line breaks. That's the reason why this new helper exists now.

Additionally, as a result of the first PR review made by @jreidinger, the solution also includes

* [Accepting a block for this new helper](https://github.com/yast/yast-yast2/pull/1011/commits/a53773a067dbd3e9e8608e72b9906103bbd273bf), which make it more flexible and powerful
* [Converting all text helpers as refinements of the `String` class](https://github.com/yast/yast-yast2/pull/1011/commits/1da6752238f2c66e7401b39e23503d0162e797d7), which makes easier to use them (of course, keeping backward compatibility)

## Test

* Unit tests added (refinements are tested via their _equivalent_ helper methods)
* Also tested manually

##  Notes

[YARD](https://yardoc.org/features.html) does not generate the documentation for refinements.There is a workaround, but it doesn't like to me. See https://github.com/lsegal/yard/issues/780