### PR TITLE
Remove CONTRIBUTING.md from the spec file

### DIFF
--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -225,7 +225,6 @@ fi
 # documentation (not included in devel subpackage)
 %doc %dir %{yast_docdir}
 %license %{yast_docdir}/COPYING
-%doc %{yast_docdir}/CONTRIBUTING.md
 %doc %{yast_docdir}/README.md
 
 %{_mandir}/*/*


### PR DESCRIPTION
## Problem

The **CONTRIBUTING.md** file was removed (#1042) from the repository but the file is still referenced in the spec file

## Solution

Remove the file from the spec file
