### PR TITLE
Fixed unit test failure on non x86_64 archs

### DIFF
--- a/library/packages/test/y2packager/resolvable_test.rb
+++ b/library/packages/test/y2packager/resolvable_test.rb
@@ -46,14 +46,12 @@ describe Y2Packager::Resolvable do
 
     it "finds packages via an RPM dependency filter" do
       res = Y2Packager::Resolvable.find(kind: :package, provides: "application()")
-      expect(res.size).to eq(73)
       # it is enough to check just one of them
       expect(res).to include(an_object_having_attributes(name: "yast2-packager"))
     end
 
     it "finds packages via an RPM dependency regexp filter" do
       res = Y2Packager::Resolvable.find(kind: :package, obsoletes_regexp: "^yast2-config-")
-      expect(res.size).to eq(10)
       # it is enough to check just one of them
       expect(res).to include(an_object_having_attributes(name: "yast2-firewall"))
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 27 08:30:07 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fix for the previous change: fixed unit test failure on non
+  x86_64 archs (related to bsc#1175317)
+- 4.3.22
+
+-------------------------------------------------------------------
 Wed Aug 26 08:22:45 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Y2Packager::Resolvable.find(): improved error handling,

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.21
+Version:        4.3.22
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Related to https://github.com/yast/yast-yast2/pull/1092
- The included testing repository contains only the x86_64 packages, on the other architectures they will be ignored (only noarch are visible). So we cannot check the exact number of found packages in the tests.
- 4.3.22