### PR TITLE
Retranslate wizard help button in NCurses (bsc#1167224)

### DIFF
--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -1355,6 +1355,7 @@ module Yast
     # Wizard::OpenNextBackDialog(), or Wizard::OpenAcceptDialog().
     #
     def RetranslateButtons
+      textdomain "base" # Reload translations
       if UI.WidgetExists(Id(:WizardDialog)) == true # NCurses wizard
         UI.ChangeWidget(Id(:help), :Label, Label.HelpButton) if UI.WidgetExists(Id(:help))
         ReplaceButtonBox(

--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -1351,19 +1351,20 @@ module Yast
     # Retranslate the wizard buttons.
     #
     # This will revert button labels and IDs
-    # to the default that were used upon Wizard::CreateDialog(),
+    # to the defaults that were used upon Wizard::CreateDialog(),
     # Wizard::OpenNextBackDialog(), or Wizard::OpenAcceptDialog().
     #
     def RetranslateButtons
-      if UI.WidgetExists(Id(:WizardDialog)) == true
+      if UI.WidgetExists(Id(:WizardDialog)) == true # NCurses wizard
+        UI.ChangeWidget(Id(:help), :Label, Label.HelpButton) if UI.WidgetExists(Id(:help))
         ReplaceButtonBox(
           if UI.WidgetExists(Id(:accept))
             AbortAcceptButtonBox()
           else
             BackAbortNextButtonBox()
           end
-        ) # Qt wizard
-      else
+        )
+      else # Qt wizard
         UI.WizardCommand(term(:RetranslateInternalButtons))
 
         if UI.WidgetExists(:accept)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Apr  7 08:33:55 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Retranslate wizard help button in NCurses UI (bsc#1167224)
+- 4.2.81
+
+-------------------------------------------------------------------
 Fri Apr  3 09:55:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Modify the way YaST detects whether systemd is running or not

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.80
+Version:        4.2.81
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1167224

## Problem

The wizard "Help" button is not retranslated when changing the language.
This happens only in the NCurses wizard.

## Cause

The Wizard.rb module is a wrapper around the YQWizard widget and an emulation of its functionality for NCurses.

For the Qt UI, this uses `RetranslateInternalButtons()` to retranslate the "static" buttons of the wizard such as "Help".

For the NCurses UI, this was completely missing; so while buttons like "Back", "Abort", "Next" were correctly retranslated, the "Help" button was not.


## Fix

Set the label again for the "Help" button so the correctly translated text is now used.

## Screenshot

![russian-help](https://user-images.githubusercontent.com/11538225/78580118-3e787100-7832-11ea-9b7b-158336617e5c.png)


Notice the Russian "Help" button (the leftmost one on the bottom: `[Справка]`)

## Hidden Problem

That entire `Wizard::RetranslateButtons()` function turned out to be a giant NOP: Full debug logging showed that the `UI.ReplaceWidget()` call received translations in the _previous_ language, not the one that the user just selected.

Only some operations later, the buttons would actually be translated by `Wizard.SetNextButton()` etc. calls from some different code location. It was pure coincidence that this worked at all.

## Workaround for the Hidden Problem

One more `textdomain` call in `Wizard::RetranslateButtons()` to trigger reloading the translations. It must be hidden somewhere here:

https://github.com/grosser/fast_gettext/blob/master/lib/fast_gettext.rb

And this would deserve a real fix rather than this workaround if we'd use it in a more places, but right now we are only using switching languages on the fly at this place, in the first step of the installation (_inst_complex_welcome_).

## Test

Tested with SLE-15-SP2-Online-x86_64-Build170.1-Media1.iso .


## For SLE-15-SP2?

Yes according to @jsrain.