### PR TITLE
Restore back the perl-XML-Simple dependency

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 18 08:21:09 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Restore back the perl-XML-Simple dependency, it is needed for
+  ag_anyxml (related to bsc#1170886)
+- 4.3.1
+
+-------------------------------------------------------------------
 Thu May 14 07:32:16 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Re-implement XML parser (bsc#1170886):

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only
@@ -69,6 +69,8 @@ BuildRequires:  rpm
 Requires:       coreutils
 # for GPG.ycp
 Requires:       gpg2
+# for ag_anyxml
+Requires:       perl-XML-Simple
 # for defining abstract methods in libraries
 Requires:       rubygem(%{rb_default_ruby_abi}:abstract_method)
 # for file access using augeas


### PR DESCRIPTION
- Fixes build failure in `yast2-packager`
- It is needed for `anyxml` agent
- Related to [bsc#1170886](https://bugzilla.suse.com/show_bug.cgi?id=1170886)
- 4.3.1