### PR TITLE
Firewalld: Added method to check which zones have been modified from default settings

### DIFF
--- a/library/network/test/data/etc/firewalld/zones/internal.xml
+++ b/library/network/test/data/etc/firewalld/zones/internal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<zone>
+  <short>Internal</short>
+  <description>For use on internal networks. You mostly trust the other computers on the networks to not harm your computer. Only selected incoming connections are accepted.</description>
+  <service name="dhcp"/>
+  <service name="ssh"/>
+  <service name="mdns"/>
+  <service name="samba-client"/>
+  <service name="dhcpv6-client"/>
+</zone>
+

--- a/library/network/test/y2firewall/firewalld_test.rb
+++ b/library/network/test/y2firewall/firewalld_test.rb
@@ -403,4 +403,16 @@ describe Y2Firewall::Firewalld do
       firewalld.write
     end
   end
+
+  describe "#modified_from_default" do
+    context "when the given resource directoy does not exist" do
+      it "returns an empty array" do
+        expect(firewalld.modified_from_default("not_existent")).to eq([])
+      end
+    end
+
+    it "returns a list of the modified items" do
+      expect(firewalld.modified_from_default("zones", target_root: DATA_PATH)).to eq(["internal"])
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 24 08:53:31 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Provide a way to determine which resources (zones, services...)
+  have been modified from the default values (bsc#1171356)
+- 4.3.17
+
+-------------------------------------------------------------------
 Fri Jul 24 08:06:27 UTC 2020 - Jeff Kowalczyk <jkowalczyk@suse.com>
 
 - update is_wsl function to match wsl1 and wsl2 osrelease spellings

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.16
+Version:        4.3.17
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

When the user ask about a reduced profile we export all the available zones even if not modified from the default values.

    https://trello.com/c/bLXXJXbk/1904-5-reduce-firewall-section-size

## Solution

Provide a method to check which zones have been modified from the default settings

Required by https://github.com/yast/yast-firewall/pull/134