### PR TITLE
Fix systemctl command line options (bsc#1176714)

### DIFF
--- a/library/systemd/src/lib/yast2/systemctl.rb
+++ b/library/systemd/src/lib/yast2/systemctl.rb
@@ -23,7 +23,10 @@ module Yast2
     include Yast::Logger
 
     CONTROL         = "/usr/bin/systemctl".freeze
-    COMMAND_OPTIONS = " --no-legend --no-pager --no-ask-password ".freeze
+    # The combination "--full --no-legend --no-pager --plain" is appropriate for
+    # automated processing of systemctl output.
+    # https://github.com/systemd/systemd/commit/1cabd2d0c56b7de73e4a4fb645f3bbed4a528d2c
+    COMMAND_OPTIONS = " --plain --full --no-legend --no-pager --no-ask-password ".freeze
     ENV_VARS        = " LANG=C TERM=dumb COLUMNS=1024 ".freeze
     SYSTEMCTL       = ENV_VARS + CONTROL + COMMAND_OPTIONS
     TIMEOUT         = 40 # seconds

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Sep 23 13:21:38 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "--plain" and "--full" options for the "systemctl"
+  calls, these are recommended when processing the output
+  by scripts (bsc#1176714)
+- 4.3.29
+
+-------------------------------------------------------------------
 Mon Sep 21 11:28:33 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Decrease error logging to avoid false positives in the y2log

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.28
+Version:        4.3.29
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Fixes https://bugzilla.suse.com/show_bug.cgi?id=1176714
- It's related to https://github.com/systemd/systemd/commit/1cabd2d0c56b7de73e4a4fb645f3bbed4a528d2c, which says 
  > The combination "--full --no-legend --no-pager --plain" is appropriate for  automated processing of systemctl output.

## Test

Tested manually (as suggested in https://bugzilla.suse.com/show_bug.cgi?id=1176714#c11):

- Run `yast2 users`
- Go to `Expert Options` -> `Encryption`
- This will display DES as the selected option
- With the fix it correctly selects the SHA-512 option
