### PR TITLE
CI: Experimentally enable GitHub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+
+# See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  Tests:
+    runs-on: ubuntu-latest
+    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v1
+
+    - name: Inspect Installed Packages
+      run: rpm -qa | sort
+
+    - name: Rubocop, Tests, Package Build
+      run: yast-travis-ruby

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ YaST - The Basic Libraries
 ==========================
 
 [![Travis Build](https://travis-ci.org/yast/yast-yast2.svg?branch=master)](https://travis-ci.org/yast/yast-yast2)
+[![CI](https://github.com/yast/yast-yast2/workflows/CI/badge.svg)](https://github.com/yast/yast-yast2/actions?query=workflow%3ACI)
 [![Coverage Status](https://img.shields.io/coveralls/yast/yast-yast2.svg)](https://coveralls.io/r/yast/yast-yast2?branch=master)
 [![Jenkins Build](http://img.shields.io/jenkins/s/https/ci.opensuse.org/yast-yast2-master.svg)](https://ci.opensuse.org/view/Yast/job/yast-yast2-master/)
 [![Code Climate](https://codeclimate.com/github/yast/yast-yast2/badges/gpa.svg)](https://codeclimate.com/github/yast/yast-yast2)


### PR DESCRIPTION
- This is a proof of concept for using the GitHub actions as the CI
- Let's see how it compares with Travis
- You can see an example run here: https://github.com/yast/yast-yast2/runs/869651708