### PR TITLE
Reduce profile on-demand

### DIFF
--- a/library/general/src/lib/installation/auto_client.rb
+++ b/library/general/src/lib/installation/auto_client.rb
@@ -61,8 +61,10 @@ module Installation
       when "Import"
         import(param)
       when "Export"
+        target = param["target"] if param.is_a?(Hash)
+        target ||= "default"
         m = method(:export)
-        m.arity.zero? ? export : export(param)
+        m.arity.zero? ? export : export(target: target.to_sym)
       when "Summary"
         summary
       when "Reset"
@@ -100,12 +102,11 @@ module Installation
     #
     # The profile is a Hash or an Array according to the configuration item
     # `X-SuSE-YaST-AutoInstDataType`
-    # @param _params [Hash<String,Object>] Additional parameters
-    # @option [String] "target" Control how much information should be exported
-    #   (e.g., "default", "compact")
+    # @param target [Symbol] Control how much information should be exported
+    #   (e.g., :default or :compact).
     # @return [Hash, Array] profile data
-    def export(_params)
-      raise NotImplementedError, "Calling abstract method 'export'"
+    def export(target:)
+      raise NotImplementedError, "Calling abstract method 'export' with target '#{target}'"
     end
 
     # Provide a brief summary of configuration.

--- a/library/general/src/lib/installation/auto_client.rb
+++ b/library/general/src/lib/installation/auto_client.rb
@@ -101,6 +101,8 @@ module Installation
     # The profile is a Hash or an Array according to the configuration item
     # `X-SuSE-YaST-AutoInstDataType`
     # @param _params [Hash<String,Object>] Additional parameters
+    # @option [String] "target" Control how much information should be exported
+    #   (e.g., "default", "compact")
     # @return [Hash, Array] profile data
     def export(_params)
       raise NotImplementedError, "Calling abstract method 'export'"

--- a/library/general/src/lib/installation/auto_client.rb
+++ b/library/general/src/lib/installation/auto_client.rb
@@ -61,7 +61,8 @@ module Installation
       when "Import"
         import(param)
       when "Export"
-        export
+        m = method(:export)
+        m.arity.zero? ? export : export(param)
       when "Summary"
         summary
       when "Reset"
@@ -99,8 +100,9 @@ module Installation
     #
     # The profile is a Hash or an Array according to the configuration item
     # `X-SuSE-YaST-AutoInstDataType`
+    # @param _params [Hash<String,Object>] Additional parameters
     # @return [Hash, Array] profile data
-    def export
+    def export(_params)
       raise NotImplementedError, "Calling abstract method 'export'"
     end
 

--- a/library/general/test/auto_client_test.rb
+++ b/library/general/test/auto_client_test.rb
@@ -9,8 +9,8 @@ class TestAuto < ::Installation::AutoClient
     args.empty? ? "import" : args
   end
 
-  def export(args)
-    args
+  def export(target:)
+    target
   end
 
   ["summary", "reset", "change", "write", "packages", "read", "modified?", "modified"].each do |m|
@@ -59,7 +59,7 @@ describe ::Installation::AutoClient do
       end
 
       it "dispatch call to abstract method export" do
-        expect(subject.run).to eq("target" => "default")
+        expect(subject.run).to eq(:default)
       end
 
       context "when #export does not receive any argument" do

--- a/library/general/test/auto_client_test.rb
+++ b/library/general/test/auto_client_test.rb
@@ -9,8 +9,18 @@ class TestAuto < ::Installation::AutoClient
     args.empty? ? "import" : args
   end
 
-  ["export", "summary", "reset", "change", "write", "packages", "read", "modified?", "modified"].each do |m|
+  def export(args)
+    args
+  end
+
+  ["summary", "reset", "change", "write", "packages", "read", "modified?", "modified"].each do |m|
     define_method(m.to_sym) { m }
+  end
+end
+
+class ExportTestAuto < ::Installation::AutoClient
+  def export
+    "export"
   end
 end
 
@@ -45,11 +55,19 @@ describe ::Installation::AutoClient do
 
     context "first client argument is Export" do
       before do
-        allow(Yast::WFM).to receive(:Args).and_return(["Export", {}])
+        allow(Yast::WFM).to receive(:Args).and_return(["Export", { "target" => "default" }])
       end
 
       it "dispatch call to abstract method export" do
-        expect(subject.run).to eq "export"
+        expect(subject.run).to eq("target" => "default")
+      end
+
+      context "when #export does not receive any argument" do
+        subject { ::ExportTestAuto }
+
+        it "dispatch call to abstract method export with no arguments" do
+          expect(subject.run).to eq "export"
+        end
       end
 
       it "raise NotImplementedError exception if abstract method not defined" do

--- a/library/general/test/auto_client_test.rb
+++ b/library/general/test/auto_client_test.rb
@@ -55,11 +55,21 @@ describe ::Installation::AutoClient do
 
     context "first client argument is Export" do
       before do
-        allow(Yast::WFM).to receive(:Args).and_return(["Export", { "target" => "default" }])
+        allow(Yast::WFM).to receive(:Args).and_return(["Export"])
       end
 
       it "dispatch call to abstract method export" do
         expect(subject.run).to eq(:default)
+      end
+
+      context "when 'target' argument is given an accepted by export method" do
+        before do
+          allow(Yast::WFM).to receive(:Args).and_return(["Export", { "target" => "compact" }])
+        end
+
+        it "dispatch call to abstract method export with 'target' argument" do
+          expect(subject.run).to eq(:compact)
+        end
       end
 
       context "when #export does not receive any argument" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 26 15:00:17 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoClient#export method can receive a hash as an argument
+  (bsc#1171356).
+- 4.3.10
+
+-------------------------------------------------------------------
 Sun Jun 21 20:01:42 UTC 2020 - Knut Anderssen <kandersen@suse.com>
 
 - Add a method to change the selection of the network backend to be

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
The AutoClient#export method can receive a hash as an argument. The idea is to support getting arguments like the `target`. See https://github.com/yast/yast-autoinstallation/pull/631 for further information.