### PR TITLE
Allow to hide dialog heading

### DIFF
--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -282,12 +282,8 @@ module Yast
             HSpacing(1),
             VBox(
               VSpacing(0.2),
-              HBox(
-                # translators: dialog title to appear before any content is initialized
-                Heading(Id(:title), Opt(:hstretch), _("Initializing ...")),
-                HStretch(),
-                ReplacePoint(Id(:relnotes_rp), Empty())
-              ),
+              # translators: dialog title to appear before any content is initialized
+              ReplacePoint(Id(:heading), dialog_heading(_("Initializing ..."))),
               VWeight(
                 1, # Layout trick: Lower layout priority with weight
                 HVCenter(Opt(:hvstretch), ReplacePoint(Id(:contents), Empty()))
@@ -333,15 +329,8 @@ module Yast
             70,
             VBox(
               VSpacing(0.2),
-              HBox(
-                # translators: dialog title to appear before any content is initialized
-                Heading(
-                  Id(:title),
-                  Opt(:hstretch),
-                  _("YaST\nInitializing ...\n")
-                ),
-                HStretch()
-              ),
+              # translators: dialog title to appear before any content is initialized
+              ReplacePoint(Id(:heading), dialog_heading(_("YaST\nInitializing ...\n"))),
               VWeight(
                 1, # Layout trick: Lower layout priority with weight
                 HVCenter(Opt(:hvstretch), ReplacePoint(Id(:contents), Empty()))
@@ -828,7 +817,7 @@ module Yast
 
         UI.ChangeWidget(Id(:back), :Enabled, has_back) if UI.WidgetExists(Id(:back))
         UI.ChangeWidget(Id(:abort), :Enabled, true) if UI.WidgetExists(Id(:abort))
-        UI.ChangeWidget(Id(:title), :Value, title) if UI.WidgetExists(Id(:title))
+        UI.ReplaceWidget(Id(:heading), dialog_heading(title)) if UI.WidgetExists(Id(:heading))
 
         UI.SetFocus(Id(:accept)) if set_focus && UI.WidgetExists(Id(:accept))
       end
@@ -1859,6 +1848,21 @@ module Yast
       UI.SetApplicationIcon(@icon_name)
       true
     end
+  end
+
+  # Returns the content for the heading of the dialog
+  #
+  # The heading is hidden when no title is given
+  #
+  # @param title [String, nil]
+  def dialog_heading(title)
+    return Empty() if title.nil? || title.empty?
+
+    HBox(
+      Heading(Id(:title), Opt(:hstretch), title),
+      HStretch(),
+      ReplacePoint(Id(:relnotes_rp), Empty())
+    )
   end
 
   Wizard = WizardClass.new

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 16 11:14:41 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Hide heading of the dialog when no title is defined or title is
+  set to an empty string.
+- Related to bsc#1175489.
+- 4.3.27
+
+-------------------------------------------------------------------
 Tue Sep 15 09:29:51 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Clear the download progres for the previous file when displaying

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.26
+Version:        4.3.27
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

A Wizard dialog always reserves space for its heading, even when the title is not set or it is set as empty. In the Expert Partitioner we want to remove the *Expert Partitioner* title and to place the menu bar at the very top. But, due to such reserved space for the heading, the menu bar starts just after some blank gap, which looks quite strange.

* Part of PBI: https://trello.com/c/dT7X5aC1/2045-menu-layout-rendering-improvements

_Keeping the heading text:_

![expert_partitioner_installation_before](https://user-images.githubusercontent.com/1691872/93344113-34b75880-f829-11ea-9eb4-2ce9e0e9aa3a.png)

_[Setting the header as empty](https://github.com/yast/yast-storage-ng/commit/ffa251b77884ae3e237e8f97133baf11bdb34ad6):_

![expert_partitioner_installation_no_title](https://user-images.githubusercontent.com/1691872/93346266-b4462700-f82b-11ea-8163-c1f87d62a395.png)

## Solution

The heading of the dialog is now managed by a `ReplacePoint` widget. The content of the heading is only added when the title is not empty. Take into account that the *Release Notes* button belongs to the header, so this button also goes away when the title is not set.

NOTE: This changes only affects to the ncurses version. For the graphics dialog, see https://github.com/libyui/libyui-qt/pull/133.

![Screenshot_tw_2020-09-16_14:36:33](https://user-images.githubusercontent.com/1691872/93345034-49482080-f82a-11ea-953a-ce8f8031acd0.png)