### PR TITLE
Fix refinements

### DIFF
--- a/library/general/src/lib/ui/text_helpers.rb
+++ b/library/general/src/lib/ui/text_helpers.rb
@@ -24,22 +24,22 @@ module UI
   module TextHelpers
     using ::Yast2::Refinements::StringManipulations
 
-    # (see StringRefinements#plain_text)
+    # (see Yast2::Refinements::StringManipulations#plain_text)
     def plain_text(text, *args, &block)
       text.plain_text(*args, &block)
     end
 
-    # (see StringRefinements#wrap_text)
+    # (see Yast2::Refinements::StringManipulations#wrap_text)
     def wrap_text(text, *args)
       text.wrap_text(*args)
     end
 
-    # (see StringRefinements#head)
+    # (see Yast2::Refinements::StringManipulations#head)
     def head(text, *args)
       text.head(*args)
     end
 
-    # (see StringRefinements#head)
+    # (see Yast2::Refinements::StringManipulations#div_with_direction)
     def div_with_direction(text, lang = nil)
       text.div_with_direction(lang)
     end

--- a/library/general/src/lib/yast2/refinements/string_manipulations.rb
+++ b/library/general/src/lib/yast2/refinements/string_manipulations.rb
@@ -21,6 +21,20 @@ require "yast"
 
 module Yast2
   module Refinements
+    # Default HTML tags replacements
+    #
+    # @see #plain_text
+    # @return [Hash<String, String>]
+    DEFAULT_HTML_TAGS_REPLACEMENTS = {
+      "<br>"  => "\n",
+      "<br/>" => "\n",
+      "<br >" => "\n",
+      "</li>" => "\n",
+      "<ol>"  => "\n\n",
+      "<ul>"  => "\n\n",
+      "</p>"  => "\n\n"
+    }.freeze
+
     # Refinements to make easier some string manipulations
     #
     # By using
@@ -29,25 +43,11 @@ module Yast2
     #   wrap_text(plain_text("<p>Just an <b>HTML</b> example to be formatted"))
     module StringManipulations
       refine String do
-        # Default HTML tags replacements
-        #
-        # @see #plain_text
-        # @return [Hash<String, String>]
-        DEFAULT_HTML_TAGS_REPLACEMENTS = {
-          "<br>"  => "\n",
-          "<br/>" => "\n",
-          "<br >" => "\n",
-          "</li>" => "\n",
-          "<ol>"  => "\n\n",
-          "<ul>"  => "\n\n",
-          "</p>"  => "\n\n"
-        }.freeze
-
         # Get a new text version after ridding of HTML tags
         #
         # By default, a fully plain text will be returned, since some tags (see
-        # {DEFAULT_HTML_TAGS_REPLACEMENTS}) are going to be replaced by line breaks while the rest of
-        # them will be removed.
+        # {Yast2::Refinements::DEFAULT_HTML_TAGS_REPLACEMENTS}) are going to be replaced by line
+        # breaks while the rest of them will be removed.
         #
         # The _tags_ param allows specifying which tags should be replaced or removed (keeping the rest
         # of them untouched).
@@ -114,7 +114,7 @@ module Yast2
         # @return [String] the new version after ridding of undesired tags.
         def plain_text(tags: nil, replacements: nil, &block)
           regex = tags ? Regexp.union(tags.map { |t| /<[^>]*#{t}[^>]*>/i }) : /<.+?>/
-          replacements ||= DEFAULT_HTML_TAGS_REPLACEMENTS
+          replacements ||= Refinements::DEFAULT_HTML_TAGS_REPLACEMENTS
 
           result = gsub(regex) do |match|
             tag = match.to_s.downcase


### PR DESCRIPTION
## Problem

The `DEFAULT_HTML_TAGS_REPLACEMENTS` constant defined in #1011 was misplaced, according to the Ruby complain when running tests

> /usr/share/YaST2/lib/yast2/refinements/string_manipulations.rb:37: warning: not defined at the refinement, but at the outer class/module

## Solution

Move it to out of the refinement.

## Notes

* Also fixed the documentation comments referencing the refinement.
* No version bump / changelog updates required :question: 
