### PR TITLE
Running chrooted fix

### DIFF
--- a/library/systemd/src/lib/yast2/systemd/unit.rb
+++ b/library/systemd/src/lib/yast2/systemd/unit.rb
@@ -106,7 +106,9 @@ module Yast2
       # @return [Yast2::Systemd::UnitProperties]
       def show(property_text = nil)
         # Using different handler during first stage (installation, update, ...)
-        if Yast::Stage.initial && !Yast::Systemd.Running
+        # Avoid to call systemctl when running inside a chroot (bsc#1168849) as
+        # it reports an error by default.
+        if Yast::WFM.scr_chrooted? || (Yast::Stage.initial && !Yast::Systemd.Running)
           UnitInstallationProperties.new(self)
         else
           UnitProperties.new(self, property_text)

--- a/library/systemd/test/yast2/systemctl_test.rb
+++ b/library/systemd/test/yast2/systemctl_test.rb
@@ -9,6 +9,7 @@ module Yast2
 
     before do
       allow(Yast::Systemd).to receive(:Running).and_return(true)
+      allow(Yast::WFM).to receive(:scr_chrooted?).and_return(false)
     end
 
     describe ".execute" do

--- a/library/systemd/test/yast2/systemd_unit_test.rb
+++ b/library/systemd/test/yast2/systemd_unit_test.rb
@@ -22,7 +22,8 @@ module Yast2
     context "Installation system without full support of systemd" do
       before do
         allow(Yast::Stage).to receive(:initial).and_return(true)
-        allow(Yast::Systemd).to receive(:Running).and_return(false)
+        allow(Yast::WFM).to receive(:scr_chrooted?).and_return(true)
+        allow(Yast::Systemd).to receive(:Running).and_return(true)
       end
 
       describe "#properties" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Apr 24 14:53:03 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Avoid using systemctl calls when already started with the
+  installation and thus, running inside the chroot (bsc#1168849)
+- 4.2.83
+
+-------------------------------------------------------------------
 Mon Apr 13 12:36:58 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Remove ip aliases that were marked to be deleted from the

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.82
+Version:        4.2.83
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

In case of a live installation, systemd is detected as running failing in case we try to show the properties of a systemd unit.

- https://bugzilla.suse.com/show_bug.cgi?id=1168849

## Solution

- Check whether we are running inside a chroot in order to return the systemd unit properties.