### PR TITLE
Update is_wsl to match osrelease spellings under both WSL1 and WSL2

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -477,7 +477,11 @@ module Yast
     #
     # @return [Boolean] true if runs on WSL; false otherwise
     def is_wsl
-      SCR.Read(path(".target.string"), "/proc/sys/kernel/osrelease").to_s.include?("-Microsoft")
+      # As of 2020-07-24 /proc/sys/kernel/osrelease contains
+      # "4.4.0-19041-Microsoft" on wsl1 and
+      # "4.19.104-microsoft-standard" on wsl2.
+      # Match on lowercase  "-microsoft"
+      SCR.Read(path(".target.string"), "/proc/sys/kernel/osrelease").to_s.downcase.include?("-microsoft")
     end
 
     publish function: :architecture, type: "string ()"

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -135,8 +135,16 @@ describe Yast::Arch do
         .and_return(osrelease)
     end
 
-    context "when it runs on a Microsoft kernel" do
-      let(:osrelease) { "5.3.11-Microsoft" }
+    context "when it runs on a Microsoft kernel under WSL1" do
+      let(:osrelease) { "4.4.0-19041-Microsoft" }
+
+      it "returns true" do
+        expect(Yast::Arch.is_wsl).to eq(true)
+      end
+    end
+
+    context "when it runs on a Microsoft kernel under WSL2" do
+      let(:osrelease) { "4.19.104-microsoft-standard" }
 
       it "returns true" do
         expect(Yast::Arch.is_wsl).to eq(true)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 24 08:06:27 UTC 2020 - Jeff Kowalczyk <jkowalczyk@suse.com>
+
+- update is_wsl function to match wsl1 and wsl2 osrelease spellings
+  (boo#1174183)
+
+-------------------------------------------------------------------
 Thu Jul 23 14:03:42 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Add Layout class to configure a Wizard layout.


### PR DESCRIPTION
Microsoft kernels are named "4.0-19041-Microsoft" on WSL1 and
"4.19.104-microsoft-standard" on WSL2. Match on lowercase "-microsoft".
(boo#1174183)