### PR TITLE
Fix XML system ID

### DIFF
--- a/library/xml/src/modules/XML.rb
+++ b/library/xml/src/modules/XML.rb
@@ -60,7 +60,7 @@ module Yast
       @listEntries = {}
 
       # The system ID, or the DTD URI
-      @systemID = ""
+      @systemID = nil
 
       # root element of the XML file
       @rootElement = ""
@@ -87,7 +87,7 @@ module Yast
           "cdataSections",
           @cdataSections
         ),
-        "systemID"      => Ops.get_string(doc_settings, "systemID", @systemID),
+        "systemID"      => doc_settings["systemID"],
         "rootElement"   => Ops.get_string(
           doc_settings,
           "rootElement",

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jul 28 14:27:40 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- XML: do not export the system ID if it is not defined
+  (boo#1174424).
+- 4.3.19
+
+-------------------------------------------------------------------
 Tue Jul 28 09:07:05 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Handle exceptions when parsing xml file (related to bsc#1170886)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.18
+Version:        4.3.19
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Do not export the system ID when it is not defined. It generates:

```xml
<!DOCTYPE profile>
```

instead of:

```xml
<!DOCTYPE profile SYSTEM "">
```

Trello: https://trello.com/c/WtDObsGz/1983-3-tw-1174424-build-20200720-autoyast-profile-doesnt-validate
Bug report: https://bugzilla.opensuse.org/show_bug.cgi?id=1174424