### PR TITLE
Bnc#1081441

### DIFF
--- a/library/control/src/modules/InstError.rb
+++ b/library/control/src/modules/InstError.rb
@@ -109,7 +109,7 @@ module Yast
     # @param [String] details (displayed as a plain text, can contain multiple lines)
     def ShowErrorPopUp(heading, error_text, details)
       bugzilla_url = "http://bugzilla.suse.com/"
-      bugzilla_url = "http://bugzilla.opensuse.org" if OSRelease.ReleaseName.include? 'openSUSE'
+      bugzilla_url = "http://bugzilla.opensuse.org" if OSRelease.ReleaseName.include? "openSUSE"
       success = UI.OpenDialog(
         Opt(:decorated, :warncolor),
         VBox(

--- a/library/control/src/modules/InstError.rb
+++ b/library/control/src/modules/InstError.rb
@@ -40,6 +40,7 @@ module Yast
       Yast.import "Label"
       Yast.import "String"
       Yast.import "Report"
+      Yast.import "OSRelease"
     end
 
     def SaveLogs
@@ -107,6 +108,8 @@ module Yast
     # @param [String] error_text
     # @param [String] details (displayed as a plain text, can contain multiple lines)
     def ShowErrorPopUp(heading, error_text, details)
+      bugzilla_url = "http://bugzilla.suse.com/"
+      bugzilla_url = "http://bugzilla.opensuse.org" if OSRelease.ReleaseName.include? 'openSUSE'
       success = UI.OpenDialog(
         Opt(:decorated, :warncolor),
         VBox(
@@ -146,7 +149,7 @@ module Yast
                         "Please, attach also all YaST logs stored in the '%2' directory.\n" \
                         "See %3 for more information about YaST logs."
                     ),
-                    "http://bugzilla.suse.com/",
+                    bugzilla_url,
                     "/var/log/YaST2/",
                     # link to the Yast Bug Reporting HOWTO
                     # for translators: use the localized page for your language if it exists,


### PR DESCRIPTION
Display appropriate Bugzilla URL depending on the release name of the product on which the error occurred.

In case of an error, the error dialog will request the user to file a report on https://bugzilla.opensuse.org when the release name in `/etc/os-release` contains "openSUSE". For any other release name, the
Bugzilla URL displayed would be https://bugzilla.suse.com.

## Screenshots

**Before**
![Error Screenshot on any SUSE release](https://user-images.githubusercontent.com/1150476/79381536-c1f73800-7f7f-11ea-9003-142a541649cf.png)

**After (on openSUSE system)**
![Error Screenshot on openSUSE](https://user-images.githubusercontent.com/1150476/79381632-e521e780-7f7f-11ea-869d-6ed93ebfef95.png)

I tested this by commenting out **NAME=** attribute from `/etc/os-release` file. In this case, the `OSRelease.ReleaseName` method will return the default value of "SUSE Linux" and in that case, https://bugzilla.suse.com URL is displayed to the user.

Fixes [bsc#1081441](https://bugzilla.novell.com/show_bug.cgi?id=1081441)