### PR TITLE
new Mode: autoyast_clone_system

### DIFF
--- a/library/general/src/modules/Mode.rb
+++ b/library/general/src/modules/Mode.rb
@@ -293,6 +293,12 @@ module Yast
       mode == "autoinst_config"
     end
 
+    # AutoYaST is running in the clone_system mode
+    # which is called by "yast clone_system"
+    def autoyast_clone_system
+      ARGV[0] == "clone_system"
+    end
+
     # test mode wrappers
 
     # Synonym of {#testsuite}.

--- a/library/general/test/mode_test.rb
+++ b/library/general/test/mode_test.rb
@@ -383,4 +383,15 @@ describe Yast::Mode do
       end
     end
   end
+
+  describe "#autoyast_clone_system" do
+    context "when -yast clone_system- has been called" do
+      before do
+        ARGV.replace(["clone_system"])
+      end
+      it "returns true" do
+        expect(Yast::Mode.autoyast_clone_system).to eq(true)
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Sun Jun 21 20:01:42 UTC 2020 - schubi@suse.de
+
+- New mode: Mode.autoyast_clone_system (needed for bsc#1172749)
+- 4.3.10
+
+-------------------------------------------------------------------
 Sun Jun 21 20:01:42 UTC 2020 - Knut Anderssen <kandersen@suse.com>
 
 - Add a method to change the selection of the network backend to be

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Problem
=========
We do not really have a flag to recognize if the AY export functions are called while cloning the system
(via yast clone_system) or are called in the AY configuration UI. The Mode.config is set in both cases.

Solution
========
This now Mode:  autoyast_clone_system which checks the argument of the yast call.