### PR TITLE
don't use /bin/systemd compat symlink (bsc#1160890)

### DIFF
--- a/library/systemd/src/modules/Systemd.rb
+++ b/library/systemd/src/modules/Systemd.rb
@@ -35,7 +35,7 @@ module Yast
     def main
       Yast.import "FileUtils"
 
-      @systemd_path = "/bin/systemd"
+      @systemd_path = "/usr/lib/systemd/systemd"
       @default_target_symlink = "/etc/systemd/system/default.target"
       @systemd_targets_dir = "/usr/lib/systemd/system"
       @systemd_mountdir = "/sys/fs/cgroup/systemd"

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 13:22:10 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemd compat symlink (bsc#1160890)
+- 4.2.58
+
+-------------------------------------------------------------------
 Wed Jan 22 15:27:15 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - CommandLine: Add ability to actions to skip writing.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.57
+Version:        4.2.58
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemd` symlink is gone.

## Solution

Don't use it.