### PR TITLE
Change the way YaST determines if systemd is running or not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
 script:
   # the "yast-travis-ruby" script is included in the base yastdevel/ruby image
   # see https://github.com/yast/docker-yast-ruby/blob/master/yast-travis-ruby
-  - docker run -it -e TRAVIS=1 -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-yast2-image yast-travis-ruby
+  - docker run -it -e TRAVIS=1 --privileged -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" yast-yast2-image yast-travis-ruby

--- a/library/systemd/src/modules/Systemd.rb
+++ b/library/systemd/src/modules/Systemd.rb
@@ -38,7 +38,6 @@ module Yast
       @systemd_path = "/usr/lib/systemd/systemd"
       @default_target_symlink = "/etc/systemd/system/default.target"
       @systemd_targets_dir = "/usr/lib/systemd/system"
-      @systemd_mountdir = "/sys/fs/cgroup/systemd"
 
       textdomain "base"
     end
@@ -52,7 +51,7 @@ module Yast
     # Check whether systemd init is currently running
     # @return boolean true if systemd init is running
     def Running
-      FileUtils.IsDirectory(@systemd_mountdir) == true
+      SCR.Read(path(".target.string"), "/proc/1/comm")&.chomp == "systemd"
     end
 
     # Set default runlevel for systemd (assumes systemd is installed)

--- a/library/systemd/src/modules/Systemd.rb
+++ b/library/systemd/src/modules/Systemd.rb
@@ -51,7 +51,7 @@ module Yast
     # Check whether systemd init is currently running
     # @return boolean true if systemd init is running
     def Running
-      SCR.Read(path(".local.string"), "/proc/1/comm")&.chomp == "systemd"
+      WFM.Read(path(".local.string"), "/proc/1/comm")&.chomp == "systemd"
     end
 
     # Set default runlevel for systemd (assumes systemd is installed)

--- a/library/systemd/src/modules/Systemd.rb
+++ b/library/systemd/src/modules/Systemd.rb
@@ -51,7 +51,7 @@ module Yast
     # Check whether systemd init is currently running
     # @return boolean true if systemd init is running
     def Running
-      SCR.Read(path(".target.string"), "/proc/1/comm")&.chomp == "systemd"
+      SCR.Read(path(".local.string"), "/proc/1/comm")&.chomp == "systemd"
     end
 
     # Set default runlevel for systemd (assumes systemd is installed)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr  3 09:55:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Modify the way YaST detects whether systemd is running or not
+  (bsc#1168307)
+- 4.2.80
+
+-------------------------------------------------------------------
 Fri Mar 27 13:12:00 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Reread network interfaces configuration after writing it avoiding

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.79
+Version:        4.2.80
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

YaST network does not show the global tab in the running system because it checks whether systemd is running or not and it is not properly detected since a change in the sysfs cgroup systemd hierarchy

- https://trello.com/c/9eYR4f6p/4042-tw-p2-1168307-lan-no-global-tab-sys-fs-cgroup-systemd-no-such-file-or-directory

## Solution

Change the way YaST determines if systemd is running.

## Test

Tested manually in a running system running the **yast2 network** module and in WSL.