### PR TITLE
Fixed accidentaly broken dependencies

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Aug 27 10:37:14 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed accidentaly broken dependencies (related to bsc#1175317)
+- 4.3.24
+
+-------------------------------------------------------------------
 Thu Aug 27 09:20:42 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Yet another unit test architecture fix :-(

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.23
+Version:        4.3.24
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only
@@ -89,7 +89,7 @@ Requires:       yast2-hardware-detection
 # for SLPAPI.pm
 Requires:       yast2-perl-bindings
 # RPM dependency filters in Pkg.Resolvables()
-BuildRequires:  yast2-pkg-bindings >= 4.3.0
+Requires:  yast2-pkg-bindings >= 4.3.0
 # for y2start
 Requires:       yast2-ruby-bindings >= 3.2.10
 # new UI::SetApplicationTitle


### PR DESCRIPTION
- Caused by a copy&paste (without edit) mistake [here](https://github.com/yast/yast-yast2/commit/f276944b2bff049b557aa8b2eb3426489858ec3c#diff-9cf9a66e281d2c4515d6f3682dd152eb).
- 4.3.24