### PR TITLE
Error handling in Y2Packager::Resolvable.find()

### DIFF
--- a/library/packages/src/lib/y2packager/resolvable.rb
+++ b/library/packages/src/lib/y2packager/resolvable.rb
@@ -55,10 +55,19 @@ module Y2Packager
     #    you might ask to preload the attributes right at the beginning and avoid
     #    querying libzypp again later.
     # @return [Array<Y2Packager::Resolvable>] Found resolvables or empty array if nothing found
+    # @raise [ArgumentError] Raises ArgumentError when the passed regular expression is invalid
+    # @note The regular expressions used in the RPM dependency filters (e.g. "provides_regexp",
+    #    "supplements_regexp") are POSIX extended regular expressions, not Ruby regular expressions!
     # @see https://yast-pkg-bindings.surge.sh/ Yast::Pkg.Resolvables
     def self.find(params, preload = [])
       attrs = (preload + UNIQUE_ATTRIBUTES).uniq
-      Yast::Pkg.Resolvables(params, attrs).map { |r| new(r) }
+      resolvables = Yast::Pkg.Resolvables(params, attrs)
+
+      # currently nil is returned only when an invalid regular expression
+      # is passed in a RPM dependency filter (like supplements_regexp: "autoyast(")
+      raise ArgumentError, Yast::Pkg.LastError if resolvables.nil?
+
+      resolvables.map { |r| new(r) }
     end
 
     #

--- a/library/packages/test/y2packager/resolvable_test.rb
+++ b/library/packages/test/y2packager/resolvable_test.rb
@@ -43,6 +43,31 @@ describe Y2Packager::Resolvable do
       expect(res).to_not be_empty
       expect(res.all? { |r| r.kind == :package && r.name == "yast2-add-on" }).to be true
     end
+
+    it "finds packages via an RPM dependency filter" do
+      res = Y2Packager::Resolvable.find(kind: :package, provides: "application()")
+      expect(res.size).to eq(73)
+      # it is enough to check just one of them
+      expect(res).to include(an_object_having_attributes(name: "yast2-packager"))
+    end
+
+    it "finds packages via an RPM dependency regexp filter" do
+      res = Y2Packager::Resolvable.find(kind: :package, obsoletes_regexp: "^yast2-config-")
+      expect(res.size).to eq(10)
+      # it is enough to check just one of them
+      expect(res).to include(an_object_having_attributes(name: "yast2-firewall"))
+    end
+
+    it "returns an empty list if the RPM dependency filter does not match" do
+      res = Y2Packager::Resolvable.find(kind: :package, provides: "missing_provides")
+      expect(res).to be_empty
+    end
+
+    it "raises ArgumentError when the RPM dependency regexp filter is invalid" do
+      # the "(" character is a grouping meta character, the closing ")" is missing
+      expect { Y2Packager::Resolvable.find(kind: :package, provides_regexp: "foo(") }
+        .to raise_error(ArgumentError, /Invalid regular expression/)
+    end
   end
 
   describe ".any?" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Aug 26 08:22:45 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Y2Packager::Resolvable.find(): improved error handling,
+  added more unit tests (related to bsc#1175317)
+- 4.3.21
+
+-------------------------------------------------------------------
 Tue Aug 25 09:46:20 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Unify profile element paths (bsc#1175680).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.20
+Version:        4.3.21
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only
@@ -49,8 +49,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:simpleidn)
 # Needed already in build time
 BuildRequires:  yast2-core >= 2.18.12
 BuildRequires:  yast2-devtools >= 3.1.10
-# Pkg.Resolvables()
-BuildRequires:  yast2-pkg-bindings >= 4.2.0
+# RPM dependency filters in Pkg.Resolvables()
+BuildRequires:  yast2-pkg-bindings >= 4.3.0
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # for XML module
 BuildRequires:  rubygem(%rb_default_ruby_abi:nokogiri)
@@ -88,8 +88,8 @@ Requires:       yast2-core >= 2.23.0
 Requires:       yast2-hardware-detection
 # for SLPAPI.pm
 Requires:       yast2-perl-bindings
-# Pkg.Resolvables()
-Requires:       yast2-pkg-bindings >= 4.2.0
+# RPM dependency filters in Pkg.Resolvables()
+BuildRequires:  yast2-pkg-bindings >= 4.3.0
 # for y2start
 Requires:       yast2-ruby-bindings >= 3.2.10
 # new UI::SetApplicationTitle


### PR DESCRIPTION
- Improved error handling - the `Pkg.Resolvables()` call can now return `nil` as an error result, we need to handle that case
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1175317
- Related to https://github.com/yast/yast-pkg-bindings/pull/136
- Added more unit tests