### PR TITLE
CWM improvements

### DIFF
--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -184,6 +184,14 @@ module CWM
     include ValueBasedWidget
     include ItemsSelection
     abstract_method :label
+
+    alias_method :orig_value=, :value=
+    def value=(val)
+      if opt.include?(:editable) && !items.map(&:first).include?(val)
+        change_items([[val, val]] + items)
+      end
+      self.orig_value = val
+    end
   end
 
   # Widget representing selection box to select value.

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -357,6 +357,14 @@ module CWM
 
     include ItemsSelection
     abstract_method :label
+
+    # @see AbstractWidget#cwm_definition
+    # @return [WidgetHash]
+    def cwm_definition
+      res = super
+      res["handle_events"] = items.map(&:first) unless handle_all_events
+      res
+    end
   end
 
   # Multiline text widget

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -187,10 +187,14 @@ module CWM
 
     alias_method :orig_value=, :value=
     def value=(val)
-      if opt.include?(:editable) && !items.map(&:first).include?(val)
-        change_items([[val, val]] + items)
-      end
+      change_items([[val, val]] + items) if editable? && !items.map(&:first).include?(val)
       self.orig_value = val
+    end
+
+  private
+
+    def editable?
+      opt.include?(:editable)
     end
   end
 

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -186,6 +186,13 @@ module CWM
     abstract_method :label
 
     alias_method :orig_value=, :value=
+
+    # Sets the current value
+    #
+    # If the given value is not in the list of items but the widget is editable,
+    # the item is added to the list.
+    #
+    # @param val [Object] Value to assign to the widget
     def value=(val)
       change_items([[val, val]] + items) if editable? && !items.map(&:first).include?(val)
       self.orig_value = val

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -110,3 +110,30 @@ describe CWM::RichText do
     end
   end
 end
+
+describe CWM::ComboBox do
+  class MountPointSelector < CWM::ComboBox
+    def label
+      ""
+    end
+
+    def opt
+      [:editable]
+    end
+
+    def items
+      [["/", "/ (root)"]]
+    end
+  end
+
+  subject { MountPointSelector.new }
+
+  describe "#value=" do
+    describe "when the widget is editable" do
+      it "adds the given value to the list of items" do
+        expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
+        subject.value = "/srv"
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Fri Sep 25 08:59:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Small improvements to CWM based widgets (related to bsc#1136454):
+  - An editable ComboBox will refresh the list of items when a new
+    one is given as its current value.
+  - By default, a MenuButton widget listens to events from all its
+    buttons.
+- 4.3.31
+
+-------------------------------------------------------------------
 Thu Sep 24 07:25:01 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Do not crash when trying to parse non-existing ("nil") add-on

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.30
+Version:        4.3.31
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Two small improvements after the first review of https://github.com/yast/yast-autoinstallation/pull/592.

* When setting the value of a `ComboBox` item, the new value will be added to the list of items if it was not already included and the combo is editable.
* A MenuButton listens to events from its children.