### PR TITLE
Do not crash when the "software/base_products" is not defined

### DIFF
--- a/library/packages/src/lib/y2packager/product_control_product.rb
+++ b/library/packages/src/lib/y2packager/product_control_product.rb
@@ -51,6 +51,13 @@ module Y2Packager
         return @products if @products
 
         control_products = Yast::ProductFeatures.GetFeature("software", "base_products")
+
+        if !control_products.is_a?(Array)
+          log.warn("Invalid or missing 'software/base_products' value: #{control_products.inspect}")
+          @products = []
+          return @products
+        end
+
         arch = REG_ARCH[Yast::Arch.architecture] || Yast::Arch.architecture
         linuxrc_products = (Yast::Linuxrc.InstallInf("specialproduct") || "").split(",").map(&:strip)
 

--- a/library/packages/test/y2packager/product_control_product_test.rb
+++ b/library/packages/test/y2packager/product_control_product_test.rb
@@ -73,6 +73,15 @@ describe Y2Packager::ProductControlProduct do
       product = Y2Packager::ProductControlProduct.products.first
       expect(product.register_target).to eq("sle-15-x86_64")
     end
+
+    it "returns empty list if the control file value is missing" do
+      # when the value is not found ProductFeatures return empty string!
+      expect(Yast::ProductFeatures).to receive(:GetFeature)
+        .with("software", "base_products").and_return("")
+
+      products = Y2Packager::ProductControlProduct.products
+      expect(products).to be_empty
+    end
   end
 
   describe ".selected" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jan 30 11:19:00 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not crash when the "software/base_products" is not defined
+  in the control.xml (bsc#1161956)
+- 4.2.62
+
+-------------------------------------------------------------------
 Wed Jan 29 13:22:50 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Speed up run on WSL (bsc#1157575)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.61
+Version:        4.2.62
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## The Problem

- The installer crashes when `software/base_products` is not defined in `control.xml` in the Live installer.
- See https://bugzilla.suse.com/show_bug.cgi?id=1161956

## The Solution

- Check the `ProductFeatures.GetFeature` returned value, if it not an `Array` then do not try using it.
- This is rather a workaround for the bug, there is another problem because the `ProductControlProduct` class should actually not be used on the Live medium at all... 

## Testing

- Added an unit test
