### PR TITLE
Add ProgressBar widget

### DIFF
--- a/library/cwm/src/lib/cwm/dynamic_progress_bar.rb
+++ b/library/cwm/src/lib/cwm/dynamic_progress_bar.rb
@@ -21,7 +21,10 @@ require "abstract_method"
 require "cwm/progress_bar"
 
 module CWM
-  # Widget for a dynamic progress bar, where the label can be set for every step
+  # Widget for a dynamic progress bar, where the label can be set for every step.
+  #
+  # This progress bar is useful when steps are not known in advance or part of them are dynamically
+  # generated.
   #
   # @example
   #
@@ -50,8 +53,6 @@ module CWM
       super()
     end
 
-  private
-
     # @!method label
     #
     #   Label for the progress bar when no step is given, see {#forward}.
@@ -65,6 +66,8 @@ module CWM
     #
     #   @return [Integer]
     abstract_method :steps_count
+
+  private
 
     # @see ProgressBar#steps
     def steps

--- a/library/cwm/src/lib/cwm/dynamic_progress_bar.rb
+++ b/library/cwm/src/lib/cwm/dynamic_progress_bar.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "abstract_method"
+require "cwm/progress_bar"
+
+module CWM
+  # Widget for a dynamic progress bar, where the label can be set for every step
+  #
+  # @example
+  #
+  #   class MyProgressBar < CWM::DynamicProgessBar
+  #     def steps_count
+  #       3
+  #     end
+  #
+  #     def label
+  #       "Progress"
+  #     end
+  #   end
+  #
+  #   pg = MyProgressBar.new
+  #
+  #   pg.forward("step 1") #=> shows label "step 1"
+  #   pg.forward           #=> shows label "Progress"
+  #   pg.forward("step 3") #=> shows label "step 3"
+  class DynamicProgressBar < ProgressBar
+    # Moves the progress forward and sets the given step as label
+    #
+    # @see ProgressBar#forward
+    def forward(step = nil)
+      next_step(step) if step
+
+      super()
+    end
+
+  private
+
+    # @!method label
+    #
+    #   Label for the progress bar when no step is given, see {#forward}.
+    #
+    #   @return [String]
+    abstract_method :label
+
+    # @!method steps_count
+    #
+    #   Number of steps
+    #
+    #   @return [Integer]
+    abstract_method :steps_count
+
+    # @see ProgressBar#steps
+    def steps
+      @steps ||= [label] * steps_count
+    end
+
+    # Sets the label for the next step
+    #
+    # @param step [String]
+    def next_step(step)
+      return if complete?
+
+      steps[current_step_index + 1] = step
+    end
+  end
+end

--- a/library/cwm/src/lib/cwm/progress_bar.rb
+++ b/library/cwm/src/lib/cwm/progress_bar.rb
@@ -1,0 +1,118 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "abstract_method"
+require "cwm/custom_widget"
+
+module CWM
+  # Widget for a progress bar
+  #
+  # @example
+  #
+  #   class MyProgressBar < CWM::ProgessBar
+  #     def steps
+  #       ["step 1", "step 2", "step 3"]
+  #     end
+  #   end
+  #
+  #   pg = MyProgressBar.new
+  #
+  #   pg.forward #=> shows label "step 1"
+  #   pg.forward #=> shows label "step 2"
+  #   pg.forward #=> shows label "step 3"
+  class ProgressBar < CustomWidget
+    # Constructor
+    def initialize
+      super
+
+      @current_step_index = 0
+    end
+
+    # @see CWM::CustomWidget#contents
+    def contents
+      ProgressBar(Id(widget_id), current_label, total_steps, current_step_index)
+    end
+
+    # Moves the progress forward and sets the next step as label if needed (see #show_steps?)
+    def forward
+      return if complete?
+
+      @current_step_index += 1
+
+      refresh
+    end
+
+  private
+
+    # @!method steps
+    #
+    #   Steps for the progress bar
+    #
+    #   @return [Array<String>]
+    abstract_method :steps
+
+    # Index to the current step
+    #
+    # @return [Integer]
+    attr_reader :current_step_index
+
+    # Whether the steps should be used for the label of the progress bar
+    #
+    # @return [Boolean] if false, no label is shown
+    def show_steps?
+      true
+    end
+
+    # Total number of steps
+    #
+    # @return [Integer]
+    def total_steps
+      steps.size
+    end
+
+    # Label to use for the current step
+    #
+    # @return [String]
+    def current_label
+      label = show_steps? ? current_step : nil
+
+      label || ""
+    end
+
+    # Current step
+    #
+    # @return [String]
+    def current_step
+      steps[current_step_index]
+    end
+
+    # Whether the progress bar is already complete
+    #
+    # @return [Boolean]
+    def complete?
+      current_step_index == total_steps
+    end
+
+    # Refreshes the progress bar according to the current step
+    def refresh
+      Yast::UI.ChangeWidget(Id(widget_id), :Value, current_step_index)
+      Yast::UI.ChangeWidget(Id(widget_id), :Label, current_label)
+    end
+  end
+end

--- a/library/cwm/src/lib/cwm/progress_bar.rb
+++ b/library/cwm/src/lib/cwm/progress_bar.rb
@@ -58,14 +58,14 @@ module CWM
       refresh
     end
 
-  private
-
     # @!method steps
     #
     #   Steps for the progress bar
     #
     #   @return [Array<String>]
     abstract_method :steps
+
+  private
 
     # Index to the current step
     #
@@ -87,6 +87,8 @@ module CWM
     end
 
     # Label to use for the current step
+    #
+    # @see {#show_steps?}
     #
     # @return [String]
     def current_label

--- a/library/cwm/src/lib/cwm/rspec.rb
+++ b/library/cwm/src/lib/cwm/rspec.rb
@@ -1,3 +1,22 @@
+# Copyright (c) [2017-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 # in your specs:
 #   require "cwm/rspec"
 
@@ -222,6 +241,33 @@ RSpec.shared_examples "CWM::Dialog" do
   describe "#skip_store_for" do
     it "produces an Array" do
       expect(subject.skip_store_for).to be_an Array
+    end
+  end
+end
+
+RSpec.shared_examples "CWM::ProgressBar" do
+  include_examples "CWM::CustomWidget"
+
+  describe "#steps" do
+    it "produces an Array of String" do
+      expect(subject.send(:steps)).to be_an Array
+      expect(subject.send(:steps)).to all(be_a(String))
+    end
+  end
+end
+
+RSpec.shared_examples "CWM::DynamicProgressBar" do
+  include_examples "CWM::ProgressBar"
+
+  describe "#label" do
+    it "produces an String or nil" do
+      expect(subject.send(:label)).to be_a(String).or(be_nil)
+    end
+  end
+
+  describe "#steps_count" do
+    it "produces an Integer" do
+      expect(subject.send(:steps_count)).to be_a(Integer)
     end
   end
 end

--- a/library/cwm/src/lib/cwm/widget.rb
+++ b/library/cwm/src/lib/cwm/widget.rb
@@ -1,8 +1,29 @@
+# Copyright (c) [2016-2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
 require "yast"
 
 require "cwm/abstract_widget"
 require "cwm/custom_widget"
 require "cwm/common_widgets"
+require "cwm/dynamic_progress_bar"
+require "cwm/progress_bar"
 require "cwm/table"
 require "cwm/tabs"
 require "cwm/tree"

--- a/library/cwm/test/dynamic_progress_bar_test.rb
+++ b/library/cwm/test/dynamic_progress_bar_test.rb
@@ -1,0 +1,69 @@
+#! /usr/bin/env rspec --format doc
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+require "cwm/rspec"
+require "cwm/dynamic_progress_bar"
+
+Yast.import "UI"
+
+describe CWM::DynamicProgressBar do
+  class TestDynamicProgressBar < CWM::DynamicProgressBar
+    def steps_count
+      3
+    end
+
+    def label
+      "Progress"
+    end
+  end
+
+  subject { TestDynamicProgressBar.new }
+
+  include_examples "CWM::DynamicProgressBar"
+
+  describe "#forward" do
+    before do
+      allow(Yast::UI).to receive(:ChangeWidget).with(anything, :Label, anything)
+
+      allow(Yast::UI).to receive(:ChangeWidget).with(anything, :Value, anything)
+    end
+
+    context "when the step is given" do
+      let(:step) { "step 1" }
+
+      it "updates the label according to the given step" do
+        expect(Yast::UI).to receive(:ChangeWidget).with(anything, :Label, step)
+
+        subject.forward(step)
+      end
+    end
+
+    context "when the step is not given" do
+      it "updates the label according to the defined label" do
+        expect(Yast::UI).to receive(:ChangeWidget).with(anything, :Label, "Progress")
+
+        subject.forward
+      end
+    end
+  end
+end

--- a/library/cwm/test/progress_bar_test.rb
+++ b/library/cwm/test/progress_bar_test.rb
@@ -1,0 +1,96 @@
+#! /usr/bin/env rspec --format doc
+
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+require "cwm/rspec"
+require "cwm/progress_bar"
+
+Yast.import "UI"
+
+describe CWM::ProgressBar do
+  class TestProgressBar < CWM::ProgressBar
+    def steps
+      ["step 1", "step 2", "step 3"]
+    end
+  end
+
+  subject { TestProgressBar.new }
+
+  include_examples "CWM::ProgressBar"
+
+  describe "#forward" do
+    before do
+      allow(Yast::UI).to receive(:ChangeWidget).with(anything, :Label, anything)
+
+      allow(Yast::UI).to receive(:ChangeWidget).with(anything, :Value, anything)
+    end
+
+    context "when the progress bar is complete" do
+      before do
+        3.times { subject.forward }
+      end
+
+      it "does not modify the progress bar" do
+        expect(Yast::UI).to_not receive(:ChangeWidget).with(anything, :Value, anything)
+        expect(Yast::UI).to_not receive(:ChangeWidget).with(anything, :Label, anything)
+
+        subject.forward
+      end
+    end
+
+    context "when the progress bar is not complete" do
+      before do
+        subject.forward # there are three steps
+      end
+
+      it "moves progress forward" do
+        expect(Yast::UI).to_not receive(:ChangeWidget).with(anything, :Value, 1)
+
+        subject.forward
+      end
+
+      context "and steps should be shown" do
+        before do
+          allow(subject).to receive(:show_steps?).and_return(true)
+        end
+
+        it "updates the label according to the step" do
+          expect(Yast::UI).to_not receive(:ChangeWidget).with(anything, :Label, "step 2")
+
+          subject.forward
+        end
+      end
+
+      context "and steps should not be shown" do
+        before do
+          allow(subject).to receive(:show_steps?).and_return(false)
+        end
+
+        it "shows an empty label" do
+          expect(Yast::UI).to receive(:ChangeWidget).with(anything, :Label, "")
+
+          subject.forward
+        end
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 31 16:07:35 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Add new widgets CWM::ProgressBar and CWM::DynamicProgressBar.
+- Needed for bsc#1135366.
+- 4.2.63
+
+-------------------------------------------------------------------
 Thu Jan 30 11:19:00 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not crash when the "software/base_products" is not defined

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.62
+Version:        4.2.63
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
### Problem

The Expert Partitioner needs a new dialog to show the progress when applying changes. This new dialog requires a progress bar.

* https://bugzilla.suse.com/show_bug.cgi?id=1135366

### Solution

Add new classes `CWM::ProgresBar` and `CWM::DynamicProgressBar`.

### Testing

* Manually tested
* Added unit tests.

### Screenshots

<details>
<summary>Show/Hide</summary>

![Screenshot from 2020-01-31 16-13-35](https://user-images.githubusercontent.com/1112304/73554981-ad0d0d00-4444-11ea-8c8a-130b9fa79077.png)


</details>