### PR TITLE
Better management of libzypp repovars

### DIFF
--- a/library/packages/src/lib/y2packager/zypp_url.rb
+++ b/library/packages/src/lib/y2packager/zypp_url.rb
@@ -19,8 +19,11 @@ module Y2Packager
   #
   # Libzypp URLs do not conform to rfc3986 because they can include the so-called
   # Repository Variables. Those vars can have several formats like $variable,
-  # ${variable}, ${variable-word} or ${variable+word}. They can appear in any
-  # component of the URL (host, path, port...) except in scheme, user or password.
+  # ${variable}, ${variable-word} or ${variable+word}. According to libzypp's
+  # documentation, the variables can appear in any component of the URL (host, path,
+  # port...) except in scheme, user or password. But, at the time of writing, zypper
+  # throws an "invalid port component" error when trying to use variables as part of
+  # the port, even with the most recent available version of libzypp.
   #
   # See https://doc.opensuse.org/projects/libzypp/HEAD/zypp-repovars.html
   #
@@ -85,6 +88,9 @@ module Y2Packager
     #    suggests and may affect the reliability of the parsing.
     # 2) Extract the port section before parsing the URL if it contains repovars, storing
     #    its value in a separate instance variable and restoring it on demand.
+    #
+    # Anyways, using variables in the port of an URL doesn't seem to really work in libzypp,
+    # although it's documented to be valid.
     #
     # @return [String]
     def port

--- a/library/packages/src/lib/y2packager/zypp_url.rb
+++ b/library/packages/src/lib/y2packager/zypp_url.rb
@@ -30,6 +30,7 @@ module Y2Packager
   #
   class ZyppUrl < SimpleDelegator
     Yast.import "Pkg"
+    include Yast::Logger
 
     # Repository schemes considered local (see #local?)
     # https://github.com/openSUSE/libzypp/blob/a7a038aeda1ad6d9e441e7d3755612aa83320dce/zypp/Url.cc#L458
@@ -37,9 +38,19 @@ module Y2Packager
 
     # Constructor
     #
+    # If the argument is a string with an invalid URL, an empty URL is created
+    #
     # @param url [String, ZyppUrl, URI::Generic]
     def initialize(url)
-      __setobj__(URI(repovars_escape(url.to_s)))
+      uri =
+        begin
+          URI(repovars_escape(url.to_s))
+        rescue URI::InvalidURIError => e
+          log.error "Failed to parse URL, considered as empty: #{e.inspect}"
+          URI("")
+        end
+
+      __setobj__(uri)
     end
 
     # @return [URI::Generic]

--- a/library/packages/src/lib/y2packager/zypp_url.rb
+++ b/library/packages/src/lib/y2packager/zypp_url.rb
@@ -1,0 +1,163 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2017-2020 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "uri"
+require "yast"
+require "delegate"
+
+module Y2Packager
+  # This class represents a libzypp URL
+  #
+  # Libzypp URLs do not conform to rfc3986 because they can include the so-called
+  # Repository Variables. Those vars can have several formats like $variable,
+  # ${variable}, ${variable-word} or ${variable+word}. They can appear in any
+  # component of the URL (host, path, port...) except in scheme, user or password.
+  #
+  # See https://doc.opensuse.org/projects/libzypp/HEAD/zypp-repovars.html
+  #
+  # The current implementation relies on SimpleDelegator to expose all the methods
+  # of an underlying URI object, so objects of this class can be used as a direct
+  # replacement in places that used to use URI, like {Y2Packager::Repository#raw_url}
+  #
+  class ZyppUrl < SimpleDelegator
+    Yast.import "Pkg"
+
+    # Repository schemes considered local (see #local?)
+    # https://github.com/openSUSE/libzypp/blob/a7a038aeda1ad6d9e441e7d3755612aa83320dce/zypp/Url.cc#L458
+    LOCAL_SCHEMES = [:cd, :dvd, :dir, :hd, :iso, :file].freeze
+
+    # Constructor
+    #
+    # @param url [String, ZyppUrl, URI::Generic]
+    def initialize(url)
+      __setobj__(URI(repovars_escape(url.to_s)))
+    end
+
+    # @return [URI::Generic]
+    def uri
+      __getobj__
+    end
+
+    alias_method :to_uri, :uri
+
+    # Constructs String from the URL
+    #
+    # @return [String]
+    def to_s
+      repovars_unescape(uri.to_s)
+    end
+
+    # See URI::Generic#hostname
+    #
+    # @return [String]
+    def hostname
+      repovars_unescape(uri.hostname)
+    end
+
+    # See URI::Generic#hostname
+    #
+    # FIXME: escaping does not work here because the port wouldn't accept the escaped
+    # characters either. If we really want to support the usage of repository variables
+    # in the port, we would likely have to implement one of these solutions:
+    #
+    # 1) Modify the regexp used by URI to parse/validate the port, so it accepts the
+    #    vars (escaped or not). That's not as easy as the documentation of the URI class
+    #    suggests and may affect the reliability of the parsing.
+    # 2) Extract the port section before parsing the URL if it contains repovars, storing
+    #    its value in a separate instance variable and restoring it on demand.
+    #
+    # @return [String]
+    def port
+      repovars_unescape(uri.port)
+    end
+
+    # See URI::Generic#path
+    #
+    # @return [String]
+    def path
+      repovars_unescape(uri.path)
+    end
+
+    # See URI::Generic#path
+    #
+    # Offered for completeness, even if the query component makes very little
+    # sense in a zypper URL.
+    #
+    # @return [String]
+    def query
+      repovars_unescape(uri.query)
+    end
+
+    # Whether the URL is local
+    #
+    # @return [Boolean] true if the URL is considered local; false otherwise
+    def local?
+      LOCAL_SCHEMES.include?(scheme&.to_sym)
+    end
+
+    # Expanded version of the URL in which the repository vars has been replaced
+    # by their value
+    #
+    # @return [ZyppUrl] an URL that is expected to conform to rfc3986
+    def expanded
+      ZyppUrl.new(Yast::Pkg.ExpandedUrl(to_s))
+    end
+
+    # String representation of the state of the object
+    #
+    # @return [String]
+    def inspect
+      # Prevent SimpleDelegator from forwarding this to the wrapped URI object
+      "#<#{self.class}:#{object_id}} @uri=#{uri.inspect}>"
+    end
+
+    # Compares two URLs
+    #
+    # NOTE: this considers an URI::Generic object to be equal if it represents
+    # the same URL. That should increase a bit the robustness when a ZyppUrl
+    # object is introduced to replace an existing URI one.
+    def ==(other)
+      if other.is_a?(URI::Generic)
+        uri == other
+      elsif other.class == self.class
+        uri == other.uri
+      else
+        false
+      end
+    end
+
+    # @see #==
+    alias_method :eql?, :==
+
+  private
+
+    # Preprocess a string so it can be accepted as a valid URI
+    #
+    # Escaping and unescaping the invalid characters is implemented as an
+    # alternative to the solution that may look more obvious and elegant:
+    # configuring the parser of URI to accept those characters. Done this way
+    # because configuring the parser implies dealing with very complex regexps,
+    # which is not only risky but would also prevent us from benefiting from
+    # future improvements in the Ruby's URI regexps.
+    #
+    # @param str [String] original string that may include repo vars
+    # @return [String]
+    def repovars_escape(str)
+      str.gsub("{", "%7B").gsub("}", "%7D")
+    end
+
+    # @see #repovars_escape
+    def repovars_unescape(str)
+      str.gsub("%7B", "{").gsub("%7D", "}")
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/zypp_url.rb
+++ b/library/packages/src/lib/y2packager/zypp_url.rb
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2017-2020 SUSE LLC, All Rights Reserved.
+# Copyright (c) 2020 SUSE LLC, All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of version 2 of the GNU General Public License as published by the

--- a/library/packages/test/repository_test.rb
+++ b/library/packages/test/repository_test.rb
@@ -182,7 +182,7 @@ describe Y2Packager::Repository do
 
   describe "#local" do
     before do
-      allow(repo).to receive(:scheme).and_return(scheme)
+      allow(repo.raw_url).to receive(:scheme).and_return(scheme)
     end
 
     context "when scheme is :cd" do
@@ -334,6 +334,12 @@ describe Y2Packager::Repository do
 
     it "allows using an URI class parameter" do
       new_url = URI("https://example.com/new_repo")
+      expect(Yast::Pkg).to receive(:SourceChangeUrl).with(repo.repo_id, new_url.to_s).and_return(true)
+      expect { repo.url = new_url }.to change { repo.url.to_s }.from(repo.url.to_s).to(new_url.to_s)
+    end
+
+    it "allows using an ZyppUrl class parameter" do
+      new_url = Y2Packager::ZyppUrl.new("https://example.com/new_repo")
       expect(Yast::Pkg).to receive(:SourceChangeUrl).with(repo.repo_id, new_url.to_s).and_return(true)
       expect { repo.url = new_url }.to change { repo.url }.from(repo.url).to(new_url)
     end

--- a/library/packages/test/repository_test.rb
+++ b/library/packages/test/repository_test.rb
@@ -151,6 +151,17 @@ describe Y2Packager::Repository do
           expect(repo.product_dir).to eq("/product")
         end
       end
+
+      context "if the raw url cannot be parsed" do
+        let(:repo_raw_url) { "http://download.opensuse.org:80$releasever/update/leap/15.2/oss" }
+
+        it "returns a repository with an empty url" do
+          repo = described_class.find(repo_id)
+          expect(repo.repo_id).to eq(repo_id)
+          expect(repo.raw_url.to_s).to eq ""
+          expect(repo.url.to_s).to eq ""
+        end
+      end
     end
 
     context "when an invalid repo_id is given" do

--- a/library/packages/test/repository_test.rb
+++ b/library/packages/test/repository_test.rb
@@ -12,6 +12,7 @@ describe Y2Packager::Repository do
   let(:enabled) { true }
   let(:autorefresh) { true }
   let(:repo_url) { URI("http://download.opensuse.org/update/leap/42.1/oss") }
+  let(:repo_raw_url) { repo_url }
 
   subject(:repo) do
     Y2Packager::Repository.new(repo_id: repo_id, name: "repo-oss", enabled: enabled,
@@ -88,16 +89,67 @@ describe Y2Packager::Repository do
 
     context "when a valid repo_id is given" do
       let(:repo_data) do
-        { "enabled" => true, "autorefresh" => true, "url" => repo_url, "raw_url" => repo_url,
+        { "enabled" => true, "autorefresh" => true, "url" => repo_url, "raw_url" => repo_raw_url,
           "name" => "Repo #1", "product_dir" => "/product", "repo_alias" => "alias" }
       end
 
-      it "returns a repository with the given repo_id" do
+      it "returns the repository with the given repo_id" do
         repo = described_class.find(repo_id)
         expect(repo.repo_id).to eq(repo_id)
         expect(repo.enabled?).to eq(repo_data["enabled"])
         expect(repo.url).to eq(URI(repo_data["url"]))
         expect(repo.product_dir).to eq("/product")
+      end
+
+      context "if the raw url contains a repo var like $releasever" do
+        let(:repo_raw_url) { "http://download.opensuse.org/update/leap/$releasever/oss" }
+
+        it "returns the repository with the given repo_id" do
+          repo = described_class.find(repo_id)
+          expect(repo.repo_id).to eq(repo_id)
+          expect(repo.enabled?).to eq(repo_data["enabled"])
+          expect(repo.raw_url.to_s).to eq(repo_data["raw_url"].to_s)
+          expect(repo.product_dir).to eq("/product")
+        end
+      end
+
+      # Regression test for bug#1172867, using ${var_name} used to cause an exception
+      context "if the raw url contains a repo var like ${releasever}" do
+        let(:repo_raw_url) { "http://download.opensuse.org/update/leap/${releasever}/oss" }
+
+        it "returns the repository with the given repo_id" do
+          repo = described_class.find(repo_id)
+          expect(repo.repo_id).to eq(repo_id)
+          expect(repo.enabled?).to eq(repo_data["enabled"])
+          expect(repo.raw_url.to_s).to eq(repo_data["raw_url"].to_s)
+          expect(repo.product_dir).to eq("/product")
+        end
+      end
+
+      # Regression test for bug#1172867, part 2
+      context "if the raw url contains a repo var like ${var-word}" do
+        let(:repo_raw_url) { "http://download.opensuse.org/update/leap/${var-word}/oss" }
+
+        it "returns the repository with the given repo_id" do
+          repo = described_class.find(repo_id)
+          expect(repo.repo_id).to eq(repo_id)
+          expect(repo.enabled?).to eq(repo_data["enabled"])
+          expect(repo.raw_url.to_s).to eq(repo_data["raw_url"].to_s)
+          expect(repo.product_dir).to eq("/product")
+        end
+      end
+
+      # Regression test for bug#1172867, part 3
+      context "if the raw url contains a repo var like ${var+word}" do
+        let(:repo_raw_url) { "http://download.opensuse.org/update/leap/${var+word}/oss" }
+
+        it "returns the repository with the given repo_id" do
+          repo = described_class.find(repo_id)
+          expect(repo.repo_id).to eq(repo_id)
+          expect(repo.enabled?).to eq(repo_data["enabled"])
+          expect(repo.raw_url.to_s).to eq(repo_data["raw_url"].to_s)
+          expect(repo.product_dir).to eq("/product")
+        end
       end
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jul 16 12:48:24 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Better management of libzypp repovars (eg. those enclosed in
+  curly brackets) introducing the new Y2Packager::ZyppUrl class
+- Do not crash during the upgrade process if some repository URL
+  cannot be parsed (bsc#1172867)
+- 4.3.15
+
+-------------------------------------------------------------------
 Fri Jul 10 14:15:30 UTC 2020 - David Diaz <dgonzalez@suse.com>
 
 - Make CFA::MultiFileConfig fully reusable (related to bsc#1155735,

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.14
+Version:        4.3.15
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Libzypp URLs can include the so-called [Repository Variables](https://doc.opensuse.org/projects/libzypp/HEAD/zypp-repovars.html) (repovars for the friends). They can have several formats like `$variable`, `${variable}`, `${variable-word}` or `${variable+word}`. They can appear in many parts of the URL, including the host, the path and even the port! (well, see some clarifications about the port below)

Of course, those vars are expanded before the URL is used for any real connection.

Before this pull request, the `Repository` class used two attributes to store the expanded and raw version of those URLs as [Ruby's URI](https://ruby-doc.org/stdlib-2.7.1/libdoc/uri/rdoc/URI.html) objects. Unfortunately, having curly brackets as part of the host, the path or the port of an URL does not conform to [RFC3986](https://tools.ietf.org/html/rfc3986). As a consequence Ruby thrown exceptions that went directly to our user's face.

See https://bugzilla.opensuse.org/show_bug.cgi?id=1172867  (and also the corresponding Trello card at https://trello.com/c/8DgGs7J1/)

## Solution

Instead of using `URI` objects directly, introduce a new `ZyppUrl` class that offers all the functionality of the `URI` one (with the same API to keep compatibility) and, in addition, handles repovars correctly in most cases. The only situation that is not handled properly is when those vars are used as part of the port section of the URL (see `FIXME`), but I manually tested that such thing doesn't work in general. Despite what libzypp's documentation says, `zypper` fails to add a repository with such URL and it fails in all operations if the repository is added manually.

Moreover, with that new class there is no need to store both (raw and expanded) URLs, the `Repository` object stores only the raw one, since the expanded URL is something the new class can calculate from the raw version (asking libzypp, of course).

Last but not least, when a non-understandable URL is parsed the new class creates an empty URL as result, instead of throwing an exception. That should save us from crashing in front of user's face next time somebody invents a new crazy feature for libzypp URLs or if repovars are used as part of the port specification (assuming that will actually work in the future and will be used by someone).

## Testing

- Added unit tests to prove this can handle correctly URLs like `http://example.com/$var/oss`, `http://example.com/${var}/oss`,  `http://example.com/${var-word}/oss`, `http://example.com/${var+word}/oss`.
- Added unit test to prove that using repovars in the port section (like `http://example.com:$releaseport/path`) do not cause a crash (the URL is considered to be empty).
- Tested manually upgrading from a Leap 15.0 with the following repository: `https://download.opensuse.org/repositories/LibreOffice:/Factory/openSUSE_Leap_${releasever}`. See the following screenshots.

Without the patch:

![repovars-crash](https://user-images.githubusercontent.com/3638289/87431353-c9fa5e80-c5e6-11ea-8670-8e16d5d78add.png)

With the patch, the repository is correctly visualized in the list and the process can continue (at least, to the installation summary screen):

![repovars-repolist](https://user-images.githubusercontent.com/3638289/87431502-04fc9200-c5e7-11ea-9232-19af57b954b0.png)
