### PR TITLE
Update progress status when an error pop up is displayed (bsc#1175926)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Metrics/BlockLength:
     - "library/*/test/**/*_test.rb"
 
 Metrics/PerceivedComplexity:
-  Max: 65
+  Max: 70
 
 # this needs more testing if we can have frozen string literals
 Style/FrozenStringLiteralComment:

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -141,7 +141,7 @@ module Yast
     # at start of file providal
     #
     def StartProvide(name, archivesize, remote)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("StartProvide: name: %1, remote: %2", name, remote)
       if remote
         sz = String.FormatSizeWithPrecision(archivesize, 2, false)
@@ -172,7 +172,7 @@ module Yast
     # during file providal
     #
     def ProgressProvide(percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ProgressProvide: %1", percent)
       if @_provide_popup
         UI.ChangeWidget(Id(:progress), :Value, percent)
@@ -187,7 +187,7 @@ module Yast
 
     # redirect ProgressDeltaApply callback (a different signature is required)
     def ProgressDeltaApply(percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       ProgressProvide(percent)
 
       nil
@@ -199,7 +199,7 @@ module Yast
     #  // return "R" for retry
     #  // return "C" for abort
     def DoneProvide(error, reason, name)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("DoneProvide: %1, %2, %3", error, reason, name)
 
       if @_provide_popup
@@ -364,7 +364,7 @@ module Yast
 
     #  At start of package install.
     def StartPackage(name, _location, _summary, installsize, is_delete)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       return if !@enable_asterix_package
 
       @_package_name = name
@@ -400,7 +400,7 @@ module Yast
 
     #  During package install.
     def ProgressPackage(percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if @_package_popup
         UI.ChangeWidget(Id(:progress), :Value, percent)
         return UI.PollInput != :abort
@@ -444,7 +444,7 @@ module Yast
     #  return "R" for retry
     #  return "C" for abort (not implemented !)
     def DonePackage(error, reason)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # remove invalid characters (bnc#876459)
       if !reason.valid_encoding?
         reason.encode!("UTF-16", undef: :replace, invalid: :replace, replace: "?")
@@ -576,7 +576,7 @@ module Yast
     # return url to change media URL
 
     def MediaChange(error_code, error, url, product, current, current_label, wanted, wanted_label, double_sided, devices, current_device)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       devices = deep_copy(devices)
       if @autorefreshing && @autorefreshing_aborted
         Builtins.y2milestone("Refresh aborted")
@@ -963,7 +963,7 @@ module Yast
 
     # dummy repository change callback, see SlideShowCallbacks for the real one
     def SourceChange(source, medianr)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceChange (%1, %2)", source, medianr)
       @_current_source = source
 
@@ -1056,7 +1056,7 @@ module Yast
     end
 
     def SourceCreateInit
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceCreateInit")
 
       OpenSourcePopup()
@@ -1065,7 +1065,7 @@ module Yast
     end
 
     def SourceCreateDestroy
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceCreateDestroy")
 
       CloseSourcePopup()
@@ -1074,7 +1074,7 @@ module Yast
     end
 
     def SourceCreateStart(url)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceCreateStart: %1", url)
 
       # popup label (%1 is repository URL)
@@ -1096,7 +1096,7 @@ module Yast
     end
 
     def SourceCreateProgress(percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       ret = SourcePopupSetProgress(percent)
       Builtins.y2milestone("SourceCreateProgress(%1) = %2", percent, ret)
 
@@ -1104,7 +1104,7 @@ module Yast
     end
 
     def SourceCreateError(url, error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source create: error: url: %1, error: %2, description: %3",
         URL.HidePassword(url),
@@ -1168,7 +1168,7 @@ module Yast
     end
 
     def SourceCreateEnd(url, error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # set 100% progress
       SourcePopupSetProgress(100)
 
@@ -1183,7 +1183,7 @@ module Yast
     end
 
     def SourceProbeStart(url)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceProbeStart: %1", URL.HidePassword(url))
 
       # popup label (%1 is repository URL)
@@ -1210,7 +1210,7 @@ module Yast
     end
 
     def SourceProbeFailed(url, type)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Repository %1 is not %2 repository",
         URL.HidePassword(url),
@@ -1221,7 +1221,7 @@ module Yast
     end
 
     def SourceProbeSucceeded(url, type)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Repository %1 is type %2",
         URL.HidePassword(url),
@@ -1232,12 +1232,12 @@ module Yast
     end
 
     def SourceProbeProgress(_url, value)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       SourcePopupSetProgress(value)
     end
 
     def SourceProbeError(url, error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source probe: error: url: %1, error: %2, description: %3",
         URL.HidePassword(url),
@@ -1303,7 +1303,7 @@ module Yast
     end
 
     def SourceProbeEnd(url, error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       CloseSourcePopup()
       CloseSourcePopup()
 
@@ -1318,7 +1318,7 @@ module Yast
     end
 
     def SourceReportStart(source_id, url, task)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source report start: src: %1, URL: %2, task: %3",
         source_id,
@@ -1342,7 +1342,7 @@ module Yast
     end
 
     def SourceReportProgress(value)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       ret = SourcePopupSetProgress(value)
       Builtins.y2debug("SourceReportProgress(%1) = %2", value, ret)
 
@@ -1350,7 +1350,7 @@ module Yast
     end
 
     def SourceReportError(source_id, url, error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source report: error: id: %1, url: %2, error: %3, description: %4",
         source_id,
@@ -1412,7 +1412,7 @@ module Yast
     end
 
     def SourceReportEnd(src_id, url, task, error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source report end: src: %1, url: %2, task: %3, error: %4, description: %5",
         src_id,
@@ -1429,7 +1429,7 @@ module Yast
     end
 
     def SourceReportInit
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Source report init")
       OpenSourcePopup()
 
@@ -1437,7 +1437,7 @@ module Yast
     end
 
     def SourceReportDestroy
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Source report destroy")
       CloseSourcePopup()
 
@@ -1447,7 +1447,7 @@ module Yast
     # at start of delta providal
     #
     def StartDeltaProvide(name, archivesize)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       sz = String.FormatSizeWithPrecision(archivesize, 2, false)
       if Mode.commandline
         CommandLine.PrintVerbose(
@@ -1471,7 +1471,7 @@ module Yast
     # at start of delta application
     #
     def StartDeltaApply(name)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if Mode.commandline
         CommandLine.PrintVerbose(
           Builtins.sformat(_("Applying delta RPM package %1..."), name)
@@ -1496,7 +1496,7 @@ module Yast
     end
 
     def FinishDeltaProvide
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if @_provide_popup
         UI.CloseDialog
         @_provide_popup = false
@@ -1506,7 +1506,7 @@ module Yast
     end
 
     def ProblemDeltaDownload(descr)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       FinishDeltaProvide() # close popup
       Builtins.y2milestone("Failed to download delta RPM: %1", descr)
 
@@ -1514,7 +1514,7 @@ module Yast
     end
 
     def ProblemDeltaApply(descr)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       FinishDeltaProvide() # close popup
       Builtins.y2milestone("Failed to apply delta RPM: %1", descr)
 
@@ -1539,7 +1539,7 @@ module Yast
     end
 
     def ScriptStart(patch_name, patch_version, patch_arch, script_path)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       patch_full_name = FormatPatchName(patch_name, patch_version, patch_arch)
 
       Builtins.y2milestone(
@@ -1602,7 +1602,7 @@ module Yast
     end
 
     def ScriptProgress(ping, output)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ScriptProgress: ping:%1, output: %2", ping, output)
 
       if @_script_popup
@@ -1623,7 +1623,7 @@ module Yast
     end
 
     def ScriptProblem(description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2warning("ScriptProblem: %1", description)
 
       ui = Popup.AnyQuestion3(
@@ -1657,7 +1657,7 @@ module Yast
     end
 
     def ScriptFinish
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ScriptFinish")
 
       UI.CloseDialog if @_script_popup
@@ -1666,7 +1666,7 @@ module Yast
     end
 
     def Message(patch_name, patch_version, patch_arch, message)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       patch_full_name = FormatPatchName(patch_name, patch_version, patch_arch)
       Builtins.y2milestone("Message (%1): %2", patch_full_name, message)
 
@@ -1767,14 +1767,14 @@ module Yast
     end
 
     def DestDownload
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       CloseDownloadProgressPopup() if !full_screen
 
       nil
     end
 
     def StartDownload(url, localfile)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Downloading %1 to %2",
         URL.HidePassword(url),
@@ -1804,7 +1804,7 @@ module Yast
     end
 
     def ProgressDownload(percent, bps_avg, bps_current)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if @autorefreshing && @autorefreshing_aborted
         Builtins.y2milestone("Refresh aborted")
         return false
@@ -1875,7 +1875,7 @@ module Yast
 
     # just log the status, errors are handled in MediaChange callback
     def DoneDownload(error_value, error_text)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if error_value == 0
         Builtins.y2milestone("Download finished")
       elsif @autorefreshing && @autorefreshing_aborted
@@ -1892,7 +1892,7 @@ module Yast
     end
 
     def RefreshStarted
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Autorefreshing repositories...")
 
       if !Mode.commandline && UI.WidgetExists(Id(:abort))
@@ -1908,7 +1908,7 @@ module Yast
     end
 
     def RefreshDone
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if !Mode.commandline && UI.WidgetExists(Id(:abort))
         UI.ChangeWidget(Id(:abort), :Label, Label.AbortButton)
         UI.RecalcLayout
@@ -1934,7 +1934,7 @@ module Yast
     end
 
     def StartRebuildDB
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # heading of popup
       heading = _("Checking Package Database")
 
@@ -1962,14 +1962,14 @@ module Yast
     end
 
     def ProgressRebuildDB(percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       UI.ChangeWidget(Id(:progress), :Value, percent)
 
       nil
     end
 
     def StopRebuildDB(error_value, error_text)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if error_value != 0
         # error message, %1 is the cause for the error
         Popup.Error(
@@ -1986,7 +1986,7 @@ module Yast
     end
 
     def NotifyRebuildDB
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       nil
     end
 
@@ -2004,7 +2004,7 @@ module Yast
     end
 
     def StartConvertDB(_unused1)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # heading of popup
       heading = _("Checking Package Database")
 
@@ -2036,14 +2036,14 @@ module Yast
     end
 
     def ProgressConvertDB(percent, _file)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       UI.ChangeWidget(Id(:progress), :Value, percent)
 
       nil
     end
 
     def StopConvertDB(error_value, error_text)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if error_value != 0
         # error message, %1 is the cause for the error
         Popup.Error(
@@ -2060,7 +2060,7 @@ module Yast
     end
 
     def NotifyConvertDB
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       nil
     end
 
@@ -2081,7 +2081,7 @@ module Yast
 
     # Callback for start RPM DB scan event
     def StartScanDb
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Scanning RPM DB...")
 
       if Mode.commandline
@@ -2125,7 +2125,7 @@ module Yast
 
     # Callback for RPM DB scan progress
     def ProgressScanDb(value)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if Mode.commandline
         CommandLine.PrintVerboseNoCR(CLEAR_PROGRESS_TEXT + "#{value}%")
       elsif @_scan_popup && UI.WidgetExists(Id(:label_scanDB_popup))
@@ -2145,7 +2145,7 @@ module Yast
 
     # Callback for error handling during RPM DB scan
     def ErrorScanDb(error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2error(
         "ErrorScanDb callback: error: %1, description: %2",
         error,
@@ -2237,7 +2237,7 @@ module Yast
 
     # Callback for finish RPM DB scan event
     def DoneScanDb(error, description)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "RPM DB scan finished: error: %1, reason: '%2'",
         error,
@@ -2258,7 +2258,7 @@ module Yast
     end
 
     def Authentication(url, msg, username, password)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # FIXME: after SLE12 release
       # The following 'if' block is a workaround for bnc#895719 that should be
       # extracted to a proper private method (not sure if it will work as
@@ -2338,7 +2338,7 @@ module Yast
     end
 
     def ProgressStart(id, task, in_percent, is_alive, _min, _max, _val_raw, val_percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ProgressStart: %1", id)
 
       @tick_progress = is_alive
@@ -2392,7 +2392,7 @@ module Yast
     end
 
     def ProgressEnd(id)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ProgressFinish: %1", id)
 
       # remove the last element from the progress stack
@@ -2425,7 +2425,7 @@ module Yast
     end
 
     def ProgressProgress(id, val_raw, val_percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2debug("ProgressProgress: %1, %2%% ", id, val_percent)
 
       if Mode.commandline
@@ -2467,7 +2467,7 @@ module Yast
     # @param [Array<String>] stages Descriptions of the stages
     # @param [String] help Help text describing the process
     def ProcessStart(task, stages, help)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       stages = deep_copy(stages)
       Builtins.y2milestone(
         "Process: Start: task: %1, stages: %2, help: %3",
@@ -2509,7 +2509,7 @@ module Yast
     # Hander for ProcessProgress callback - report total progress
     # @param [Fixnum] percent Total progress in percent
     def ProcessProgress(percent)
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2debug("Process: %1%%", percent)
 
       return true if Mode.commandline
@@ -2521,7 +2521,7 @@ module Yast
 
     # Hander for ProcessNextStage callback - the current stage has been finished
     def ProcessNextStage
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Setting stage: %1", @last_stage)
 
       return if Mode.commandline
@@ -2535,7 +2535,7 @@ module Yast
 
     # Hander for ProcessDone callback - the process has been finished
     def ProcessDone
-      log.debug("Starting callback #{self.class}::#{__method__}")
+      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Process: Finished")
       return if Mode.commandline
 

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -141,7 +141,6 @@ module Yast
     # at start of file providal
     #
     def StartProvide(name, archivesize, remote)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("StartProvide: name: %1, remote: %2", name, remote)
       if remote
         sz = String.FormatSizeWithPrecision(archivesize, 2, false)
@@ -172,7 +171,6 @@ module Yast
     # during file providal
     #
     def ProgressProvide(percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ProgressProvide: %1", percent)
       if @_provide_popup
         UI.ChangeWidget(Id(:progress), :Value, percent)
@@ -187,7 +185,6 @@ module Yast
 
     # redirect ProgressDeltaApply callback (a different signature is required)
     def ProgressDeltaApply(percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       ProgressProvide(percent)
 
       nil
@@ -199,7 +196,6 @@ module Yast
     #  // return "R" for retry
     #  // return "C" for abort
     def DoneProvide(error, reason, name)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("DoneProvide: %1, %2, %3", error, reason, name)
 
       if @_provide_popup
@@ -364,7 +360,6 @@ module Yast
 
     #  At start of package install.
     def StartPackage(name, _location, _summary, installsize, is_delete)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       return if !@enable_asterix_package
 
       @_package_name = name
@@ -400,7 +395,6 @@ module Yast
 
     #  During package install.
     def ProgressPackage(percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if @_package_popup
         UI.ChangeWidget(Id(:progress), :Value, percent)
         return UI.PollInput != :abort
@@ -444,7 +438,6 @@ module Yast
     #  return "R" for retry
     #  return "C" for abort (not implemented !)
     def DonePackage(error, reason)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # remove invalid characters (bnc#876459)
       if !reason.valid_encoding?
         reason.encode!("UTF-16", undef: :replace, invalid: :replace, replace: "?")
@@ -576,7 +569,6 @@ module Yast
     # return url to change media URL
 
     def MediaChange(error_code, error, url, product, current, current_label, wanted, wanted_label, double_sided, devices, current_device)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       devices = deep_copy(devices)
       if @autorefreshing && @autorefreshing_aborted
         Builtins.y2milestone("Refresh aborted")
@@ -963,7 +955,6 @@ module Yast
 
     # dummy repository change callback, see SlideShowCallbacks for the real one
     def SourceChange(source, medianr)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceChange (%1, %2)", source, medianr)
       @_current_source = source
 
@@ -1056,7 +1047,6 @@ module Yast
     end
 
     def SourceCreateInit
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceCreateInit")
 
       OpenSourcePopup()
@@ -1065,7 +1055,6 @@ module Yast
     end
 
     def SourceCreateDestroy
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceCreateDestroy")
 
       CloseSourcePopup()
@@ -1074,7 +1063,6 @@ module Yast
     end
 
     def SourceCreateStart(url)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceCreateStart: %1", url)
 
       # popup label (%1 is repository URL)
@@ -1096,7 +1084,6 @@ module Yast
     end
 
     def SourceCreateProgress(percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       ret = SourcePopupSetProgress(percent)
       Builtins.y2milestone("SourceCreateProgress(%1) = %2", percent, ret)
 
@@ -1104,7 +1091,6 @@ module Yast
     end
 
     def SourceCreateError(url, error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source create: error: url: %1, error: %2, description: %3",
         URL.HidePassword(url),
@@ -1168,7 +1154,6 @@ module Yast
     end
 
     def SourceCreateEnd(url, error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # set 100% progress
       SourcePopupSetProgress(100)
 
@@ -1183,7 +1168,6 @@ module Yast
     end
 
     def SourceProbeStart(url)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("SourceProbeStart: %1", URL.HidePassword(url))
 
       # popup label (%1 is repository URL)
@@ -1210,7 +1194,6 @@ module Yast
     end
 
     def SourceProbeFailed(url, type)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Repository %1 is not %2 repository",
         URL.HidePassword(url),
@@ -1221,7 +1204,6 @@ module Yast
     end
 
     def SourceProbeSucceeded(url, type)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Repository %1 is type %2",
         URL.HidePassword(url),
@@ -1232,12 +1214,10 @@ module Yast
     end
 
     def SourceProbeProgress(_url, value)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       SourcePopupSetProgress(value)
     end
 
     def SourceProbeError(url, error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source probe: error: url: %1, error: %2, description: %3",
         URL.HidePassword(url),
@@ -1303,7 +1283,6 @@ module Yast
     end
 
     def SourceProbeEnd(url, error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       CloseSourcePopup()
       CloseSourcePopup()
 
@@ -1318,7 +1297,6 @@ module Yast
     end
 
     def SourceReportStart(source_id, url, task)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source report start: src: %1, URL: %2, task: %3",
         source_id,
@@ -1342,7 +1320,6 @@ module Yast
     end
 
     def SourceReportProgress(value)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       ret = SourcePopupSetProgress(value)
       Builtins.y2debug("SourceReportProgress(%1) = %2", value, ret)
 
@@ -1350,7 +1327,6 @@ module Yast
     end
 
     def SourceReportError(source_id, url, error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source report: error: id: %1, url: %2, error: %3, description: %4",
         source_id,
@@ -1412,7 +1388,6 @@ module Yast
     end
 
     def SourceReportEnd(src_id, url, task, error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Source report end: src: %1, url: %2, task: %3, error: %4, description: %5",
         src_id,
@@ -1429,7 +1404,6 @@ module Yast
     end
 
     def SourceReportInit
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Source report init")
       OpenSourcePopup()
 
@@ -1437,7 +1411,6 @@ module Yast
     end
 
     def SourceReportDestroy
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Source report destroy")
       CloseSourcePopup()
 
@@ -1447,7 +1420,6 @@ module Yast
     # at start of delta providal
     #
     def StartDeltaProvide(name, archivesize)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       sz = String.FormatSizeWithPrecision(archivesize, 2, false)
       if Mode.commandline
         CommandLine.PrintVerbose(
@@ -1471,7 +1443,6 @@ module Yast
     # at start of delta application
     #
     def StartDeltaApply(name)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if Mode.commandline
         CommandLine.PrintVerbose(
           Builtins.sformat(_("Applying delta RPM package %1..."), name)
@@ -1496,7 +1467,6 @@ module Yast
     end
 
     def FinishDeltaProvide
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if @_provide_popup
         UI.CloseDialog
         @_provide_popup = false
@@ -1506,7 +1476,6 @@ module Yast
     end
 
     def ProblemDeltaDownload(descr)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       FinishDeltaProvide() # close popup
       Builtins.y2milestone("Failed to download delta RPM: %1", descr)
 
@@ -1514,7 +1483,6 @@ module Yast
     end
 
     def ProblemDeltaApply(descr)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       FinishDeltaProvide() # close popup
       Builtins.y2milestone("Failed to apply delta RPM: %1", descr)
 
@@ -1539,7 +1507,6 @@ module Yast
     end
 
     def ScriptStart(patch_name, patch_version, patch_arch, script_path)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       patch_full_name = FormatPatchName(patch_name, patch_version, patch_arch)
 
       Builtins.y2milestone(
@@ -1602,7 +1569,6 @@ module Yast
     end
 
     def ScriptProgress(ping, output)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ScriptProgress: ping:%1, output: %2", ping, output)
 
       if @_script_popup
@@ -1623,7 +1589,6 @@ module Yast
     end
 
     def ScriptProblem(description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2warning("ScriptProblem: %1", description)
 
       ui = Popup.AnyQuestion3(
@@ -1657,7 +1622,6 @@ module Yast
     end
 
     def ScriptFinish
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ScriptFinish")
 
       UI.CloseDialog if @_script_popup
@@ -1666,7 +1630,6 @@ module Yast
     end
 
     def Message(patch_name, patch_version, patch_arch, message)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       patch_full_name = FormatPatchName(patch_name, patch_version, patch_arch)
       Builtins.y2milestone("Message (%1): %2", patch_full_name, message)
 
@@ -1767,14 +1730,12 @@ module Yast
     end
 
     def DestDownload
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       CloseDownloadProgressPopup() if !full_screen
 
       nil
     end
 
     def StartDownload(url, localfile)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "Downloading %1 to %2",
         URL.HidePassword(url),
@@ -1804,7 +1765,6 @@ module Yast
     end
 
     def ProgressDownload(percent, bps_avg, bps_current)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if @autorefreshing && @autorefreshing_aborted
         Builtins.y2milestone("Refresh aborted")
         return false
@@ -1875,7 +1835,6 @@ module Yast
 
     # just log the status, errors are handled in MediaChange callback
     def DoneDownload(error_value, error_text)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if error_value == 0
         Builtins.y2milestone("Download finished")
       elsif @autorefreshing && @autorefreshing_aborted
@@ -1892,7 +1851,6 @@ module Yast
     end
 
     def RefreshStarted
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Autorefreshing repositories...")
 
       if !Mode.commandline && UI.WidgetExists(Id(:abort))
@@ -1908,7 +1866,6 @@ module Yast
     end
 
     def RefreshDone
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if !Mode.commandline && UI.WidgetExists(Id(:abort))
         UI.ChangeWidget(Id(:abort), :Label, Label.AbortButton)
         UI.RecalcLayout
@@ -1934,7 +1891,6 @@ module Yast
     end
 
     def StartRebuildDB
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # heading of popup
       heading = _("Checking Package Database")
 
@@ -1962,14 +1918,12 @@ module Yast
     end
 
     def ProgressRebuildDB(percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       UI.ChangeWidget(Id(:progress), :Value, percent)
 
       nil
     end
 
     def StopRebuildDB(error_value, error_text)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if error_value != 0
         # error message, %1 is the cause for the error
         Popup.Error(
@@ -1986,7 +1940,6 @@ module Yast
     end
 
     def NotifyRebuildDB
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       nil
     end
 
@@ -2004,7 +1957,6 @@ module Yast
     end
 
     def StartConvertDB(_unused1)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # heading of popup
       heading = _("Checking Package Database")
 
@@ -2036,14 +1988,12 @@ module Yast
     end
 
     def ProgressConvertDB(percent, _file)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       UI.ChangeWidget(Id(:progress), :Value, percent)
 
       nil
     end
 
     def StopConvertDB(error_value, error_text)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if error_value != 0
         # error message, %1 is the cause for the error
         Popup.Error(
@@ -2060,7 +2010,6 @@ module Yast
     end
 
     def NotifyConvertDB
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       nil
     end
 
@@ -2081,7 +2030,6 @@ module Yast
 
     # Callback for start RPM DB scan event
     def StartScanDb
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Scanning RPM DB...")
 
       if Mode.commandline
@@ -2125,7 +2073,6 @@ module Yast
 
     # Callback for RPM DB scan progress
     def ProgressScanDb(value)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       if Mode.commandline
         CommandLine.PrintVerboseNoCR(CLEAR_PROGRESS_TEXT + "#{value}%")
       elsif @_scan_popup && UI.WidgetExists(Id(:label_scanDB_popup))
@@ -2145,7 +2092,6 @@ module Yast
 
     # Callback for error handling during RPM DB scan
     def ErrorScanDb(error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2error(
         "ErrorScanDb callback: error: %1, description: %2",
         error,
@@ -2237,7 +2183,6 @@ module Yast
 
     # Callback for finish RPM DB scan event
     def DoneScanDb(error, description)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone(
         "RPM DB scan finished: error: %1, reason: '%2'",
         error,
@@ -2258,7 +2203,6 @@ module Yast
     end
 
     def Authentication(url, msg, username, password)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       # FIXME: after SLE12 release
       # The following 'if' block is a workaround for bnc#895719 that should be
       # extracted to a proper private method (not sure if it will work as
@@ -2338,7 +2282,6 @@ module Yast
     end
 
     def ProgressStart(id, task, in_percent, is_alive, _min, _max, _val_raw, val_percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ProgressStart: %1", id)
 
       @tick_progress = is_alive
@@ -2392,7 +2335,6 @@ module Yast
     end
 
     def ProgressEnd(id)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("ProgressFinish: %1", id)
 
       # remove the last element from the progress stack
@@ -2425,7 +2367,6 @@ module Yast
     end
 
     def ProgressProgress(id, val_raw, val_percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2debug("ProgressProgress: %1, %2%% ", id, val_percent)
 
       if Mode.commandline
@@ -2467,7 +2408,6 @@ module Yast
     # @param [Array<String>] stages Descriptions of the stages
     # @param [String] help Help text describing the process
     def ProcessStart(task, stages, help)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       stages = deep_copy(stages)
       Builtins.y2milestone(
         "Process: Start: task: %1, stages: %2, help: %3",
@@ -2509,7 +2449,6 @@ module Yast
     # Hander for ProcessProgress callback - report total progress
     # @param [Fixnum] percent Total progress in percent
     def ProcessProgress(percent)
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2debug("Process: %1%%", percent)
 
       return true if Mode.commandline
@@ -2521,7 +2460,6 @@ module Yast
 
     # Hander for ProcessNextStage callback - the current stage has been finished
     def ProcessNextStage
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Setting stage: %1", @last_stage)
 
       return if Mode.commandline
@@ -2535,7 +2473,6 @@ module Yast
 
     # Hander for ProcessDone callback - the process has been finished
     def ProcessDone
-      log.info("Starting callback #{self.class}::#{__method__}") if ENV["Y2DEBUG_CALLBACKS"] == "1"
       Builtins.y2milestone("Process: Finished")
       return if Mode.commandline
 

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -596,6 +596,12 @@ module Yast
         current_device
       )
 
+      if full_screen
+        # make sure the old subprogress is cleared when displaying a popup (bsc#1175926)
+        Progress.SubprogressValue(0)
+        Progress.SubprogressTitle("")
+      end
+
       url_scheme = Ops.get_string(URL.Parse(url), "scheme", "").downcase
 
       # true if it makes sense to offer an eject button (for cd/dvd only ...)

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -75,7 +75,9 @@ module Yast
       hook = <<-HOOK
       def #{name}_hook(*params)
         log.info("Starting callback #{self}::#{name}")
-        #{name}_without_hook(*params)
+        result = #{name}_without_hook(*params)
+        log.info("Callback #{self}::#{name} returned: \#{result.inspect}")
+        result
       end
       HOOK
       # __FILE__ and __LINE__ are used in a backtrace

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -141,6 +141,7 @@ module Yast
     # at start of file providal
     #
     def StartProvide(name, archivesize, remote)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("StartProvide: name: %1, remote: %2", name, remote)
       if remote
         sz = String.FormatSizeWithPrecision(archivesize, 2, false)
@@ -171,6 +172,7 @@ module Yast
     # during file providal
     #
     def ProgressProvide(percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("ProgressProvide: %1", percent)
       if @_provide_popup
         UI.ChangeWidget(Id(:progress), :Value, percent)
@@ -185,6 +187,7 @@ module Yast
 
     # redirect ProgressDeltaApply callback (a different signature is required)
     def ProgressDeltaApply(percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       ProgressProvide(percent)
 
       nil
@@ -196,6 +199,7 @@ module Yast
     #  // return "R" for retry
     #  // return "C" for abort
     def DoneProvide(error, reason, name)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("DoneProvide: %1, %2, %3", error, reason, name)
 
       if @_provide_popup
@@ -360,6 +364,7 @@ module Yast
 
     #  At start of package install.
     def StartPackage(name, _location, _summary, installsize, is_delete)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       return if !@enable_asterix_package
 
       @_package_name = name
@@ -395,6 +400,7 @@ module Yast
 
     #  During package install.
     def ProgressPackage(percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if @_package_popup
         UI.ChangeWidget(Id(:progress), :Value, percent)
         return UI.PollInput != :abort
@@ -438,6 +444,7 @@ module Yast
     #  return "R" for retry
     #  return "C" for abort (not implemented !)
     def DonePackage(error, reason)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       # remove invalid characters (bnc#876459)
       if !reason.valid_encoding?
         reason.encode!("UTF-16", undef: :replace, invalid: :replace, replace: "?")
@@ -569,6 +576,7 @@ module Yast
     # return url to change media URL
 
     def MediaChange(error_code, error, url, product, current, current_label, wanted, wanted_label, double_sided, devices, current_device)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       devices = deep_copy(devices)
       if @autorefreshing && @autorefreshing_aborted
         Builtins.y2milestone("Refresh aborted")
@@ -949,6 +957,7 @@ module Yast
 
     # dummy repository change callback, see SlideShowCallbacks for the real one
     def SourceChange(source, medianr)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("SourceChange (%1, %2)", source, medianr)
       @_current_source = source
 
@@ -1041,6 +1050,7 @@ module Yast
     end
 
     def SourceCreateInit
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("SourceCreateInit")
 
       OpenSourcePopup()
@@ -1049,6 +1059,7 @@ module Yast
     end
 
     def SourceCreateDestroy
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("SourceCreateDestroy")
 
       CloseSourcePopup()
@@ -1057,6 +1068,7 @@ module Yast
     end
 
     def SourceCreateStart(url)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("SourceCreateStart: %1", url)
 
       # popup label (%1 is repository URL)
@@ -1078,6 +1090,7 @@ module Yast
     end
 
     def SourceCreateProgress(percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       ret = SourcePopupSetProgress(percent)
       Builtins.y2milestone("SourceCreateProgress(%1) = %2", percent, ret)
 
@@ -1085,6 +1098,7 @@ module Yast
     end
 
     def SourceCreateError(url, error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Source create: error: url: %1, error: %2, description: %3",
         URL.HidePassword(url),
@@ -1148,6 +1162,7 @@ module Yast
     end
 
     def SourceCreateEnd(url, error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       # set 100% progress
       SourcePopupSetProgress(100)
 
@@ -1162,6 +1177,7 @@ module Yast
     end
 
     def SourceProbeStart(url)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("SourceProbeStart: %1", URL.HidePassword(url))
 
       # popup label (%1 is repository URL)
@@ -1188,6 +1204,7 @@ module Yast
     end
 
     def SourceProbeFailed(url, type)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Repository %1 is not %2 repository",
         URL.HidePassword(url),
@@ -1198,6 +1215,7 @@ module Yast
     end
 
     def SourceProbeSucceeded(url, type)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Repository %1 is type %2",
         URL.HidePassword(url),
@@ -1208,10 +1226,12 @@ module Yast
     end
 
     def SourceProbeProgress(_url, value)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       SourcePopupSetProgress(value)
     end
 
     def SourceProbeError(url, error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Source probe: error: url: %1, error: %2, description: %3",
         URL.HidePassword(url),
@@ -1277,6 +1297,7 @@ module Yast
     end
 
     def SourceProbeEnd(url, error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       CloseSourcePopup()
       CloseSourcePopup()
 
@@ -1291,6 +1312,7 @@ module Yast
     end
 
     def SourceReportStart(source_id, url, task)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Source report start: src: %1, URL: %2, task: %3",
         source_id,
@@ -1314,6 +1336,7 @@ module Yast
     end
 
     def SourceReportProgress(value)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       ret = SourcePopupSetProgress(value)
       Builtins.y2debug("SourceReportProgress(%1) = %2", value, ret)
 
@@ -1321,6 +1344,7 @@ module Yast
     end
 
     def SourceReportError(source_id, url, error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Source report: error: id: %1, url: %2, error: %3, description: %4",
         source_id,
@@ -1382,6 +1406,7 @@ module Yast
     end
 
     def SourceReportEnd(src_id, url, task, error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Source report end: src: %1, url: %2, task: %3, error: %4, description: %5",
         src_id,
@@ -1398,6 +1423,7 @@ module Yast
     end
 
     def SourceReportInit
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("Source report init")
       OpenSourcePopup()
 
@@ -1405,6 +1431,7 @@ module Yast
     end
 
     def SourceReportDestroy
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("Source report destroy")
       CloseSourcePopup()
 
@@ -1414,6 +1441,7 @@ module Yast
     # at start of delta providal
     #
     def StartDeltaProvide(name, archivesize)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       sz = String.FormatSizeWithPrecision(archivesize, 2, false)
       if Mode.commandline
         CommandLine.PrintVerbose(
@@ -1437,6 +1465,7 @@ module Yast
     # at start of delta application
     #
     def StartDeltaApply(name)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if Mode.commandline
         CommandLine.PrintVerbose(
           Builtins.sformat(_("Applying delta RPM package %1..."), name)
@@ -1461,6 +1490,7 @@ module Yast
     end
 
     def FinishDeltaProvide
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if @_provide_popup
         UI.CloseDialog
         @_provide_popup = false
@@ -1470,6 +1500,7 @@ module Yast
     end
 
     def ProblemDeltaDownload(descr)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       FinishDeltaProvide() # close popup
       Builtins.y2milestone("Failed to download delta RPM: %1", descr)
 
@@ -1477,6 +1508,7 @@ module Yast
     end
 
     def ProblemDeltaApply(descr)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       FinishDeltaProvide() # close popup
       Builtins.y2milestone("Failed to apply delta RPM: %1", descr)
 
@@ -1501,6 +1533,7 @@ module Yast
     end
 
     def ScriptStart(patch_name, patch_version, patch_arch, script_path)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       patch_full_name = FormatPatchName(patch_name, patch_version, patch_arch)
 
       Builtins.y2milestone(
@@ -1563,6 +1596,7 @@ module Yast
     end
 
     def ScriptProgress(ping, output)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("ScriptProgress: ping:%1, output: %2", ping, output)
 
       if @_script_popup
@@ -1583,6 +1617,7 @@ module Yast
     end
 
     def ScriptProblem(description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2warning("ScriptProblem: %1", description)
 
       ui = Popup.AnyQuestion3(
@@ -1616,6 +1651,7 @@ module Yast
     end
 
     def ScriptFinish
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("ScriptFinish")
 
       UI.CloseDialog if @_script_popup
@@ -1624,6 +1660,7 @@ module Yast
     end
 
     def Message(patch_name, patch_version, patch_arch, message)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       patch_full_name = FormatPatchName(patch_name, patch_version, patch_arch)
       Builtins.y2milestone("Message (%1): %2", patch_full_name, message)
 
@@ -1724,12 +1761,14 @@ module Yast
     end
 
     def DestDownload
+      log.debug("Starting callback #{self.class}::#{__method__}")
       CloseDownloadProgressPopup() if !full_screen
 
       nil
     end
 
     def StartDownload(url, localfile)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "Downloading %1 to %2",
         URL.HidePassword(url),
@@ -1759,6 +1798,7 @@ module Yast
     end
 
     def ProgressDownload(percent, bps_avg, bps_current)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if @autorefreshing && @autorefreshing_aborted
         Builtins.y2milestone("Refresh aborted")
         return false
@@ -1829,6 +1869,7 @@ module Yast
 
     # just log the status, errors are handled in MediaChange callback
     def DoneDownload(error_value, error_text)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if error_value == 0
         Builtins.y2milestone("Download finished")
       elsif @autorefreshing && @autorefreshing_aborted
@@ -1845,6 +1886,7 @@ module Yast
     end
 
     def RefreshStarted
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("Autorefreshing repositories...")
 
       if !Mode.commandline && UI.WidgetExists(Id(:abort))
@@ -1860,6 +1902,7 @@ module Yast
     end
 
     def RefreshDone
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if !Mode.commandline && UI.WidgetExists(Id(:abort))
         UI.ChangeWidget(Id(:abort), :Label, Label.AbortButton)
         UI.RecalcLayout
@@ -1885,6 +1928,7 @@ module Yast
     end
 
     def StartRebuildDB
+      log.debug("Starting callback #{self.class}::#{__method__}")
       # heading of popup
       heading = _("Checking Package Database")
 
@@ -1912,12 +1956,14 @@ module Yast
     end
 
     def ProgressRebuildDB(percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       UI.ChangeWidget(Id(:progress), :Value, percent)
 
       nil
     end
 
     def StopRebuildDB(error_value, error_text)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if error_value != 0
         # error message, %1 is the cause for the error
         Popup.Error(
@@ -1934,6 +1980,7 @@ module Yast
     end
 
     def NotifyRebuildDB
+      log.debug("Starting callback #{self.class}::#{__method__}")
       nil
     end
 
@@ -1951,6 +1998,7 @@ module Yast
     end
 
     def StartConvertDB(_unused1)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       # heading of popup
       heading = _("Checking Package Database")
 
@@ -1982,12 +2030,14 @@ module Yast
     end
 
     def ProgressConvertDB(percent, _file)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       UI.ChangeWidget(Id(:progress), :Value, percent)
 
       nil
     end
 
     def StopConvertDB(error_value, error_text)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if error_value != 0
         # error message, %1 is the cause for the error
         Popup.Error(
@@ -2004,6 +2054,7 @@ module Yast
     end
 
     def NotifyConvertDB
+      log.debug("Starting callback #{self.class}::#{__method__}")
       nil
     end
 
@@ -2024,6 +2075,7 @@ module Yast
 
     # Callback for start RPM DB scan event
     def StartScanDb
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("Scanning RPM DB...")
 
       if Mode.commandline
@@ -2067,6 +2119,7 @@ module Yast
 
     # Callback for RPM DB scan progress
     def ProgressScanDb(value)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       if Mode.commandline
         CommandLine.PrintVerboseNoCR(CLEAR_PROGRESS_TEXT + "#{value}%")
       elsif @_scan_popup && UI.WidgetExists(Id(:label_scanDB_popup))
@@ -2086,6 +2139,7 @@ module Yast
 
     # Callback for error handling during RPM DB scan
     def ErrorScanDb(error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2error(
         "ErrorScanDb callback: error: %1, description: %2",
         error,
@@ -2177,6 +2231,7 @@ module Yast
 
     # Callback for finish RPM DB scan event
     def DoneScanDb(error, description)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone(
         "RPM DB scan finished: error: %1, reason: '%2'",
         error,
@@ -2197,6 +2252,7 @@ module Yast
     end
 
     def Authentication(url, msg, username, password)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       # FIXME: after SLE12 release
       # The following 'if' block is a workaround for bnc#895719 that should be
       # extracted to a proper private method (not sure if it will work as
@@ -2276,6 +2332,7 @@ module Yast
     end
 
     def ProgressStart(id, task, in_percent, is_alive, _min, _max, _val_raw, val_percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("ProgressStart: %1", id)
 
       @tick_progress = is_alive
@@ -2329,6 +2386,7 @@ module Yast
     end
 
     def ProgressEnd(id)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("ProgressFinish: %1", id)
 
       # remove the last element from the progress stack
@@ -2361,6 +2419,7 @@ module Yast
     end
 
     def ProgressProgress(id, val_raw, val_percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2debug("ProgressProgress: %1, %2%% ", id, val_percent)
 
       if Mode.commandline
@@ -2402,6 +2461,7 @@ module Yast
     # @param [Array<String>] stages Descriptions of the stages
     # @param [String] help Help text describing the process
     def ProcessStart(task, stages, help)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       stages = deep_copy(stages)
       Builtins.y2milestone(
         "Process: Start: task: %1, stages: %2, help: %3",
@@ -2443,6 +2503,7 @@ module Yast
     # Hander for ProcessProgress callback - report total progress
     # @param [Fixnum] percent Total progress in percent
     def ProcessProgress(percent)
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2debug("Process: %1%%", percent)
 
       return true if Mode.commandline
@@ -2454,6 +2515,7 @@ module Yast
 
     # Hander for ProcessNextStage callback - the current stage has been finished
     def ProcessNextStage
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("Setting stage: %1", @last_stage)
 
       return if Mode.commandline
@@ -2467,6 +2529,7 @@ module Yast
 
     # Hander for ProcessDone callback - the process has been finished
     def ProcessDone
+      log.debug("Starting callback #{self.class}::#{__method__}")
       Builtins.y2milestone("Process: Finished")
       return if Mode.commandline
 

--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -44,6 +44,50 @@ module Yast
     # symbols for ticking in cmd line
     TICK_LABELS = ["/", "-", "\\", "|"].freeze
 
+    # Debugging: log the called callbacks when Y2DEBUG_CALLBACKS is set to 1
+    #
+    # This uses some Ruby meta programming, the "method_added" is called whenever
+    # a new method is added into this class, i.e. when each of the following "def"
+    # is processed.
+    #
+    # @param name [Symbol] name of the added method
+    def self.method_added(name)
+      # log the callbacks only when requested, it's quite verbose
+      return if ENV["Y2DEBUG_CALLBACKS"] != "1"
+
+      name_str = name.to_s
+
+      # do not add a hook for a hook itself otherwise it would result
+      # in an endless recursive loop adding a hook for a hook for a hook for...
+      if name_str.end_with?("_hook") ||
+          # ignore dynamically added helper methods for the published variables
+          name_str.start_with?("_") ||
+          # ignore lowercase methods, they are just some helper methods
+          name_str.match(/^[[:lower:]]/) ||
+          # already present
+          method_defined?("#{name}_hook")
+
+        return
+      end
+
+      # add a new *_hook method as a wrapper for the original method,
+      # log the name of the called method
+      hook = <<-HOOK
+      def #{name}_hook(*params)
+        log.info("Starting callback #{self}::#{name}")
+        #{name}_without_hook(*params)
+      end
+      HOOK
+      # __FILE__ and __LINE__ are used in a backtrace
+      class_eval(hook, __FILE__, __LINE__)
+
+      # rename the original method
+      class_eval("alias #{name}_without_hook #{name}", __FILE__, __LINE__)
+
+      # replace the original method with the hook
+      class_eval("alias #{name} #{name}_hook", __FILE__, __LINE__)
+    end
+
     def main
       Yast.import "Pkg"
       Yast.import "UI"

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,9 +1,8 @@
 -------------------------------------------------------------------
-Thu Sep 10 07:30:52 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+Wed Sep  9 07:45:39 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
-- Enhance GPG module with symmetric encryption
-  (related to bsc#1176336)
-- add new shared password dialog
+- Clear the download progres for the previous file when displaying
+  an error popup (bsc#1175926)
 - 4.3.25
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,8 +1,18 @@
 -------------------------------------------------------------------
-Wed Sep  9 07:45:39 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+Tue Sep 15 09:29:51 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Clear the download progres for the previous file when displaying
   an error popup (bsc#1175926)
+- Enable additional callback logging when $Y2DEBUG_CALLBACKS is
+  set to "1"
+- 4.3.26
+
+-------------------------------------------------------------------
+Thu Sep 10 07:30:52 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- Enhance GPG module with symmetric encryption
+  (related to bsc#1176336)
+- add new shared password dialog
 - 4.3.25
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.25
+Version:        4.3.26
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## The Problem

- The download progress in the main window still shows the details about the previously downloaded file when an error pop up is displayed for a different file. That's quite confusing.
- See https://bugzilla.suse.com/show_bug.cgi?id=1175926

![refresh_progress_broken](https://user-images.githubusercontent.com/907998/92574007-d584a180-f286-11ea-845b-8f7d4913585e.png)


## The Fix

- Just reset the progress status before displaying the popup
- I wanted to display the URL of the failed file in the progress but unfortunately the URL parameter of the callback contains the repository URL (like `http://example.com`), not the failed file URL (like `http://example.com/repodata/repomd.xml`). That would be confusing so I decided to just clear the old label.

![refresh_progress_fixed](https://user-images.githubusercontent.com/907998/92574096-f3520680-f286-11ea-87fb-b47b2a8666b9.png)

## Additional Logging

- For easier debugging I have added a debug log to all callbacks so we can see the order in which they were called. Activated only when `Y2DEBUG_CALLBACKS` is set to `1`.