### PR TITLE
Add a basic CFA class to manage nsswitch.conf

### DIFF
--- a/library/general/src/lib/cfa/nsswitch.rb
+++ b/library/general/src/lib/cfa/nsswitch.rb
@@ -107,7 +107,8 @@ module CFA
     #
     # @param db_name [String] the database name, e.g., "passwd" or "hosts"
     #
-    # @return [Array<String>] database service specifications
+    # @return [Array<String>, nil] database service specifications or nil if db_name is not found
+    # otherwise
     def services_for(db_name)
       databases[db_name]&.services
     end
@@ -138,15 +139,11 @@ module CFA
     #
     # @see CFA::BaseModel#save
     def save
-      return false unless modified?
-
-      new_content = @parser.serialize(data)
+      return unless modified?
 
       @parser.file_name = write_path if @parser.respond_to?(:file_name=)
-      @file_handler.write(write_path, new_content)
-      @current_content = new_content
-
-      true
+      @current_content = @parser.serialize(data)
+      @file_handler.write(write_path, @current_content)
     end
 
     # Whether the content has changed

--- a/library/general/src/lib/cfa/nsswitch.rb
+++ b/library/general/src/lib/cfa/nsswitch.rb
@@ -1,0 +1,273 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cfa/base_model"
+require "yast2/target_file"
+
+Yast.import "FileUtils"
+
+module CFA
+  # Model to handle the Name Service Switch configuration file
+  #
+  # @note Since nsswitch.conf does not allow to overrides single entries, the content will be
+  #   read from /usr/etc/nsswitch.conf only when /etc/nsswitch.conf file does not exist yet.
+  #   In any case, changes will be always written to /etc/nsswitch.conf.
+  #
+  # @example Reading service specifications of a database
+  #   file = Nsswitch.new
+  #   file.load
+  #   file.services_for("hosts") #=> ["db", "files"]
+  #
+  # @example Writing service specifications for a database
+  #   file = Nsswitch.new
+  #   file.load
+  #   file.update_entry("hosts", ["db", "files"])
+  #   file.save
+  #
+  # @example Deleting a database entry
+  #   file = Nsswitch.new
+  #   file.load
+  #   file.delete_entry("hosts")
+  #   file.save
+  #
+  # @example Loading shortcut
+  #   file = Nsswitch.load
+  #   file.entries #=> ["passwd", "group", "shadow", "hosts", "networks", "aliases"]
+  class Nsswitch < BaseModel
+    include Yast::Logger
+
+    # Path to local configuration file
+    LOCAL_PATH = "/etc/nsswitch.conf".freeze
+    private_constant :LOCAL_PATH
+
+    # Path to vendor configuration file
+    VENDOR_PATH = "/usr/etc/nsswitch.conf".freeze
+    private_constant :VENDOR_PATH
+
+    class << self
+      # Instantiates and loads the file
+      #
+      # This method is basically a shortcut to instantiate and load the content in just one call.
+      #
+      # @param file_handler [#read,#write] something able to read/write a string (like File)
+      # @return [Nsswitch] File with the already loaded content
+      def load(file_handler: Yast::TargetFile)
+        new(file_handler: file_handler).tap(&:load)
+      end
+    end
+
+    # Constructor
+    #
+    # @param file_handler [#read,#write] something able to read/write a string (like File)
+    #
+    # @see CFA::BaseModel#initialize
+    def initialize(file_handler: Yast::TargetFile)
+      super(AugeasParser.new("nsswitch.lns"), load_path, file_handler: file_handler)
+    end
+
+    # Loads the file content
+    #
+    # If the file does not exist, consider it as empty.
+    #
+    # @see CFA::BaseModel#load
+    def load
+      super
+      fix_collection_names(data)
+      @current_content = @parser.serialize(data)
+    rescue Errno::ENOENT # PATH does not exist yet
+      self.data = @parser.empty
+      @loaded = true
+    end
+
+    # Returns a list of defined databases
+    #
+    # @return [Array<String>] List of database names
+    def entries
+      databases.keys
+    end
+
+    # Service specifications for given database name
+    #
+    # @param db_name [String] the database name, e.g., "passwd" or "hosts"
+    #
+    # @return [Array<String>] database service specifications
+    def services_for(db_name)
+      databases[db_name]&.services
+    end
+
+    # Update (or create if it does not exist yet) the entry for given database name
+    #
+    #
+    # @note Current services, if any, are completely replaced
+    #
+    # @see #entry_for
+    # @see DatabaseEntry#services=
+    #
+    # @param db_name [String] the database name, e.g., "passwd" or "hosts"
+    # @param services [Array<String>] service specifications for the database
+    def update_entry(db_name, services)
+      database = entry_for(db_name)
+      database.services = services
+    end
+
+    # Delete entry for given database name
+    #
+    # @param db_name [String] the database db_name, e.g., "passwd" or "hosts"
+    def delete_entry(db_name)
+      data.delete(database_matcher(db_name))
+    end
+
+    # Writes the current content to /etc/nsswitch.conf
+    #
+    # @see CFA::BaseModel#save
+    def save
+      return false unless modified?
+
+      new_content = @parser.serialize(data)
+
+      @parser.file_name = write_path if @parser.respond_to?(:file_name=)
+      @file_handler.write(write_path, new_content)
+      @current_content = new_content
+
+      true
+    end
+
+    # Whether the content has changed
+    #
+    # @return [Boolean] true if content has been modified; false otherwise.
+    def modified?
+      @current_content != @parser.serialize(data)
+    end
+
+  private
+
+    # The path for loading the content
+    #
+    # @return [String] path to local configuration file if it exists; path to vendor one otherwise
+    def load_path
+      Yast::FileUtils.Exists(LOCAL_PATH) ? LOCAL_PATH : VENDOR_PATH
+    end
+
+    # The path for writing the content
+    #
+    # @return [String] path to local configuration file
+    def write_path
+      LOCAL_PATH
+    end
+
+    # Return the CFA::Matcher for given database name
+    #
+    # @param db_name [String] the database name, e.g., "passwd" or "hosts"
+    #
+    # @return [CFA::Matcher]
+    def database_matcher(db_name)
+      CFA::Matcher.new { |k, v| k == "database[]" && v.value == db_name }
+    end
+
+    # Find or create the DatabaseEntry for given database name
+    #
+    # @param db_name [String] the database name, e.g., "passwd" or "hosts"
+    #
+    # @return [DatabaseEntry]
+    def entry_for(db_name)
+      return databases[db_name] if databases.keys.include?(db_name)
+
+      database = CFA::AugeasTreeValue.new(CFA::AugeasTree.new, db_name)
+      data.add("database[]", database)
+      DatabaseEntry.new(database)
+    end
+
+    # Available databases
+    #
+    # @return [Hash{String => DatabaseEntry}]
+    def databases
+      raw_databases.each_with_object({}) do |database, collection|
+        name = database[:value].value.to_s
+        collection[name] = DatabaseEntry.new(database[:value])
+      end
+    end
+
+    # Available databases in internal structure
+    #
+    # @return [Array<Hash{Symbol => CFA::AugeasTreeValue, String, Symbol}>]
+    def raw_databases
+      data.select(CFA::Matcher.new(collection: "database"))
+    end
+
+    # Known collection keys
+    COLLECTION_KEYS = ["database", "service"].freeze
+    private_constant :COLLECTION_KEYS
+
+    # Fix collection names adding the missing "[]"
+    #
+    # When a collection has only one element, Augeas does not add "[]" suffix, reason why is
+    # necessary to fix at least those collections that are going to be hitted for either, read or
+    # write.
+    #
+    # @param tree [AugeasTree,AugeasTreeValue]
+    def fix_collection_names(tree)
+      tree.data.each do |entry|
+        entry[:key] << "[]" if COLLECTION_KEYS.include?(entry[:key])
+        fix_collection_names(entry[:value].tree) if entry[:value].is_a?(AugeasTreeValue)
+        fix_collection_names(entry[:value]) if entry[:value].is_a?(AugeasTree)
+      end
+    end
+
+    # Internal class for managing database entries
+    class DatabaseEntry
+      # Constructor
+      #
+      # @param data [CFA::AugeasTreeValue]
+      def initialize(data)
+        @data = data
+      end
+
+      # The database name
+      #
+      # @return [String]
+      def name
+        data.value
+      end
+
+      # The database service specifications
+      #
+      # @return [Array<String>]
+      def services
+        data.tree.collection("service").map(&:to_s)
+      end
+
+      # Set service specifications
+      #
+      # TODO: add support for reactions
+      #
+      # @param services [Array<String>]
+      def services=(services)
+        data.tree.delete("service[]")
+        data.tree.delete("reaction[]")
+
+        services.each { |service| data.tree.add("service[]", service) }
+      end
+
+    private
+
+      attr_reader :data
+    end
+  end
+end

--- a/library/general/test/cfa/nsswitch_test.rb
+++ b/library/general/test/cfa/nsswitch_test.rb
@@ -76,10 +76,6 @@ describe CFA::Nsswitch do
         subject.update_entry("hosts", ["dns", "nis"])
       end
 
-      it "returns true" do
-        expect(subject.save).to eq(true)
-      end
-
       it "writes to /etc/nsswitch.conf file" do
         expect(file_handler).to receive(:write)
           .with("/etc/nsswitch.conf", anything)
@@ -94,10 +90,6 @@ describe CFA::Nsswitch do
     end
 
     context "when it has not changed" do
-      it "returns false" do
-        expect(subject.save).to eq(false)
-      end
-
       it "does nothing" do
         expect(file_handler).to_not receive(:write)
         subject.save

--- a/library/general/test/cfa/nsswitch_test.rb
+++ b/library/general/test/cfa/nsswitch_test.rb
@@ -1,0 +1,190 @@
+# Copyright (c) [2020] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "cfa/nsswitch"
+
+describe CFA::Nsswitch do
+  subject { described_class.new(file_handler: file_handler) }
+
+  let(:file_handler) { Yast::TargetFile }
+
+  let(:scenario) { "custom" }
+
+  around do |example|
+    change_scr_root(File.join(GENERAL_DATA_PATH, "nsswitch.conf", scenario), &example)
+  end
+
+  describe "#load" do
+    context "when /etc/nsswitch.conf exists" do
+      before do
+        allow(file_handler).to receive(:read).and_call_original
+      end
+
+      it "does not read /usr/etc/nsswitch.conf file" do
+        expect(file_handler).to_not receive(:read)
+          .with("/usr/etc/nsswitch.conf")
+        subject.load
+      end
+
+      it "reads /etc/nsswitch.conf file" do
+        expect(file_handler).to receive(:read)
+          .with("/etc/nsswitch.conf")
+          .and_call_original
+        subject.load
+      end
+    end
+
+    context "when /etc/nsswitch.conf does not exist" do
+      let(:scenario) { "vendor" }
+
+      it "reads vendor files" do
+        expect(file_handler).to receive(:read)
+          .with("/usr/etc/nsswitch.conf")
+          .and_call_original
+        subject.load
+      end
+    end
+  end
+
+  describe "#save" do
+    before do
+      subject.load
+
+      # Avoid writing data example files
+      allow(file_handler).to receive(:write)
+    end
+
+    context "when it has changed" do
+      before do
+        subject.update_entry("hosts", ["dns", "nis"])
+      end
+
+      it "returns true" do
+        expect(subject.save).to eq(true)
+      end
+
+      it "writes to /etc/nsswitch.conf file" do
+        expect(file_handler).to receive(:write)
+          .with("/etc/nsswitch.conf", anything)
+        subject.save
+      end
+
+      it "does not write to /usr/etc/nsswitch.conf file" do
+        expect(file_handler).to_not receive(:write)
+          .with("/user/etc/nsswitch.conf", anything)
+        subject.save
+      end
+    end
+
+    context "when it has not changed" do
+      it "returns false" do
+        expect(subject.save).to eq(false)
+      end
+
+      it "does nothing" do
+        expect(file_handler).to_not receive(:write)
+        subject.save
+      end
+    end
+  end
+
+  describe "#modified?" do
+    before  { subject.load }
+
+    context "when it has changed" do
+      before do
+        subject.update_entry("hosts", ["dns", "nis"])
+      end
+
+      it "returns true" do
+        expect(subject.modified?).to eq(true)
+      end
+    end
+
+    context "when it has not changed" do
+      it "returns false" do
+        expect(subject.modified?).to eq(false)
+      end
+    end
+  end
+
+  describe "#entries" do
+    before { subject.load }
+
+    it "returns the database names currently present in the configuration" do
+      expect(subject.entries).to eq(["passwd", "group", "shadow", "hosts"])
+    end
+  end
+
+  describe "#services_for" do
+    before { subject.load }
+
+    context "when given an available database entry" do
+      it "returns the service specifications for given database name" do
+        expect(subject.services_for("hosts")).to eq(["db", "files"])
+      end
+    end
+
+    context "when given a not available database entry" do
+      it "returns nil" do
+        expect(subject.services_for("foo")).to be_nil
+      end
+    end
+  end
+
+  describe "#update_entry" do
+    before { subject.load }
+
+    context "when given an available database entry" do
+      it "changes database entry to use given services" do
+        old_services = subject.services_for("hosts")
+        new_services = ["other", "services"]
+        subject.update_entry("hosts", new_services)
+        updated_services = subject.services_for("hosts")
+
+        expect(updated_services).to eq(new_services)
+        expect(updated_services).to_not eq(old_services)
+      end
+    end
+
+    context "when given a not available database entry" do
+      it "creates the database entry with given services" do
+        expect(subject.entries).to_not include("foo")
+
+        subject.update_entry("foo", ["bar"])
+
+        expect(subject.entries).to include("foo")
+        expect(subject.services_for("foo")).to eq(["bar"])
+      end
+    end
+  end
+
+  describe "#delete_entry" do
+    before { subject.load }
+
+    it "deletes given entry" do
+      expect(subject.services_for("hosts")).to_not be_nil
+
+      subject.delete_entry("hosts")
+
+      expect(subject.services_for("hosts")).to be_nil
+    end
+  end
+end

--- a/library/general/test/data/nsswitch.conf/custom/etc/nsswitch.conf
+++ b/library/general/test/data/nsswitch.conf/custom/etc/nsswitch.conf
@@ -1,0 +1,13 @@
+# /etc/nsswitch.conf
+#
+# An custom Name Service Switch config file.
+#
+# Valid databases are: aliases, ethers, group, gshadow, hosts,
+# initgroups, netgroup, networks, passwd, protocols, publickey,
+# rpc, services, and shadow.
+
+passwd: compat
+group:  compat
+shadow: compat
+
+hosts:  db files

--- a/library/general/test/data/nsswitch.conf/custom/usr/etc/nsswitch.conf
+++ b/library/general/test/data/nsswitch.conf/custom/usr/etc/nsswitch.conf
@@ -1,0 +1,74 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# Valid databases are: aliases, ethers, group, gshadow, hosts,
+# initgroups, netgroup, networks, passwd, protocols, publickey,
+# rpc, services, and shadow.
+#
+# Valid service provider entries include (in alphabetical order):
+#
+#	compat			Use /etc files plus *_compat pseudo-db
+#	db			Use the pre-processed /var/db files
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files in /etc
+#	hesiod			Use Hesiod (DNS) for user lookups
+#	nis			Use NIS (NIS version 2), also called YP
+#	nisplus			Use NIS+ (NIS version 3)
+#
+# See `info libc 'NSS Basics'` for more information.
+#
+# Commonly used alternative service providers (may need installation):
+#
+#	ldap			Use LDAP directory server
+#	myhostname		Use systemd host names
+#	mymachines		Use systemd machine names
+#	mdns*, mdns*_minimal	Use Avahi mDNS/DNS-SD
+#	resolve			Use systemd resolved resolver
+#	sss			Use System Security Services Daemon (sssd)
+#	systemd			Use systemd for dynamic user option
+#	winbind			Use Samba winbind support
+#	wins			Use Samba wins support
+#	wrapper			Use wrapper module for testing
+#
+# Notes:
+#
+# 'sssd' performs its own 'files'-based caching, so it should generally
+# come before 'files'.
+#
+# WARNING: Running nscd with a secondary caching service like sssd may
+# 	   lead to unexpected behaviour, especially with how long
+# 	   entries are cached.
+#
+# Installation instructions:
+#
+# To use 'db', install the appropriate package(s) (provide 'makedb' and
+# libnss_db.so.*), and place the 'db' in front of 'files' for entries
+# you want to be looked up first in the databases, like this:
+#
+# passwd:    db files
+# shadow:    db files
+# group:     db files
+
+passwd:		compat
+group:		compat
+shadow:		compat
+# Allow initgroups to default to the setting for group.
+# initgroups:	compat
+
+hosts:  	files dns
+networks:	files dns
+
+aliases:	files usrfiles
+ethers:		files usrfiles
+gshadow:	files usrfiles
+netgroup:	files nis
+protocols:	files usrfiles
+publickey:	files
+rpc:		files usrfiles
+
+bootparams:	files
+netmasks:	files
+services:	files usrfiles

--- a/library/general/test/data/nsswitch.conf/vendor/usr/etc/nsswitch.conf
+++ b/library/general/test/data/nsswitch.conf/vendor/usr/etc/nsswitch.conf
@@ -1,0 +1,74 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# Valid databases are: aliases, ethers, group, gshadow, hosts,
+# initgroups, netgroup, networks, passwd, protocols, publickey,
+# rpc, services, and shadow.
+#
+# Valid service provider entries include (in alphabetical order):
+#
+#	compat			Use /etc files plus *_compat pseudo-db
+#	db			Use the pre-processed /var/db files
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files in /etc
+#	hesiod			Use Hesiod (DNS) for user lookups
+#	nis			Use NIS (NIS version 2), also called YP
+#	nisplus			Use NIS+ (NIS version 3)
+#
+# See `info libc 'NSS Basics'` for more information.
+#
+# Commonly used alternative service providers (may need installation):
+#
+#	ldap			Use LDAP directory server
+#	myhostname		Use systemd host names
+#	mymachines		Use systemd machine names
+#	mdns*, mdns*_minimal	Use Avahi mDNS/DNS-SD
+#	resolve			Use systemd resolved resolver
+#	sss			Use System Security Services Daemon (sssd)
+#	systemd			Use systemd for dynamic user option
+#	winbind			Use Samba winbind support
+#	wins			Use Samba wins support
+#	wrapper			Use wrapper module for testing
+#
+# Notes:
+#
+# 'sssd' performs its own 'files'-based caching, so it should generally
+# come before 'files'.
+#
+# WARNING: Running nscd with a secondary caching service like sssd may
+# 	   lead to unexpected behaviour, especially with how long
+# 	   entries are cached.
+#
+# Installation instructions:
+#
+# To use 'db', install the appropriate package(s) (provide 'makedb' and
+# libnss_db.so.*), and place the 'db' in front of 'files' for entries
+# you want to be looked up first in the databases, like this:
+#
+# passwd:    db files
+# shadow:    db files
+# group:     db files
+
+passwd:		compat
+group:		compat
+shadow:		compat
+# Allow initgroups to default to the setting for group.
+# initgroups:	compat
+
+hosts:  	files dns
+networks:	files dns
+
+aliases:	files usrfiles
+ethers:		files usrfiles
+gshadow:	files usrfiles
+netgroup:	files nis
+protocols:	files usrfiles
+publickey:	files
+rpc:		files usrfiles
+
+bootparams:	files
+netmasks:	files
+services:	files usrfiles

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 22 16:08:16 UTC 2020 - David Diaz <dgonzalez@suse.com>
+
+- Add a CFA based class to manage nsswitch.conf (bsc#1173119).
+- 4.3.16
+
+-------------------------------------------------------------------
 Thu Jul 16 12:48:24 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Better management of libzypp repovars (eg. those enclosed in

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.15
+Version:        4.3.16
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Factory started to serve the default `nsswitch.conf` file under `/usr/etc/` instead of `/etc`. However, YaST will try to read `/etc/nsswitch.conf` even if it does not existe **yet**.

* https://bugzilla.suse.com/show_bug.cgi?id=1173119
* https://trello.com/c/uDtev8AO/1949-5-add-support-for-usr-etc-nsswitchconf

## Solution

Since `nsswitch.conf` is a [complex configuration file which does not allow overrides of single entries](https://en.opensuse.org/openSUSE:Packaging_UsrEtc#Variant_3), `/etc/nsswitch.conf` must contain all desired configuration when it exists. So, YaST will read the configuration from `/usr/etc/nsswitch.conf` when `/etc/nsswitch.conf` is not available but will **always write to `/etc/nsswitch.conf`**. That way, it ensures that **the first time the file is written** it will contain not only the modified values but also the rest of the default configuration.

## Tests

* Added a unit test