### PR TITLE
Fix system service actions

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun  5 15:13:42 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Improve actions to stop and start a system service.
+- Related to bsc#1162514.
+- 4.1.78
+
+-------------------------------------------------------------------
 Mon Apr 13 12:36:58 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Remove ip aliases that were marked to be deleted from the

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.77
+Version:        4.1.78
 
 Release:        0
 Summary:        YaST2 - Main Package


### PR DESCRIPTION
## Problem

When a systemd service is initially stopped, the `SystemService` object will always consider the service as stopped. But sometimes the service could be started later via its socket. In that case, if we set the service to be restarted, the systemd service would never be stopped because `SystemService` believes that the systemd service continues stopped.

Moreover, in case that the service is configured to be started on demand, `SystemService` tries to start the socket instead of the service. But it would fail to start the socket because the service is already running.

* https://bugzilla.suse.com/show_bug.cgi?id=1162514
* https://trello.com/c/gEHPeax1/1882-sles15-sp1-p5-1162514-iscsi-session-is-not-connected-after-successful-connection-via-yast2-iscsi-client

## Solution

There are two possible solutions:

a) To check the current systemd status on the system to determine whether to stop/start the service.

b) Always try to stop/start the service independently on its current state.

Option b) was implemented. When a systemd service is already stopped, another call to `systemctl stop service` does not affect at all. And the same happens when trying to start an already started service.

## Testing

* Manually tested
* Adapted unit tests
