### PR TITLE
[CWM] Minor improvements for the MultiStatusSelector widget

### DIFF
--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -175,7 +175,17 @@ module CWM
 
     # Updates the content based on items list
     def refresh
-      content.value = items.map(&:to_richtext).join("<br>")
+      new_value = items.map do |item|
+        item_content = item.to_richtext
+
+        if Yast::UI.TextMode
+          "#{item_content}<br>"
+        else
+          "<p>#{item_content}</p>"
+        end
+      end
+
+      content.value = new_value.join
     end
 
     # Convenience widget to keep the content updated

--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -121,6 +121,21 @@ module CWM
       HBox(content)
     end
 
+    # Updates the content based on items list
+    def refresh
+      new_value = items.map do |item|
+        item_content = item.to_richtext
+
+        if Yast::UI.TextMode
+          "#{item_content}<br>"
+        else
+          "<p>#{item_content}</p>"
+        end
+      end
+
+      content.value = new_value.join
+    end
+
     # @macro seeAbstractWidget
     def handle(event)
       if event["ID"].to_s.include?(Item.event_id)
@@ -171,21 +186,6 @@ module CWM
     # @return [Item, nil] the item which id matches with given object#to_s
     def find_item(needle)
       items.find { |i| i.id.to_s == needle.to_s }
-    end
-
-    # Updates the content based on items list
-    def refresh
-      new_value = items.map do |item|
-        item_content = item.to_richtext
-
-        if Yast::UI.TextMode
-          "#{item_content}<br>"
-        else
-          "<p>#{item_content}</p>"
-        end
-      end
-
-      content.value = new_value.join
     end
 
     # Convenience widget to keep the content updated

--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -210,6 +210,8 @@ module CWM
     class Item
       extend Yast::I18n
 
+      textdomain "base"
+
       # Map to icons used in GUI to represent all the known statuses in both scenarios, during
       # installation (`inst` mode) and in a running system (`normal` mode).
       #
@@ -260,8 +262,6 @@ module CWM
       # Id to identify an event fired by the check box label
       LABEL_EVENT_ID = "#{EVENT_ID}label".freeze
       private_constant :LABEL_EVENT_ID
-
-      textdomain "cwm"
 
       # @!method id
       #   The item id

--- a/library/cwm/test/multi_status_selector_test.rb
+++ b/library/cwm/test/multi_status_selector_test.rb
@@ -62,8 +62,47 @@ describe CWM::MultiStatusSelector do
   let(:first_item) { { id: 1, status: :selected, enabled: false } }
   let(:second_item) { { id: 2, status: :unselected, enabled: true } }
   let(:items) { [first_item, second_item] }
+  let(:content) { subject.contents.nested_find { |i| i.is_a?(CWM::RichText) } }
 
   include_examples "CWM::CustomWidget"
+
+  describe "#refresh" do
+    before do
+      allow(Yast::UI).to receive(:TextMode).and_return(text_mode)
+    end
+
+    context "when running in text mode" do
+      let(:text_mode) { true }
+
+      it "includes <br> tags" do
+        expect(content).to receive(:value=).with(/<br>/)
+
+        subject.refresh
+      end
+
+      it "does not include <p> tags" do
+        expect(content).to_not receive(:value=).with(/<p>/)
+
+        subject.refresh
+      end
+    end
+
+    context "when not running in text mode" do
+      let(:text_mode) { false }
+
+      it "includes <p> tags" do
+        expect(content).to receive(:value=).with(/<p>/)
+
+        subject.refresh
+      end
+
+      it "does not include <br> tags" do
+        expect(content).to_not receive(:value=).with(/<br>/)
+
+        subject.refresh
+      end
+    end
+  end
 
   describe "#init" do
     it "renders all items" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 13 01:54:58 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- CWM::MultiStatusSelector minor improvements (related to
+  bsc#1157780).
+- 4.2.73
+
+-------------------------------------------------------------------
 Thu Mar 12 09:14:16 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Add the new CWM::MultiStatusSelector custom widget (related to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.72
+Version:        4.2.73
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
### Problem

There is not enough space between items when running in Qt

### Solution

To surround items in `<p>` when not running in text mode.

## Screenshots

<details>
<summary>Click to show/hide</summary>

---

#### Before

![Screenshot_sl5sp2_2020-03-13_01:13:27](https://user-images.githubusercontent.com/1691872/76582459-3432b380-64ce-11ea-8086-e9399a80fe59.png)

#### After

![Screenshot_sl5sp2_2020-03-13_02:05:47](https://user-images.githubusercontent.com/1691872/76582789-2cbfda00-64cf-11ea-8761-6b7e979026b1.png)


</details>

---

See also https://github.com/yast/yast-yast2/pull/1029