### PR TITLE
autoimage removed in docu

### DIFF
--- a/library/general/doc/Hooks.md
+++ b/library/general/doc/Hooks.md
@@ -237,7 +237,6 @@ those above from 2 to 13. Instead there are these:
 * autoinit
 * autosetup
 * initial_autoinstallation_proposal
-* autoimage
 
 Those entries might vary due to different entries in you xml profile which drives
 the autoinstallation workflow. The rest of the checkpoints listed above should not much differ.


### PR DESCRIPTION
Changes in *.changes, *.spec not needed because it is not in the RPM