### PR TITLE
[CWM] Add new widget to manage multi status selection lists

### DIFF
--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -34,6 +34,10 @@ module CWM
   #
   # If you want to see it in action, have a look at yast2-registration or yast2-packager modules.
   #
+  # TODO: make possible to use it more than once in the same dialog, maybe by using the parent
+  # widget_id as a prefix for the event_id. See {CWM::MultiStatusSelector#handle} and
+  # {CWM::MultiStatusSelector::Item.event_id}.
+  #
   # @example Defining a MultiStatusSelector to manage products selection (with dependencies)
   #
   #     require "cwm/multi_status_selector"

--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -175,7 +175,7 @@ module CWM
 
     # Updates the content based on items list
     def refresh
-      content.value = items.map(&:to_s).join("<br>")
+      content.value = items.map(&:to_richtext).join("<br>")
     end
 
     # Convenience widget to keep the content updated

--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -1,0 +1,470 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "cwm"
+require "abstract_method"
+
+module CWM
+  # Custom widget to manage multi status selection items
+  #
+  # It uses a RichText to emulate the multi selection list meeting following requirements:
+  #
+  #  - Allow to select more than one item.
+  #  - Able to represent multiple statuses: no selected, selected, auto selected.
+  #  - Items can be enable or disabled.
+  #  - Emit different events to distinguish the interaction through check box input or its label.
+  #  - Automatic text wrapping.
+  #  - Keep the vertical scroll.
+  #
+  # If you want to see it in action, have a look at yast2-registration or yast2-packager modules.
+  #
+  # @example Defining a MultiStatusSelector to manage products selection (with dependencies)
+  #
+  #     require "cwm/multi_status_selector"
+  #
+  #     class MyMultiStatusSelector < CWM::MultiStatusSelector
+  #       attr_reader :items
+  #
+  #       def initialize(products)
+  #         @products = products
+  #         @items = products.map { |p| Item.new(p) }
+  #       end
+  #
+  #       def contents
+  #         VBox(
+  #           VWeight(60, super),
+  #           VWeight(40, details)
+  #         )
+  #       end
+  #
+  #       def toggle(item)
+  #         item.toggle
+  #         select_dependencies
+  #         label_event_handler(item)
+  #       end
+  #
+  #       private
+  #
+  #       attr_accessor :products
+  #
+  #       def details
+  #         @details ||= CWM::RichText.new
+  #       end
+  #
+  #       def select_dependencies
+  #         # logic to recalculate auto selected items
+  #       end
+  #
+  #       def label_event_handler(item)
+  #         details.value = item.description
+  #       end
+  #
+  #       class Item < CWM::MultiStateSelector::Item
+  #         attr_reader :status, :dependencies
+  #
+  #         def initialize(product)
+  #           @product = product
+  #           @status = product.status || UNSELECTED
+  #           @dependencies = product.dependencies || []
+  #         end
+  #
+  #         def id
+  #           product.id
+  #         end
+  #
+  #         def label
+  #           product.friendly_name || product.name
+  #         end
+  #
+  #         def description
+  #           # build the item description
+  #         end
+  #
+  #         private
+  #
+  #         attr_reader :product
+  #       end
+  #     end
+  class MultiStatusSelector < CustomWidget
+    # @!method items
+    #   The items collection
+    #   @return [Array<Item>] the collection of available items
+    abstract_method :items
+
+    # @macro seeAbstractWidget
+    def init
+      refresh
+    end
+
+    # @macro seeAbstractWidget
+    def contents
+      HBox(content)
+    end
+
+    # @macro seeAbstractWidget
+    def handle(event)
+      if event["ID"].to_s.match?(Item.event_id)
+        id, fired_by = event["ID"].split(Item.event_id)
+
+        item = find_item(id)
+
+        return unless item
+
+        send("#{fired_by}_event_handler", item)
+      end
+
+      nil
+    end
+
+    # Toggles the status of given item
+    #
+    # Redefine it if needed to perform additional actions before or after toggling the item, like
+    # calculating dependencies for auto selection.
+    #
+    # @param item [Item] item to toggle the status
+    def toggle(item)
+      item.toggle
+    end
+
+  private
+
+    # @macro seeAbstractWidget
+    def handle_all_events
+      true
+    end
+
+    # Handles the event fired by the Item check box input
+    #
+    # @param item [Item] the item that fired the event
+    def input_event_handler(item)
+      toggle(item)
+      refresh
+    end
+
+    # Handles the event fired by the Item check box label
+    #
+    # @param [Item] the item that fired the event
+    def label_event_handler(item)
+      log.debug("Unhandled label event fired by #{item.inspect}")
+    end
+
+    # Returns the item with given id
+    #
+    # @param id [String] the id of the searched item
+    # @return [Item, nil] the item matching with given id
+    def find_item(id)
+      items.find { |i| i.id.to_s == id }
+    end
+
+    # Updates the content based on items list
+    def refresh
+      content.value = items.map(&:to_s).join("<br>")
+    end
+
+    # Convenience widget to keep the content updated
+    #
+    # @return [ContentArea]
+    def content
+      @content ||= Content.new
+    end
+
+    # A CWM::RichText able to keep the vertical scroll after updating its value
+    class Content < RichText
+      # @macro seeAbstractWidget
+      def opt
+        [:notify]
+      end
+
+      # @macro seeRichText
+      def keep_scroll?
+        true
+      end
+    end
+
+    # A plain Ruby object in charge to build an item "check box" representation
+    #
+    # It already provides a default state (always enabled) and the logic to deal with the status
+    # (selected, unselected or auto selected) but it can be extended by redefining the #status,
+    # #toggle, and/or #enabled? methods.
+    #
+    # Derived classes must define #id and #label attributes/methods.
+    #
+    # See the {MultiStatusSelector} example.
+    class Item
+      extend Yast::I18n
+
+      # Map to icons used in GUI to represent all the known statuses in both scenarios, during
+      # installation (`inst` mode) and in a running system (`normal` mode).
+      #
+      # Available statuses are
+      #
+      #   - `[ ]` not selected
+      #   - `[x]` selected
+      #   - `[a]` auto-selected
+      IMAGES = {
+        "inst:[a]:enabled"    => "auto-selected.svg",
+        "inst:[x]:enabled"    => "inst_checkbox-on.svg",
+        "inst:[x]:disabled"   => "inst_checkbox-on-disabled.svg",
+        "inst:[ ]:enabled"    => "inst_checkbox-off.svg",
+        "inst:[ ]:disabled"   => "inst_checkbox-off-disabled.svg",
+        "normal:[a]:enabled"  => "auto-selected.svg",
+        "normal:[x]:enabled"  => "checkbox-on.svg",
+        "normal:[ ]:enabled"  => "checkbox-off.svg",
+        # NOTE: Normal theme has no special images for disabled check boxes
+        "normal:[x]:disabled" => "checkbox-on.svg",
+        "normal:[ ]:disabled" => "checkbox-off.svg"
+      }.freeze
+      private_constant :IMAGES
+
+      # Path to the icons in the system
+      IMAGES_DIR = "/usr/share/YaST2/theme/current/wizard".freeze
+      private_constant :IMAGES_DIR
+
+      # Selected status
+      SELECTED = :selected
+      private_constant :SELECTED
+
+      # Not selected status
+      UNSELECTED = :unselected
+      private_constant :UNSELECTED
+
+      # Auto selected status
+      AUTO_SELECTED = :auto_selected
+      private_constant :AUTO_SELECTED
+
+      # Id to identify an event fired by the check box
+      EVENT_ID = "#checkbox#".freeze
+      private_constant :EVENT_ID
+
+      # Id to identify an event fired by the check box input
+      INPUT_EVENT_ID = "#{EVENT_ID}input".freeze
+      private_constant :INPUT_EVENT_ID
+
+      # Id to identify an event fired by the check box label
+      LABEL_EVENT_ID = "#{EVENT_ID}label".freeze
+      private_constant :LABEL_EVENT_ID
+
+      textdomain "cwm"
+
+      # @!method id
+      #   The item id
+      #   @return [#to_s]
+      abstract_method :id
+
+      # @!method label
+      #   The item label
+      #   @return [#to_s]
+      abstract_method :label
+
+      # @return [Symbol] the current item status
+      attr_reader :status
+
+      # Returns the common identifier of fired events
+      #
+      # @return [String] event identifier
+      def self.event_id
+        EVENT_ID
+      end
+
+      # Help text
+      #
+      # @return [String]
+      def self.help
+        help_text = "<p>"
+        # TRANSLATORS: help text for a not selected check box
+        help_text << "#{icon_for(UNSELECTED)} = #{_("Not selected")}<br />"
+        # TRANSLATORS: help text for a selected check box
+        help_text << "#{icon_for(SELECTED)} = #{_("Selected")}<br />"
+        # TRANSLATORS: help text for an automatically selected check box
+        # (it has a different look that a user selected check box)
+        help_text << "#{icon_for(AUTO_SELECTED)} = #{_("Auto selected")}"
+        help_text << "</p>"
+        help_text
+      end
+
+      # Returns the icon to be used for an item with given status and state
+      #
+      # @see .value_for
+      #
+      # @param status [Symbol] the item status (e.g., :selected, :registered, :auto_selected)
+      # @param mode [String] the running mode, "normal" or "inst"
+      # @param state [String] the item state, "enabled" or "disabled"
+      #
+      # @return [String] an <img> tag when running in GUI mode; plain text otherwise
+      def self.icon_for(status, mode: "normal", state: "enabled")
+        value = value_for(status)
+
+        if Yast::UI.TextMode
+          value
+        else
+          # an image key looks like "inst:[a]:enabled"
+          image_key = [mode, value, state].join(":")
+
+          "<img src=\"#{IMAGES_DIR}/#{IMAGES[image_key]}\">"
+        end
+      end
+
+      # Returns the status string representation
+      #
+      # @param status [Symbol] the status identifier
+      #
+      # @return [String] the status text representation
+      def self.value_for(status)
+        case status
+        when SELECTED
+          "[x]"
+        when AUTO_SELECTED
+          "[a]"
+        else
+          "[ ]"
+        end
+      end
+
+      # Toggles the current status
+      def toggle
+        @status = selected? ? UNSELECTED : SELECTED
+      end
+
+      # Determines if the item is enabled or not
+      #
+      # @return [Boolean] true when item is enabled; false otherwise
+      def enabled?
+        true
+      end
+
+      # Whether item is selected
+      #
+      # @return [Boolean] true if the status is selected; false otherwise
+      def selected?
+        status == SELECTED
+      end
+
+      # Whether item is not selected
+      #
+      # @return [Boolean] true if the status is not selected; false otherwise
+      def unselected?
+        [SELECTED, AUTO_SELECTED].none?(status)
+      end
+
+      # Whether item is auto selected
+      #
+      # @return [Boolean] true if the status is auto selected; false otherwise
+      def auto_selected?
+        status == AUTO_SELECTED
+      end
+
+      # Sets the item as selected
+      def select!
+        @status = SELECTED
+      end
+
+      # Sets the item as not selected
+      def unselect!
+        @status = UNSELECTED
+      end
+
+      # Sets the item as auto-selected
+      def auto_select!
+        @status = AUTO_SELECTED
+      end
+
+      # Returns richtext representation for the item
+      #
+      # Basically, an string containing two <a> or <span> tags, depending on the #enabled? method.
+      # One for the check box input and another for the label.
+      #
+      # @return [String] the item richtext representation
+      def to_s
+        "#{checkbox_input} #{checkbox_label}"
+      end
+
+    private
+
+      # @see .icon_for
+      def icon
+        self.class.icon_for(status, mode: mode, state: state)
+      end
+
+      # Builds the check box input representation
+      #
+      # @return [String]
+      def checkbox_input
+        if enabled?
+          "<a href=\"#{id}#{INPUT_EVENT_ID}\" style=\"#{text_style}\">#{icon}</a>"
+        else
+          "<span style\"#{text_style}\">#{icon}</a>"
+        end
+      end
+
+      # Builds the check box label representation
+      #
+      # @return [String]
+      def checkbox_label
+        if enabled?
+          "<a href=\"#{id}#{LABEL_EVENT_ID}\" style=\"#{text_style}\">#{label}</a>"
+        else
+          "<span style\"#{text_style}\">#{label}</a>"
+        end
+      end
+
+      # Returns the current mode
+      #
+      # @return [String] "normal" in a running system; "inst" during the installation
+      def mode
+        installation? ? "inst" : "normal"
+      end
+
+      # Returns the current input state
+      #
+      # @return [String] "enabled" when item must be enabled; "disabled" otherwise
+      def state
+        enabled? ? "enabled" : "disabled"
+      end
+
+      # Returns style rules for the text
+      #
+      # @return [String] the status text representation
+      def text_style
+        "text-decoration: none; color: #{color}"
+      end
+
+      # Determines the color for the text
+      #
+      # @return [String] "grey" for a disabled item;
+      #                  "white" when enabled and running in installation mode;
+      #                  "black" otherwise
+      def color
+        return "grey" unless enabled?
+        return "white" if installation?
+
+        "black"
+      end
+
+      # Determines whether running in installation mode
+      #
+      # We do not use Stage.initial because of firstboot, which runs in 'installation' mode
+      # but in 'firstboot' stage.
+      #
+      # @return [Boolean] Boolean if running in installation or update mode
+      def installation?
+        Yast::Mode.installation || Yast::Mode.update
+      end
+    end
+  end
+end

--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -119,13 +119,10 @@ module CWM
 
     # @macro seeAbstractWidget
     def handle(event)
-      if event["ID"].to_s.match?(Item.event_id)
+      if event["ID"].to_s.include?(Item.event_id)
         id, fired_by = event["ID"].split(Item.event_id)
 
         item = find_item(id)
-
-        return unless item
-
         send("#{fired_by}_event_handler", item)
       end
 
@@ -166,10 +163,10 @@ module CWM
 
     # Returns the item with given id
     #
-    # @param id [String] the id of the searched item
-    # @return [Item, nil] the item matching with given id
-    def find_item(id)
-      items.find { |i| i.id.to_s == id }
+    # @param needle [#to_s] any object that responds to `#to_s`
+    # @return [Item, nil] the item which id matches with given object#to_s
+    def find_item(needle)
+      items.find { |i| i.id.to_s == needle.to_s }
     end
 
     # Updates the content based on items list
@@ -390,7 +387,7 @@ module CWM
       # One for the check box input and another for the label.
       #
       # @return [String] the item richtext representation
-      def to_s
+      def to_richtext
         "#{checkbox_input} #{checkbox_label}"
       end
 

--- a/library/cwm/test/multi_status_selector_test.rb
+++ b/library/cwm/test/multi_status_selector_test.rb
@@ -64,6 +64,59 @@ describe CWM::MultiStatusSelector do
   let(:items) { [first_item, second_item] }
 
   include_examples "CWM::CustomWidget"
+
+  describe "#handle" do
+    let(:item) { subject.items.first }
+    let(:event) { { "ID" => event_id } }
+
+    context "when handling an event triggered by the check box label" do
+      let(:event_id) { "#{item.id}#checkbox#label" }
+
+      it "executes the label event handler" do
+        expect(subject).to receive(:label_event_handler).with(item)
+
+        subject.handle(event)
+      end
+
+      it "does not execute the input event handler" do
+        expect(subject).to_not receive(:input_event_handler)
+
+        subject.handle(event)
+      end
+    end
+
+    context "when handling an event triggered by the check box input" do
+      let(:event_id) { "#{item.id}#checkbox#input" }
+
+      it "executes the input event handler" do
+        expect(subject).to receive(:input_event_handler).with(item)
+
+        subject.handle(event)
+      end
+
+      it "does not execute the label event handler" do
+        expect(subject).to_not receive(:label_event_handler)
+
+        subject.handle(event)
+      end
+    end
+
+    context "when handling an event not triggered by the item" do
+      let(:event) { { "ID" => :whatever } }
+
+      it "does not execute the input event handler" do
+        expect(subject).to_not receive(:input_event_handler)
+
+        subject.handle(event)
+      end
+
+      it "does not execute the label event handler" do
+        expect(subject).to_not receive(:label_event_handler)
+
+        subject.handle(event)
+      end
+    end
+  end
 end
 
 describe CWM::MultiStatusSelector::Item do

--- a/library/cwm/test/multi_status_selector_test.rb
+++ b/library/cwm/test/multi_status_selector_test.rb
@@ -1,0 +1,339 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+require "cwm/rspec"
+require "cwm/multi_status_selector"
+
+class DummyMultiStatusSelector < CWM::MultiStatusSelector
+  def initialize(items)
+    @items = items.map { |i| DummyItem.new(i[:id], i[:status], i[:enabled]) }
+  end
+
+  attr_reader :items
+
+  class DummyItem < Item
+    def initialize(id, status, enabled)
+      @id = "dummy-item-#{id}"
+      @label = "Label for #{@id}"
+      @status = status
+      @enabled = enabled
+    end
+
+    attr_reader :id, :label, :status
+
+    def enabled?
+      @enabled
+    end
+  end
+end
+
+class DummyItem < CWM::MultiStatusSelector::Item
+  def initialize(id, status, enabled)
+    @id = "dummy-item-#{id}"
+    @label = "Label for #{@id}"
+    @status = status
+    @enabled = enabled
+  end
+
+  attr_reader :id, :label, :status
+end
+
+describe CWM::MultiStatusSelector do
+  subject { DummyMultiStatusSelector.new(items) }
+
+  let(:first_item) { { id: 1, status: :selected, enabled: false } }
+  let(:second_item) { { id: 2, status: :unselected, enabled: true } }
+  let(:items) { [first_item, second_item] }
+
+  include_examples "CWM::CustomWidget"
+end
+
+describe CWM::MultiStatusSelector::Item do
+  subject { DummyMultiStatusSelector::DummyItem.new(id, status, enabled) }
+
+  let(:id) { 99 }
+  let(:status) { nil }
+  let(:enabled) { true }
+
+  let(:link_id) { "#{subject.id}#{described_class.event_id}" }
+  let(:regexp_input_link) { /<a href="#{link_id}.*img.*<\/a>/ }
+  let(:regexp_label_link) { /<a href="#{link_id}.*>#{subject.label}<\/a>/ }
+
+  describe "#toggle" do
+    context "when item is selected" do
+      let(:status) { :selected }
+
+      it "changes to unselected" do
+        expect(subject.status).to eq(:selected)
+
+        subject.toggle
+
+        expect(subject.status).to eq(:unselected)
+      end
+    end
+
+    context "when item is not selected" do
+      let(:status) { :unselected }
+
+      it "changes to selected" do
+        expect(subject.status).to eq(:unselected)
+
+        subject.toggle
+
+        expect(subject.status).to eq(:selected)
+      end
+    end
+
+    context "when item is auto selected" do
+      let(:status) { :auto_selected }
+
+      it "changes to selected" do
+        expect(subject.status).to eq(:auto_selected)
+
+        subject.toggle
+
+        expect(subject.status).to eq(:selected)
+      end
+    end
+
+    context "when item has an unknown" do
+      it "changes to selected" do
+        expect(subject.status).to eq(nil)
+
+        subject.toggle
+
+        expect(subject.status).to eq(:selected)
+      end
+    end
+  end
+
+  describe "#enabled?" do
+    context "when enabled" do
+      let(:enabled) { true }
+
+      it "returns true" do
+        expect(subject.enabled?).to eq(true)
+      end
+    end
+
+    context "when not enabled" do
+      let(:enabled) { false }
+
+      it "returns false" do
+        expect(subject.enabled?).to eq(false)
+      end
+    end
+  end
+
+  describe "#selected?" do
+    context "when selected" do
+      let(:status) { :selected }
+
+      it "returns true" do
+        expect(subject.selected?).to eq(true)
+      end
+    end
+
+    context "when not selected" do
+      let(:status) { :whatever }
+
+      it "returns false" do
+        expect(subject.selected?).to eq(false)
+      end
+    end
+  end
+
+  describe "#select!" do
+    it "sets item as selected" do
+      subject.select!
+
+      expect(subject.status).to eq(:selected)
+    end
+  end
+
+  describe "#unselected?" do
+    context "when not selected" do
+      let(:status) { :whatever }
+
+      it "returns true" do
+        expect(subject.unselected?).to eq(true)
+      end
+    end
+
+    context "when selected" do
+      let(:status) { :selected }
+
+      it "returns false" do
+        expect(subject.unselected?).to eq(false)
+      end
+    end
+
+    context "when auto selected" do
+      let(:status) { :auto_selected }
+
+      it "returns false" do
+        expect(subject.unselected?).to eq(false)
+      end
+    end
+  end
+
+  describe "#unselect!" do
+    it "sets item as unselected" do
+      subject.unselect!
+
+      expect(subject.status).to eq(:unselected)
+    end
+  end
+
+  describe "#auto_selected?" do
+    context "when auto selected" do
+      let(:status) { :auto_selected }
+
+      it "returns true" do
+        expect(subject.auto_selected?).to eq(true)
+      end
+    end
+
+    context "when not auto selected" do
+      let(:status) { :selected }
+
+      it "returns false" do
+        expect(subject.auto_selected?).to eq(false)
+      end
+    end
+  end
+
+  describe "#auto_select!" do
+    it "sets item as auto selected" do
+      subject.auto_select!
+
+      expect(subject.status).to eq(:auto_selected)
+    end
+  end
+
+  describe "#to_s" do
+    it "returns a string" do
+      expect(subject.to_s).to be_a(String)
+    end
+
+    context "when the item is enabled" do
+      it "includes a link for the input" do
+        expect(subject.to_s).to match(regexp_input_link)
+      end
+
+      it "includes a link for the label" do
+        expect(subject.to_s).to match(regexp_label_link)
+      end
+    end
+
+    context "when the item is not enabled" do
+      let(:enabled) { false }
+
+      it "uses a grey color" do
+        expect(subject.to_s).to match(/.*color: grey.*/)
+      end
+
+      it "includes the item label" do
+        expect(subject.to_s).to include(subject.label)
+      end
+
+      it "does not include a link for the input" do
+        expect(subject.to_s).to_not match(regexp_input_link)
+      end
+
+      it "does not include a link for the label" do
+        expect(subject.to_s).to_not match(regexp_label_link)
+      end
+    end
+
+    context "when running in text mode" do
+      before { allow(Yast::UI).to receive(:TextMode).and_return(true) }
+
+      context "and the item is selected" do
+        let(:status) { :selected }
+
+        it "displays `[x]` as icon" do
+          expect(subject.to_s).to include("[x]")
+        end
+      end
+
+      context "and the item is auto selected" do
+        let(:status) { :auto_selected }
+
+        it "displays `[a]` as icon" do
+          expect(subject.to_s).to include("[a]")
+        end
+      end
+
+      context "and the item is not selected" do
+        let(:status) { :unselected }
+
+        it "displays `[ ]` as icon" do
+          expect(subject.to_s).to include("[ ]")
+        end
+      end
+
+      context "and the item has an unknown status" do
+        let(:status) { :unknown }
+
+        it "displays `[ ]` as icon" do
+          expect(subject.to_s).to include("[ ]")
+        end
+      end
+    end
+
+    context "when NOT running in text mode" do
+      before { allow(Yast::UI).to receive(:TextMode).and_return(false) }
+
+      context "and the item is selected" do
+        let(:status) { :selected }
+
+        it "displays the proper icon" do
+          expect(subject.to_s).to include("checkbox-on.svg")
+        end
+      end
+
+      context "and the item is auto selected" do
+        let(:status) { :auto_selected }
+
+        it "displays the proper icon" do
+          expect(subject.to_s).to include("auto-selected.svg")
+        end
+      end
+
+      context "and the item is not selected" do
+        let(:status) { :unselected }
+
+        it "displays the proper ion" do
+          expect(subject.to_s).to include("checkbox-off.svg")
+        end
+      end
+
+      context "and the item has an unknown status" do
+        let(:status) { :unknown }
+
+        it "displays the proper ion" do
+          expect(subject.to_s).to include("checkbox-off.svg")
+        end
+      end
+    end
+  end
+end

--- a/library/cwm/test/multi_status_selector_test.rb
+++ b/library/cwm/test/multi_status_selector_test.rb
@@ -65,6 +65,14 @@ describe CWM::MultiStatusSelector do
 
   include_examples "CWM::CustomWidget"
 
+  describe "#init" do
+    it "renders all items" do
+      expect(subject.items).to all(receive(:to_richtext))
+
+      subject.init
+    end
+  end
+
   describe "#handle" do
     let(:item) { subject.items.first }
     let(:event) { { "ID" => event_id } }

--- a/library/cwm/test/multi_status_selector_test.rb
+++ b/library/cwm/test/multi_status_selector_test.rb
@@ -229,18 +229,18 @@ describe CWM::MultiStatusSelector::Item do
     end
   end
 
-  describe "#to_s" do
+  describe "#to_richtext" do
     it "returns a string" do
-      expect(subject.to_s).to be_a(String)
+      expect(subject.to_richtext).to be_a(String)
     end
 
     context "when the item is enabled" do
       it "includes a link for the input" do
-        expect(subject.to_s).to match(regexp_input_link)
+        expect(subject.to_richtext).to match(regexp_input_link)
       end
 
       it "includes a link for the label" do
-        expect(subject.to_s).to match(regexp_label_link)
+        expect(subject.to_richtext).to match(regexp_label_link)
       end
     end
 
@@ -248,19 +248,19 @@ describe CWM::MultiStatusSelector::Item do
       let(:enabled) { false }
 
       it "uses a grey color" do
-        expect(subject.to_s).to match(/.*color: grey.*/)
+        expect(subject.to_richtext).to match(/.*color: grey.*/)
       end
 
       it "includes the item label" do
-        expect(subject.to_s).to include(subject.label)
+        expect(subject.to_richtext).to include(subject.label)
       end
 
       it "does not include a link for the input" do
-        expect(subject.to_s).to_not match(regexp_input_link)
+        expect(subject.to_richtext).to_not match(regexp_input_link)
       end
 
       it "does not include a link for the label" do
-        expect(subject.to_s).to_not match(regexp_label_link)
+        expect(subject.to_richtext).to_not match(regexp_label_link)
       end
     end
 
@@ -271,7 +271,7 @@ describe CWM::MultiStatusSelector::Item do
         let(:status) { :selected }
 
         it "displays `[x]` as icon" do
-          expect(subject.to_s).to include("[x]")
+          expect(subject.to_richtext).to include("[x]")
         end
       end
 
@@ -279,7 +279,7 @@ describe CWM::MultiStatusSelector::Item do
         let(:status) { :auto_selected }
 
         it "displays `[a]` as icon" do
-          expect(subject.to_s).to include("[a]")
+          expect(subject.to_richtext).to include("[a]")
         end
       end
 
@@ -287,7 +287,7 @@ describe CWM::MultiStatusSelector::Item do
         let(:status) { :unselected }
 
         it "displays `[ ]` as icon" do
-          expect(subject.to_s).to include("[ ]")
+          expect(subject.to_richtext).to include("[ ]")
         end
       end
 
@@ -295,7 +295,7 @@ describe CWM::MultiStatusSelector::Item do
         let(:status) { :unknown }
 
         it "displays `[ ]` as icon" do
-          expect(subject.to_s).to include("[ ]")
+          expect(subject.to_richtext).to include("[ ]")
         end
       end
     end
@@ -306,32 +306,32 @@ describe CWM::MultiStatusSelector::Item do
       context "and the item is selected" do
         let(:status) { :selected }
 
-        it "displays the proper icon" do
-          expect(subject.to_s).to include("checkbox-on.svg")
+        it "displays the selected icon" do
+          expect(subject.to_richtext).to include("checkbox-on.svg")
         end
       end
 
       context "and the item is auto selected" do
         let(:status) { :auto_selected }
 
-        it "displays the proper icon" do
-          expect(subject.to_s).to include("auto-selected.svg")
+        it "displays the auto-selected icon" do
+          expect(subject.to_richtext).to include("auto-selected.svg")
         end
       end
 
       context "and the item is not selected" do
         let(:status) { :unselected }
 
-        it "displays the proper ion" do
-          expect(subject.to_s).to include("checkbox-off.svg")
+        it "displays the unselected icon" do
+          expect(subject.to_richtext).to include("checkbox-off.svg")
         end
       end
 
       context "and the item has an unknown status" do
         let(:status) { :unknown }
 
-        it "displays the proper ion" do
-          expect(subject.to_s).to include("checkbox-off.svg")
+        it "displays the unselected icon" do
+          expect(subject.to_richtext).to include("checkbox-off.svg")
         end
       end
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 12 09:14:16 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Add the new CWM::MultiStatusSelector custom widget (related to
+  bsc#1157780, bsc#1161308, bsc#1161200).
+- 4.2.72
+
+-------------------------------------------------------------------
 Thu Mar 12 08:26:12 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not remove the installation repositories in the "Previously

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.71
+Version:        4.2.72
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## :construction:  Better PR description is WIP

> Providing following features:
>
>  - Allow to select more than one item.
>  - Able to represent multiple statuses: no selected, selected, auto selected.
>  - Able to represent disabled items.
>  - Emit different events to distinguish the interaction through check box input or its label.
>  - Automatic text wrapping.
>  - Keep the vertical scroll.


---

Related to 

* https://trello.com/c/CmaNrDAw
* https://github.com/yast/yast-registration/pull/483#discussion_r385108398