### PR TITLE
add ability for WSL desktop file whitelisting

### DIFF
--- a/library/desktop/src/clients/menu.rb
+++ b/library/desktop/src/clients/menu.rb
@@ -62,6 +62,7 @@ module Yast
         "X-SuSE-YaST-Group",
         "X-SuSE-YaST-SortKey",
         "X-SuSE-YaST-RootOnly",
+        "X-SuSE-YaST-WSL",
         "Hidden"
       ]
 

--- a/library/desktop/src/modules/Desktop.rb
+++ b/library/desktop/src/modules/Desktop.rb
@@ -32,6 +32,7 @@ module Yast
     def main
       Yast.import "UI"
       textdomain "base"
+      Yast.import "Arch"
       Yast.import "Map"
       Yast.import "Directory"
 
@@ -111,7 +112,7 @@ module Yast
     end
 
     # Read module and group data from desktop files
-    # @param [Array<String>] Values list of values to be parsed (empty to read all)
+    # @param [Array<String>] Values list of values to be parsed (empty or nil reads nothing)
     def Read(values_to_parse)
       values_to_parse = deep_copy(values_to_parse)
       extract_desktop_filename = lambda do |fullpath|
@@ -258,12 +259,11 @@ module Yast
       end
 
       Builtins.foreach(mods) do |m|
-        if Builtins.haskey(@Modules, m) &&
-            Ops.get_string(@Modules, [m, "Hidden"], "false") != "true"
-          l = Builtins.add(
-            l,
-            Item(Id(m), Ops.get_string(@Modules, [m, "GenericName"], "???"))
-          )
+        if @Modules[m].is_a?(::Hash) &&
+            @Modules[m]["Hidden"] != "true" &&
+            # wsl specific whitelisting of modules
+            ( !Arch.is_wsl || @Modules[m]["X-SuSE-YaST-WSL"] == "true" )
+          l << Item(Id(m), Ops.get_string(@Modules, [m, "GenericName"], "???"))
         end
       end
 

--- a/library/desktop/src/modules/Desktop.rb
+++ b/library/desktop/src/modules/Desktop.rb
@@ -262,7 +262,7 @@ module Yast
         if @Modules[m].is_a?(::Hash) &&
             @Modules[m]["Hidden"] != "true" &&
             # wsl specific whitelisting of modules
-            ( !Arch.is_wsl || @Modules[m]["X-SuSE-YaST-WSL"] == "true" )
+            (!Arch.is_wsl || @Modules[m]["X-SuSE-YaST-WSL"] == "true")
           l << Item(Id(m), Ops.get_string(@Modules, [m, "GenericName"], "???"))
         end
       end

--- a/library/desktop/test/data/usr/share/applications/YaST2/org.opensuse.yast.SWSingle.desktop
+++ b/library/desktop/test/data/usr/share/applications/YaST2/org.opensuse.yast.SWSingle.desktop
@@ -1,0 +1,27 @@
+[Desktop Entry]
+X-SuSE-DocTeamID=ycc_org.opensuse.yast.SWSingle
+Type=Application
+Categories=Settings;System;Qt;X-SuSE-YaST;X-SuSE-YaST-Software;
+
+X-KDE-ModuleType=Library
+X-KDE-HasReadOnlyMode=true
+X-SuSE-YaST-Call=sw_single
+
+X-SuSE-YaST-Group=Software
+X-SuSE-YaST-Argument=
+X-SuSE-YaST-RootOnly=true
+X-SuSE-YaST-WSL=true
+X-SuSE-YaST-AutoInst=
+X-SuSE-YaST-Geometry=
+X-SuSE-YaST-SortKey=20
+X-SuSE-YaST-AutoInstResource=
+X-SuSE-YaST-Keywords=software,packages,rpm,repositories,installation,deletion
+
+Icon=yast-sw_single
+Exec=xdg-su -c "/sbin/yast2 sw_single"
+
+Name=YaST Software Management
+GenericName=Software Management
+Comment=Install or remove software packages and manage software repositories
+StartupNotify=true
+

--- a/library/desktop/test/desktop_test.rb
+++ b/library/desktop/test/desktop_test.rb
@@ -34,7 +34,7 @@ describe Yast::Desktop do
         "add-on"           => { "Name" => "YaST Add-On Products" },
         "lan"              => { "Name" => "YaST Network" },
         "services-manager" => { "Name" => "YaST Services Manager" },
-        "sw-single" => {"Name"=>"YaST Software Management"},
+        "sw-single"        => { "Name"=>"YaST Software Management" },
         "s390-extra"       => { "Name" => "YaST S390 Extra" },
         "dns-server"       => { "Name" => "YaST DNS Server" }
       )
@@ -62,9 +62,8 @@ describe Yast::Desktop do
     before do
       Yast::Desktop.Read(read_values)
       # as changed scr does not have groups desktop, define it manually here
-      Yast::Desktop.Groups = { "Software" => { "modules" => ["add-on", "sw-single"] }}
+      Yast::Desktop.Groups = { "Software" => { "modules" => ["add-on", "sw-single"] } }
     end
-
 
     context "on WSL" do
       before do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb  4 14:15:37 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Show on WSL only WSL capable modules in control center
+  (bsc#1162650)
+- 4.2.63
+
+-------------------------------------------------------------------
 Thu Jan 30 11:19:00 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not crash when the "software/base_products" is not defined

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.62
+Version:        4.2.63
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
reason: WSL is limited environment, so many modules does not make sense to show. So whitelisting only ones that has specific key in desktop file.