### PR TITLE
Remove deleted secondary IP addresses

### DIFF
--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1609,7 +1609,7 @@ module Yast
     #   removed
     # @param alias_num [String] index num of the alias that needs to be removed
     def delete_alias(devices, iface, alias_num)
-      dev_map = devices.values.find { |d| d.keys.include? (iface) } || {}
+      dev_map = devices.values.find { |d| d.keys.include?(iface) } || {}
       dev_aliases = dev_map.fetch(iface, {}).fetch("_aliases", {})
 
       base = path(".network.value") + iface

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -800,12 +800,11 @@ module Yast
 
       # remove deleted devices
       log.info("Deleted=#{@Deleted}")
-      Builtins.foreach(@Deleted) do |d|
-        # delete config file
-        p = Builtins.add(path(".network.section"), d)
-        log.debug("deleting: #{p}")
-        SCR.Write(p, nil)
+      @Deleted.each do |d|
+        iface, alias_num = d.split("#")
+        alias_num ? delete_alias(original_devs, iface, alias_num) : delete_device(iface)
       end
+
       @Deleted = []
 
       # write all devices
@@ -1589,6 +1588,39 @@ module Yast
 
       log.debug "devices=#{devices}"
       devices
+    end
+
+    # Convenience method to delete an interface config file from the system
+    #
+    # @param iface [String] interface name of the config file to be deleted
+    def delete_device(iface)
+      # delete config file
+      p = path(".network.section") + iface
+      log.debug("deleting: #{p}")
+      SCR.Write(p, nil)
+    end
+
+    # Convenience method to delete an specific ip alias from an interface
+    # config file
+    #
+    # @param devices [Hash<String, Hash<String, Object>>] hash with the devices
+    #   to remove the aliases from
+    # @param iface [String] interface name of the alias which alias need to be
+    #   removed
+    # @param alias_num [String] index num of the alias that needs to be removed
+    def delete_alias(devices, iface, alias_num)
+      dev_map = devices.values.find { |d| d.keys.include? (iface) } || {}
+      dev_aliases = dev_map.fetch(iface, {}).fetch("_aliases", {})
+
+      base = path(".network.value") + iface
+      # look in OriginalDevs because we need to catch all variables
+      # of the alias
+
+      dev_aliases.fetch(alias_num, {}).keys.each do |key|
+        p = base + "#{key}_#{alias_num}"
+        log.debug("deleting: #{p}")
+        SCR.Write(p, nil)
+      end
     end
 
     publish variable: :Name, type: "string"

--- a/library/network/src/modules/NetworkInterfaces.rb
+++ b/library/network/src/modules/NetworkInterfaces.rb
@@ -1594,7 +1594,6 @@ module Yast
     #
     # @param iface [String] interface name of the config file to be deleted
     def delete_device(iface)
-      # delete config file
       p = path(".network.section") + iface
       log.debug("deleting: #{p}")
       SCR.Write(p, nil)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 13 12:36:58 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Remove ip aliases that were marked to be deleted from the
+  interface configuration files (bsc#1146020)
+- 4.1.77
+
+-------------------------------------------------------------------
 Wed Mar 25 12:12:00 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Reread network interfaces configuration after writing it avoiding

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.76
+Version:        4.1.77
 
 Release:        0
 Summary:        YaST2 - Main Package


### PR DESCRIPTION
## Problem

Removed secondary IP addresses through the yast2-network dialog are marked to be deleted but are not removed from the ifcfg files since (https://github.com/yast/yast-yast2/pull/789)

- https://trello.com/c/xHnv0zCT/4047-osdistribution-p5-1146020-setting-additional-ip-addresses-in-eth-adapter-configurations-delete-of-additional-ip-address-not-poss
- https://bugzilla.suse.com/show_bug.cgi?id=1146020

## Solution

Delete not only removed interfaces but also removed secondary IP addresses.
