### PR TITLE
Improve the XML validation

### DIFF
--- a/library/xml/test/xml_test.rb
+++ b/library/xml/test/xml_test.rb
@@ -524,7 +524,7 @@ describe "Yast::XML" do
        </element>'
     end
 
-    it "returns array for valid xml" do
+    it "returns empty array for valid xml" do
       xml = '<?xml version="1.0"?>
              <test>
                <person>
@@ -551,6 +551,23 @@ describe "Yast::XML" do
              </test>'
 
       expect(Yast::XML.validate(xml, schema)).to_not be_empty
+    end
+
+    it "raises XMLDeserializationError for a not well formed XML" do
+      # make the document invalid by commenting out a closing tag
+      xml = '<?xml version="1.0"?>
+             <test>
+               <person>
+                 <name>
+                   clark
+                 </name>
+                 <voice>
+                   nice
+                 </voice>
+               <!-- </person> -->
+             </test>'
+
+      expect { Yast::XML.validate(xml, schema) }.to raise_error(Yast::XMLDeserializationError)
     end
   end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun  1 08:45:51 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improved XML validation, raise exception for not well formed
+  documents (related to bsc#1170886)
+- 4.3.3
+
+-------------------------------------------------------------------
 Fri May 29 05:21:09 UTC 2020 - schubi@suse.de
 
 - autoinst_issues/list.add : Fixed documentation.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Check also that the XML is well formed. If there is a syntax error then raise the `XMLDeserializationError` exception.

The parsing method `XMLToYCPString` runs the Nokogiri parser in strict mode and raises the `XMLDeserializationError` exception on parse error. It should behave consistently so the validation should also check that the document is well formed. (Nokogiri by default uses the recovery mode which automatically adds missing closing tags, etc...)