### PR TITLE
Decrease error logging (bsc#1176653)

### DIFF
--- a/library/packages/src/modules/Slides.rb
+++ b/library/packages/src/modules/Slides.rb
@@ -192,7 +192,7 @@ module Yast
       tmp = Convert.to_map(WFM.Read(path(".local.stat"), @slide_base_path))
 
       if !Ops.get_boolean(tmp, "isdir", false)
-        Builtins.y2error("Using default path instead of %1", tmp)
+        Builtins.y2milestone("Using default path instead of %1", tmp)
         @slide_base_path = "/var/adm/YaST/InstSrcManager/tmp/CurrentMedia/suse/setup/slide"
       end
 
@@ -214,7 +214,7 @@ module Yast
     def CheckBasePath
       tmp = Convert.to_map(WFM.Read(path(".local.stat"), @slide_base_path))
       if !Ops.get_boolean(tmp, "isdir", false)
-        Builtins.y2error("Using default path instead of %1", @slide_base_path)
+        Builtins.y2milestone("Using default path instead of %1", @slide_base_path)
         @slide_base_path = "/var/adm/YaST/InstSrcManager/tmp/CurrentMedia/suse/setup/slide"
 
         return false

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 21 11:28:33 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Decrease error logging to avoid false positives in the y2log
+  (bsc#1176653)
+- 4.3.28
+
+-------------------------------------------------------------------
 Wed Sep 16 11:14:41 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Hide heading of the dialog when no title is defined or title is

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.27
+Version:        4.3.28
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Fixes and error present in the y2log even in a successful installation
- See https://bugzilla.suse.com/show_bug.cgi?id=1176653

## Notes

- There seems to be a different problem, the slideshow directory does not exist at that point. But I guess it's because we do not use slideshow anymore, it has been dropped.
- The code is more or less dead and needs a cleanup (complete removal) I'm doing just a simple and quick fix to ensure the openQA test passes. 