### PR TITLE
Document X-SuSE-DocTeamID key for .desktop files

### DIFF
--- a/doc/desktop_file.md
+++ b/doc/desktop_file.md
@@ -112,3 +112,8 @@ Auto prefix:
 * *X-SuSE-YaST-AutoLogResource* Specifies whether data in profile can be logged.
   Useful if data contains sensitive information. Possible values are `true` and
   `false`. By default `true`.
+
+## Miscellaneous Keys
+
+* *X-SuSE-DocTeamID* Specifies the identifier to be used when translating
+  the module's name. To be used by `Yast::Builtins.dpgettext`.


### PR DESCRIPTION
Document `X-SuSE-DocTeamID` key seen while working on https://github.com/yast/yast-autoinstallation/pull/604.