### PR TITLE
add space to SPACE_CHARS (bsc#1173907)

### DIFF
--- a/library/types/src/modules/String.rb
+++ b/library/types/src/modules/String.rb
@@ -39,7 +39,7 @@ module Yast
     ALPHA_NUM_CHARS = ALPHA_CHARS + DIGIT_CHARS
     PUNCT_CHARS = "!\"\#$%&'()*+,-./:;<=>?@[\\]^_`{|}~".freeze
     GRAPHICAL_CHARS = ALPHA_NUM_CHARS + PUNCT_CHARS
-    SPACE_CHARS = "\f\r\n\t\v".freeze
+    SPACE_CHARS = " \f\r\n\t\v".freeze
     PRINTABLE_CHARS = SPACE_CHARS + GRAPHICAL_CHARS
 
     def main

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul  9 14:35:43 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- add space to SPACE_CHARS (bsc#1173907)
+- 4.3.14
+
+-------------------------------------------------------------------
 Tue Jul  7 09:48:04 CEST 2020 - schubi@suse.de
 
 - Command line interface: Do not start an UI while evaluating

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1173907

`SPACE_CHARS` https://github.com/yast/yast-yast2/blob/master/library/types/src/modules/String.rb#L42 doesn't include a space.

This makes it impossible to work with ESSIDs containing a space. See
https://github.com/yast/yast-network/blob/master/src/lib/y2network/widgets/wireless_essid.rb#L95-L97

## Solution

Add it.

## Evil side effects

AFAICS `SPACE_CHARS` is only used in `Yast::String.CPrint` and that's only used in the ESSID dialog. So I wouldn't expect any evil fallout by this change.