### PR TITLE
Restore the CWM::RichText scroll after updating its content

### DIFF
--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -368,6 +368,13 @@ module CWM
 
     # Determines if the vertical scroll must be kept after updating the content
     #
+    # @note Useful only to keep the sense of continuity when redrawing basically with the same text
+    #
+    # Keeping the vertical scroll after changing the value is mostly intended to be used after a
+    # redraw because of a user action. However, using it after changing the content noticeably
+    # (e.g., displaying different product descriptions), will look like a randomly positioned
+    # vertical scroll.
+    #
     # @return [Boolean] true if the vertical scroll must be kept; false otherwise
     def keep_scroll?
       false

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -365,6 +365,40 @@ module CWM
     self.widget_type = :richtext
 
     include ValueBasedWidget
+
+    # Determines if the scroll should be restored after updating the content
+    #
+    # @return [Boolean] true if the scroll should be restored; false otherwise
+    def keep_scroll?
+      false
+    end
+
+    # Updates the content
+    #
+    # Depending on #keep_scroll?, the scroll will be saved and restored.
+    #
+    # @param val [String] the new content for the widget
+    def value=(val)
+      current_vscroll = vscroll
+      super
+      self.vscroll = current_vscroll if keep_scroll?
+    end
+
+  private
+
+    # Saves the current vertical scroll
+    #
+    # @return [String] current vertical scroll value
+    def vscroll
+      Yast::UI.QueryWidget(Id(widget_id), :VScrollValue)
+    end
+
+    # Sets vertical scroll
+    #
+    # @param value [String] the new vertical scroll value
+    def vscroll=(value)
+      Yast::UI.ChangeWidget(Id(widget_id), :VScrollValue, value)
+    end
   end
 
   # Time field widget

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -366,16 +366,16 @@ module CWM
 
     include ValueBasedWidget
 
-    # Determines if the scroll should be restored after updating the content
+    # Determines if the vertical scroll must be kept after updating the content
     #
-    # @return [Boolean] true if the scroll should be restored; false otherwise
+    # @return [Boolean] true if the vertical scroll must be kept; false otherwise
     def keep_scroll?
       false
     end
 
     # Updates the content
     #
-    # Depending on #keep_scroll?, the scroll will be saved and restored.
+    # Depending on #keep_scroll?, the vertical scroll will be saved and restored.
     #
     # @param val [String] the new content for the widget
     def value=(val)

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -6,7 +6,6 @@ require "cwm/common_widgets"
 require "cwm/rspec"
 
 describe CWM::RadioButtons do
-
   class TestRadioButtons < CWM::RadioButtons
     def label
       "Choose a number"
@@ -55,6 +54,50 @@ describe CWM::RadioButtons do
       it "sets hspacing based on the method result" do
         expect(subject.cwm_definition.keys).to include("hspacing")
         expect(subject.cwm_definition["hspacing"]).to eq 3
+      end
+    end
+  end
+end
+
+describe CWM::RichText do
+  subject { described_class.new }
+  let(:widget_id) { Id(subject.widget_id) }
+
+  describe "#value=" do
+    before do
+      allow(subject).to receive(:keep_scroll?).and_return(keep_scroll)
+      allow(Yast::UI).to receive(:ChangeWidget)
+    end
+
+    context "when set to restore the scroll" do
+      let(:keep_scroll) { true }
+
+      it "saves the scroll position" do
+        expect(Yast::UI).to receive(:QueryWidget).with(widget_id, :VScrollValue)
+
+        subject.value = "Test"
+      end
+
+      it "restores the scroll" do
+        expect(Yast::UI).to receive(:ChangeWidget).with(widget_id, :VScrollValue, anything)
+
+        subject.value = "Test"
+      end
+    end
+
+    context "when set to not restore the scroll" do
+      let(:keep_scroll) { false }
+
+      it "saves the scroll position" do
+        expect(Yast::UI).to receive(:QueryWidget).with(widget_id, :VScrollValue)
+
+        subject.value = "Test"
+      end
+
+      it "does not restore the scroll" do
+        expect(Yast::UI).to_not receive(:ChangeWidget).with(widget_id, :VScrollValue, anything)
+
+        subject.value = "Test"
       end
     end
   end

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -62,42 +62,50 @@ end
 describe CWM::RichText do
   subject { described_class.new }
   let(:widget_id) { Id(subject.widget_id) }
+  let(:new_content) { "Updated content" }
+  let(:vscroll) { "40" }
 
   describe "#value=" do
     before do
-      allow(subject).to receive(:keep_scroll?).and_return(keep_scroll)
+      allow(Yast::UI).to receive(:QueryWidget).with(widget_id, :VScrollValue).and_return(vscroll)
       allow(Yast::UI).to receive(:ChangeWidget)
     end
 
-    context "when set to restore the scroll" do
-      let(:keep_scroll) { true }
-
-      it "saves the scroll position" do
-        expect(Yast::UI).to receive(:QueryWidget).with(widget_id, :VScrollValue)
-
-        subject.value = "Test"
+    context "when set to keep the scroll" do
+      before do
+        allow(subject).to receive(:keep_scroll?).and_return(true)
       end
 
-      it "restores the scroll" do
-        expect(Yast::UI).to receive(:ChangeWidget).with(widget_id, :VScrollValue, anything)
+      it "changes the widget value" do
+        expect(Yast::UI).to receive(:ChangeWidget).with(widget_id, :Value, new_content)
 
-        subject.value = "Test"
+        subject.value = new_content
+      end
+
+      it "saves vertical scroll position" do
+        expect(Yast::UI).to receive(:QueryWidget).with(widget_id, :VScrollValue)
+
+        subject.value = new_content
+      end
+
+      it "restores vertical scroll" do
+        expect(Yast::UI).to receive(:ChangeWidget).with(widget_id, :VScrollValue, vscroll)
+
+        subject.value = new_content
       end
     end
 
-    context "when set to not restore the scroll" do
-      let(:keep_scroll) { false }
+    context "when set to not keep the scroll" do
+      it "changes the widget value" do
+        expect(Yast::UI).to receive(:ChangeWidget).with(widget_id, :Value, new_content)
 
-      it "saves the scroll position" do
-        expect(Yast::UI).to receive(:QueryWidget).with(widget_id, :VScrollValue)
-
-        subject.value = "Test"
+        subject.value = new_content
       end
 
       it "does not restore the scroll" do
         expect(Yast::UI).to_not receive(:ChangeWidget).with(widget_id, :VScrollValue, anything)
 
-        subject.value = "Test"
+        subject.value = new_content
       end
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  6 13:26:57 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Allow to restore the vertical scroll of a CWM::RichText
+  (related to bsc#1049965)
+- 4.2.70
+
+-------------------------------------------------------------------
 Fri Mar  6 12:00:43 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Read the list of network service properly, no matter where

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.69
+Version:        4.2.70
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

After changing/updating its content (aka value), a CWM::RichText is not able to restore the vertical scroll. This is specially annoying in those scenarios where that widget is being used to emulate complex interfaces, such as MultiSelection list.

* https://bugzilla.suse.com/show_bug.cgi?id=1049965

## Solution

Add a flag to know if it will be necessary to save/restore the scroll before/after updating the value.

## Test

* Tested manually
* Added unit tests.

## Screencast

<details>
<summary>Click to show/hide</summary>

---

![ezgif com-optimize(5)](https://user-images.githubusercontent.com/1691872/76202208-600f1a00-61ec-11ea-8cfe-fc3c97792002.gif)


</details>

---

Related to 

* https://github.com/libyui/libyui/pull/149
* https://gist.github.com/shundhammer/1bc79af7d1a31892bd977678bc2af2c1#conservative-approach-save-scrollbar-values
* https://github.com/yast/yast-registration/pull/483#discussion_r385282607