### PR TITLE
Reset firewall API instance when reading (bsc#1166698)

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld.rb
+++ b/library/network/src/lib/y2firewall/firewalld.rb
@@ -91,6 +91,9 @@ module Y2Firewall
     def read(minimal: false)
       return false unless installed?
 
+      # Force a reset of the API instance when reading the first time (bsc#1166698)
+      @api = nil
+
       @current_zone_names = api.zones
       @current_service_names = api.services
       if minimal
@@ -266,6 +269,7 @@ module Y2Firewall
     def reset
       load_defaults
       untouched!
+      @api = nil
       @read = false
     end
 

--- a/library/network/test/y2firewall/firewalld_test.rb
+++ b/library/network/test/y2firewall/firewalld_test.rb
@@ -244,13 +244,20 @@ describe Y2Firewall::Firewalld do
     end
 
     before do
-      allow(firewalld).to receive("api").and_return api
+      allow(Y2Firewall::Firewalld::Api).to receive(:new).and_return(api)
     end
 
     it "returns false if firewalld is not installed" do
       allow(firewalld).to receive(:installed?).and_return(false)
 
       expect(firewalld.read).to eq(false)
+    end
+
+    it "resets the firewalld api instance" do
+      expect(Y2Firewall::Firewalld::Api).to receive(:new).twice.and_return(:first, api)
+      api = firewalld.api
+      firewalld.read
+      expect(firewalld.api).to_not eq(api)
     end
 
     it "stores the list of available zone names" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sat Mar 21 11:56:41 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Force a reset of the firewalld API instance before reading the
+  firewalld configuration (bsc#1166698)
+- 4.2.75
+
+-------------------------------------------------------------------
 Tue Mar 17 15:46:35 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed CWM::MultiStatusSelector help text icons displayed during

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.74
+Version:        4.2.75
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

**firewalld auto** client runs before the **tftp server** one modifying the firewalld service state. The problem is that the firewalld **API** instance is cached and thus, the tftp server uses the **online cmd** instead of the **offline**.

- https://trello.com/c/oKLCTb39/1719-3-sle15-sp2-1166698-ay-failed-at-tftpserverauto-with-error-firewalld-not-working
- https://bugzilla.suse.com/show_bug.cgi?id=1166698

## Solution

- Forcing a reset of the firewalld API instance after modifying the service state should be enough for fixing the bug (https://github.com/yast/yast-firewall/pull/128). But as the service state could be modified by other clients, forcing a reset before reading is safer and that is what also has been implemented.

## Screenshots

<details>
  <summary>Before the fix</summary>

![Screenshot_testing_2020-03-21_10:47:59](https://user-images.githubusercontent.com/7056681/77226599-7b294480-6b71-11ea-93d1-a9721c014da3.png)
</details>
<details>
  <summary>After the fix</summary>

![Screenshot_testing_2020-03-21_11:13:59](https://user-images.githubusercontent.com/7056681/77226601-7cf30800-6b71-11ea-9666-3e70977d2e81.png)
</details>

