### PR TITLE
Do not remove the installation repositories (bsc#1163081)

### DIFF
--- a/library/packages/src/lib/y2packager/original_repository_setup.rb
+++ b/library/packages/src/lib/y2packager/original_repository_setup.rb
@@ -38,8 +38,11 @@ module Y2Packager
     end
 
     # Read and store the current repository/service setup.
-    def read
-      @repositories = Repository.all
+    # @param installation_repositories [Array<Y2Packager::Repository>]
+    def read(installation_repositories = [])
+      # skip the installation repositories, we need to keep them
+      aliases = installation_repositories.map(&:repo_alias)
+      @repositories = Repository.all.reject { |r| aliases.include?(r.repo_alias) }
       @services = Service.all
       log.info("Found #{repositories.size} repositories and #{services.size} services")
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar 12 08:26:12 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not remove the installation repositories in the "Previously
+  Used Repositories" step (bsc#1163081)
+- 4.2.71
+
+-------------------------------------------------------------------
 Fri Mar  6 13:26:57 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Allow to restore the vertical scroll of a CWM::RichText

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.70
+Version:        4.2.71
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Do not remove the installation repositories in the "Previously Used Repositories" step
- https://bugzilla.suse.com/show_bug.cgi?id=1163081
- https://openqa.opensuse.org/tests/1194286#step/upgrade_select/3
- Tested manually
- 4.2.71