### PR TITLE
Fixed CWM::MultiStatusSelector help text icons

### DIFF
--- a/library/cwm/src/lib/cwm/multi_status_selector.rb
+++ b/library/cwm/src/lib/cwm/multi_status_selector.rb
@@ -299,12 +299,12 @@ module CWM
       def self.help
         help_text = "<p>"
         # TRANSLATORS: help text for a not selected check box
-        help_text << "#{icon_for(UNSELECTED)} = #{_("Not selected")}<br />"
+        help_text << "#{icon_for(UNSELECTED, mode: mode)} = #{_("Not selected")}<br />"
         # TRANSLATORS: help text for a selected check box
-        help_text << "#{icon_for(SELECTED)} = #{_("Selected")}<br />"
+        help_text << "#{icon_for(SELECTED, mode: mode)} = #{_("Selected")}<br />"
         # TRANSLATORS: help text for an automatically selected check box
         # (it has a different look that a user selected check box)
-        help_text << "#{icon_for(AUTO_SELECTED)} = #{_("Auto selected")}"
+        help_text << "#{icon_for(AUTO_SELECTED, mode: mode)} = #{_("Auto selected")}"
         help_text << "</p>"
         help_text
       end
@@ -405,11 +405,28 @@ module CWM
         "#{checkbox_input} #{checkbox_label}"
       end
 
+      # Determines whether running in installation mode
+      #
+      # We do not use Stage.initial because of firstboot, which runs in 'installation' mode
+      # but in 'firstboot' stage.
+      #
+      # @return [Boolean] Boolean if running in installation or update mode
+      def self.installation?
+        Yast::Mode.installation || Yast::Mode.update
+      end
+
+      # Returns the current mode
+      #
+      # @return [String] "normal" in a running system; "inst" during the installation
+      def self.mode
+        installation? ? "inst" : "normal"
+      end
+
     private
 
       # @see .icon_for
       def icon
-        self.class.icon_for(status, mode: mode, state: state)
+        self.class.icon_for(status, mode: self.class.mode, state: state)
       end
 
       # Builds the check box input representation
@@ -434,13 +451,6 @@ module CWM
         end
       end
 
-      # Returns the current mode
-      #
-      # @return [String] "normal" in a running system; "inst" during the installation
-      def mode
-        installation? ? "inst" : "normal"
-      end
-
       # Returns the current input state
       #
       # @return [String] "enabled" when item must be enabled; "disabled" otherwise
@@ -462,19 +472,9 @@ module CWM
       #                  "black" otherwise
       def color
         return "grey" unless enabled?
-        return "white" if installation?
+        return "white" if self.class.installation?
 
         "black"
-      end
-
-      # Determines whether running in installation mode
-      #
-      # We do not use Stage.initial because of firstboot, which runs in 'installation' mode
-      # but in 'firstboot' stage.
-      #
-      # @return [Boolean] Boolean if running in installation or update mode
-      def installation?
-        Yast::Mode.installation || Yast::Mode.update
       end
     end
   end

--- a/library/cwm/test/multi_status_selector_test.rb
+++ b/library/cwm/test/multi_status_selector_test.rb
@@ -436,4 +436,28 @@ describe CWM::MultiStatusSelector::Item do
       end
     end
   end
+
+  describe ".help" do
+    context "in installation" do
+      before do
+        allow(Yast::Mode).to receive(:installation).and_return(true)
+        allow(Yast::Mode).to receive(:update).and_return(false)
+      end
+
+      it "uses the installation icon" do
+        expect(subject.class.help).to include("inst_checkbox-on.svg")
+      end
+    end
+
+    context "in installed system" do
+      before do
+        allow(Yast::Mode).to receive(:installation).and_return(false)
+        allow(Yast::Mode).to receive(:update).and_return(false)
+      end
+
+      it "uses the standard icon" do
+        expect(subject.class.help).to include("checkbox-on.svg")
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 17 15:46:35 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed CWM::MultiStatusSelector help text icons displayed during
+  installation (related to bsc#1157780, bsc#1161308, bsc#1161200)
+- 4.2.74
+
+-------------------------------------------------------------------
 Fri Mar 13 01:54:58 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - CWM::MultiStatusSelector minor improvements (related to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.73
+Version:        4.2.74
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## The Problem
- The help text icons were not displayed properly in installation (installed system was OK)
- The problem was that the `icon_for` method call did not pass the current mode and it used the default "normal" 
- Because the `help` method is a class method I had to change some helpers to be class methods as well
- 4.2.74

## Screenshots

| Original | Fixed |
|-|-|
| ![Screenshot_sl5sp2_2020-03-13_01:13:38](https://user-images.githubusercontent.com/1691872/76581274-b28d5680-64ca-11ea-99b7-359ebf6b6811.png) | ![help_icons](https://user-images.githubusercontent.com/907998/76936794-d6e69a00-68f3-11ea-966a-5ba859e34cbe.png) |
