### PR TITLE
 [SLE-9109] Packages online search

### DIFF
--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -304,5 +304,12 @@ module Y2Packager
     def resolvable_properties
       @resolvable_properties ||= Y2Packager::Resolvable.find(kind: :product, name: name, version: version).first
     end
+
+    # Returns the version number (without the release part)
+    #
+    # @return [String] Version number
+    def version_version
+      version.split("-").first
+    end
   end
 end

--- a/library/packages/src/modules/PackagesUI.rb
+++ b/library/packages/src/modules/PackagesUI.rb
@@ -254,6 +254,7 @@ module Yast
     # if an option is missing or is nil the default value will be used. All options:
     # $[ "enable_repo_mgr" : boolean // display the repository management menu,
     #      // default: false (disabled)
+    #    "enable_online_search": boolean // enable the online search feature
     #    "display_support_status" : boolean // display the support status summary dialog,
     #      // default: depends on the Product Feature "software", "display_support_status"
     #    "mode" : symbol // package selector mode, no default value, supported values:
@@ -298,6 +299,8 @@ module Yast
       widget_options = Builtins.add(widget_options, :repoMgr) if !enable_repo_mgr.nil? && enable_repo_mgr
 
       widget_options = Builtins.add(widget_options, :confirmUnsupported) if !display_support_status.nil? && display_support_status
+
+      widget_options = Builtins.add(widget_options, :onlineSearch) if options.fetch("enable_online_search", false)
 
       Builtins.y2milestone(
         "Options for the package selector widget: %1",

--- a/library/packages/src/modules/PackagesUI.rb
+++ b/library/packages/src/modules/PackagesUI.rb
@@ -300,7 +300,7 @@ module Yast
 
       widget_options = Builtins.add(widget_options, :confirmUnsupported) if !display_support_status.nil? && display_support_status
 
-      widget_options = Builtins.add(widget_options, :onlineSearch) if options.fetch("enable_online_search", false)
+      widget_options = Builtins.add(widget_options, :onlineSearch) if options["enable_online_search"]
 
       Builtins.y2milestone(
         "Options for the package selector widget: %1",

--- a/library/packages/test/y2packager/product_test.rb
+++ b/library/packages/test/y2packager/product_test.rb
@@ -502,4 +502,12 @@ describe Y2Packager::Product do
       end
     end
   end
+
+  describe "#version_version" do
+    subject(:product) { Y2Packager::Product.new(name: "SLES", version: "15.2-0", arch: "x86_64") }
+
+    it "returns the version omitting the release part" do
+      expect(product.version_version).to eq("15.2")
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 23 11:51:43 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add an option to enable the online search in the package
+  selector (jsc#SLE-9109).
+- 4.2.58
+
+-------------------------------------------------------------------
 Wed Jan 22 15:27:15 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - CommandLine: Add ability to actions to skip writing.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.57
+Version:        4.2.58
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Please, see the whole picture in https://github.com/yast/yast-registration/pull/467.

This PR adds support to `PackagesUI.RunPackageSelector` to enable the online search feature in the UI.