### PR TITLE
Split the GitHub actions to run in parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,56 @@ jobs:
     - name: Inspect Installed Packages
       run: rpm -qa | sort
 
-    - name: Rubocop, Tests, Package Build
-      run: yast-travis-ruby
+    - name: Unit Tests
+      run: rake test:unit
+
+  Rubocop:
+    runs-on: ubuntu-latest
+    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v1
+
+    - name: Inspect Installed Packages
+      run: rpm -qa | sort
+
+    - name: Rubocop
+      run: rake check:rubocop
+
+  Package_and_POT:
+    runs-on: ubuntu-latest
+    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v1
+
+    - name: Inspect Installed Packages
+      run: rpm -qa | sort
+
+    - name: Package Build
+      run: yast-travis-ruby -o package
+
+    - name: POT Check
+      run: yast-travis-ruby -o pot
+
+  Yardoc_and_Perl:
+    runs-on: ubuntu-latest
+    container: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+
+    steps:
+
+    - name: Git Checkout
+      uses: actions/checkout@v1
+
+    - name: Inspect Installed Packages
+      run: rpm -qa | sort
+
+    - name: Yardoc
+      run: yast-travis-ruby -o yardoc
+
+    - name: Perl Syntax
+      run: yast-travis-ruby -o perl_syntax


### PR DESCRIPTION
Advantages:

- Parallel builds are faster
- Get separate results for Rubocop, unit test, etc... you do not need to check the details in the logs, you can see directly where the problem is