### PR TITLE
Product: Do not solve dependencies while checking libzypp connection

### DIFF
--- a/library/packages/src/modules/Product.rb
+++ b/library/packages/src/modules/Product.rb
@@ -188,7 +188,6 @@ module Yast
 
     # Ensures that we can load data from libzypp
     # @return [Boolean] false if libzypp lock cannot be obtained, otherwise true
-    #                   (solver errors are ignored, see bnc#886588)
     def load_zypp
       if !PackageLock.Check
         Builtins.y2error("Packager is locked, can't read product info!")
@@ -201,9 +200,6 @@ module Yast
         PackageSystem.EnsureSourceInit unless Stage.initial
       end
 
-      Pkg.PkgSolve(true)
-
-      # ignore solver errors
       true
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jun 29 15:26:44 UTC 2020 - schubi@suse.de
+- Products: Do not solve dependencies while checking libzypp
+  connection (bsc#1170322).
+- 4.3.12
+
+-------------------------------------------------------------------
 Mon Jun 29 14:26:44 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Avoid failure when downloading release notes from an inoperative

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.11
+Version:        4.3.12
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Problem
=========
While checking the libzypp connection for products an unneeded solver run has been done BEFORE any module has been added. This case has reported errors in the logs because the complete package list has not been available at that moment.

Solution
========
The solver run has been removed because it is not needed at all.