### PR TITLE
Makes CFA::MultiFileConfig reusable

### DIFF
--- a/library/general/src/lib/cfa/multi_file_config.rb
+++ b/library/general/src/lib/cfa/multi_file_config.rb
@@ -124,10 +124,10 @@ module CFA
 
     # Return the involved configuration files
     #
-    # @return [Array<LoginDefs>] Configuration files
+    # @return [Array<Class>] Configuration files
     # @see #paths
     def files
-      @files ||= paths.map { |p| LoginDefs.new(file_path: p) }
+      @files ||= paths.map { |p| self.class.file_class.new(file_path: p) }
     end
 
     # Return the paths to the configuration files
@@ -194,14 +194,14 @@ module CFA
 
     # Returns the YaST specific configuration file
     #
-    # @return [LoginDefs]
+    # @return [Class]
     def yast_config_file
       @yast_config_file ||= files.find { |f| f.file_path == yast_file_path }
     end
 
     # Returns the files with higher precedence that the YaST one
     #
-    # @return [Array<LoginDefs>] List of files
+    # @return [Array<Class>] List of files
     def higher_precedence_files
       return @higher_precedence_files if @higher_precedence_files
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 10 14:15:30 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Make CFA::MultiFileConfig fully reusable (related to bsc#1155735,
+  and bsc#1157541).
+
+-------------------------------------------------------------------
 Thu Jul  9 14:35:43 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - add space to SPACE_CHARS (bsc#1173907)


### PR DESCRIPTION
## Problem

The [CFA::MultiFileConfig](https://github.com/yast/yast-yast2/blob/5265884d711e68bd36e06aa4250eb71c50f85a35/library/general/src/lib/cfa/multi_file_config.rb) is not fully reusable because it is using `CFA::LoginDefs` for loading files. Most probably, a leftover during the [extraction of reusable code](https://github.com/yast/yast-yast2/commit/cdf92b82ac8b0030437e2be74f7abbed8fabf616) in #988.

## Solution

Simply use the provided `file_class` instead.

