### PR TITLE
Avoid failure with release notes

### DIFF
--- a/library/packages/src/lib/y2packager/release_notes_fetchers/url.rb
+++ b/library/packages/src/lib/y2packager/release_notes_fetchers/url.rb
@@ -256,13 +256,15 @@ module Y2Packager
         return @curl_proxy_args if @curl_proxy_args
 
         @curl_proxy_args = ""
-        # proxy should be set by inst_install_inf if set via Linuxrc
+
+        # Proxy should be set by inst_install_inf if set via Linuxrc
         Yast::Proxy.Read
-        # Test if proxy works
 
         return @curl_proxy_args unless Yast::Proxy.enabled
 
-        # it is enough to test http proxy, release notes are downloaded via http
+        # Test if proxy works
+        #
+        # It is enough to test http proxy, release notes are downloaded via http
         proxy_ret = Yast::Proxy.RunTestProxy(
           Yast::Proxy.http,
           "",
@@ -272,13 +274,15 @@ module Y2Packager
         )
 
         http_ret = proxy_ret.fetch("HTTP", {})
-        if http_ret.fetch("tested", true) == true && http_ret.fetch("exit", 1) == 0
-          user_pass = (Yast::Proxy.user != "") ? "#{Yast::Proxy.user}:#{Yast::Proxy.pass}" : ""
-          proxy = "--proxy #{Yast::Proxy.http}"
-          proxy << " --proxy-user '#{user_pass}'" unless user_pass.empty?
-        end
+        proxy_ok = http_ret.fetch("tested", true) == true && http_ret.fetch("exit", 1) == 0
 
-        @curl_proxy_args = proxy
+        return @curl_proxy_args unless proxy_ok
+
+        user_pass = (Yast::Proxy.user != "") ? "#{Yast::Proxy.user}:#{Yast::Proxy.pass}" : ""
+        @curl_proxy_args = "--proxy #{Yast::Proxy.http}"
+        @curl_proxy_args << " --proxy-user '#{user_pass}'" unless user_pass.empty?
+
+        @curl_proxy_args
       end
 
       # Release notes index for the given product

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 29 14:26:44 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Avoid failure when downloading release notes from an inoperative
+  proxy (bsc#1173447).
+- 4.2.85
+
+-------------------------------------------------------------------
 Fri Jun  5 15:13:42 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Improve actions to stop and start a system service.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.84
+Version:        4.2.85
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Logging crashes when trying to download release notes and the proxy was inoperative.

* https://bugzilla.suse.com/show_bug.cgi?id=1173447


## Solution

Avoid failure when the proxy is inoperative.


## Testing

Added new unit tests.
