### PR TITLE
Skip repository reloading (bsc#1165501)

### DIFF
--- a/library/packages/src/modules/Product.rb
+++ b/library/packages/src/modules/Product.rb
@@ -198,7 +198,7 @@ module Yast
       if use_installed_products?
         PackageSystem.EnsureTargetInit
       else
-        PackageSystem.EnsureSourceInit
+        PackageSystem.EnsureSourceInit unless Stage.initial
       end
 
       Pkg.PkgSolve(true)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar  6 08:58:24 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Skip repository reloading at installation to avoid unselecting
+  products to install (bsc#1165501)
+- 4.2.68
+
+-------------------------------------------------------------------
 Wed Feb 26 10:42:42 CET 2020 - schubi@suse.de
 
 - Updated docu for SysctlConfig class (bsc#1151649).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.67
+Version:        4.2.68
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1165501 
- This is related to https://github.com/yast/yast-pkg-bindings/pull/125, restoring the sources during installation has a side effect of deselecting the selected products or patterns
- 4.2.68

### Tests
- [x] Tested manually in Online installation
- [x] Tested manually in Offline installation