### PR TITLE
Updated Yast::XML.validate arguments

### DIFF
--- a/library/xml/src/modules/XML.rb
+++ b/library/xml/src/modules/XML.rb
@@ -23,6 +23,7 @@
 require "yast"
 
 require "nokogiri"
+require "pathname"
 
 module Yast
   # Exception used when trying to serialize a Ruby object that we cannot
@@ -191,19 +192,19 @@ module Yast
 
     # Validates a XML document against a given schema.
     #
-    # @param xml [String] path or content of XML (if the string contains a new
+    # @param xml [Pathname, String] path or content of XML (if the string contains a new
     #  line character it is considered as a XML string, otherwise as a file name)
-    # @param schema [String] path or content of relax ng schema
+    # @param schema [Pathname, String] path or content of relax ng schema
     # @return [Array<String>] array of strings with errors or empty array if
     #   well formed and valid
     # @raise [Yast::XMLDeserializationError] if the document is not well formed
     #   (there are syntax errors)
     def validate(xml, schema)
-      xml = SCR.Read(path(".target.string"), xml) unless xml.include?("\n")
-      if schema.include?("\n") # content, not path
+      xml = SCR.Read(path(".target.string"), xml.to_s) if xml.is_a?(Pathname)
+      if schema.is_a?(::String)
         validator = Nokogiri::XML::RelaxNG(schema)
       else
-        schema_content = SCR.Read(path(".target.string"), schema)
+        schema_content = SCR.Read(path(".target.string"), schema.to_s)
         schema_path = File.dirname(schema)
         # change directory so relative include works
         Dir.chdir(schema_path) { validator = Nokogiri::XML::RelaxNG(schema_content) }

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jun 18 15:23:54 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Updated Yast::XML.validate arguments
+- Distinguish between a String argument (containing a XML
+  document/schema) and Pathname (path to a file)
+- Related to bsc#1170886
+- 4.3.8
+
+-------------------------------------------------------------------
 Tue Jun 16 14:01:51 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a method to determine the default start mode for a system

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1170886
- Distinguish between a `String` argument (containing a XML document/schema) and `Pathname` (path to a file)
- Avoid problems with file names containing a new line character (really unlikely, but still
possible...)
- The `Yast::XML.validate` method has been added recently and my [quick search](https://github.com/search?q=org%3Ayast+%22XML.validate%22+org%3Ayast&type=Code) did not found any usage in YaST. Which means we can safely change the type and meaning of the arguments.