### PR TITLE
Do not crash when trying to parse "nil" XML file (bsc#1176593)

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1230,6 +1230,11 @@ module Yast
       ret
     end
 
+    # Read and remember the registration requirement status from an installation
+    # control XML file.
+    # The stored values can be read by the WorkflowsRequiringRegistration() method.
+    # @param filename [String] path to the XML file
+    # @return [Boolean] true if the file has been read properly, false in case of an error
     def IncorporateControlFileOptions(filename)
       return false if filename.nil?
 

--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1231,6 +1231,8 @@ module Yast
     end
 
     def IncorporateControlFileOptions(filename)
+      return false if filename.nil?
+
       begin
         update_file = XML.XMLToYCPFile(filename)
       rescue RuntimeError => e

--- a/library/xml/src/modules/XML.rb
+++ b/library/xml/src/modules/XML.rb
@@ -165,7 +165,7 @@ module Yast
     # @return [Hash] parsed content
     # @raise [XMLDeserializationError] when non supported XML is passed
     def XMLToYCPFile(xml_file)
-      raise XMLDeserializationError, "Cannot find XML file" if SCR.Read(path(".target.size"), xml_file) <= 0
+      raise XMLDeserializationError, "Cannot find XML file" if xml_file.nil? || SCR.Read(path(".target.size"), xml_file) <= 0
 
       log.info "Reading #{xml_file}"
       XMLToYCPString(SCR.Read(path(".target.string"), xml_file))

--- a/library/xml/src/modules/XML.rb
+++ b/library/xml/src/modules/XML.rb
@@ -165,7 +165,8 @@ module Yast
     # @return [Hash] parsed content
     # @raise [XMLDeserializationError] when non supported XML is passed
     def XMLToYCPFile(xml_file)
-      raise XMLDeserializationError, "Cannot find XML file" if xml_file.nil? || SCR.Read(path(".target.size"), xml_file) <= 0
+      raise ArgumentError, "XMLToYCPFile() received nil" if xml_file.nil?
+      raise XMLDeserializationError, "Cannot find XML file #{xml_file}" if SCR.Read(path(".target.size"), xml_file) <= 0
 
       log.info "Reading #{xml_file}"
       XMLToYCPString(SCR.Read(path(".target.string"), xml_file))

--- a/library/xml/test/xml_test.rb
+++ b/library/xml/test/xml_test.rb
@@ -591,4 +591,10 @@ describe "Yast::XML" do
       end
     end
   end
+
+  describe "#XMLToYCPFile" do
+    it "raises ArgumentError when nil is passed" do
+      expect { subject.XMLToYCPFile(nil) }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep 24 07:25:01 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not crash when trying to parse non-existing ("nil") add-on
+  product control XML file (bsc#1176593)
+- 4.3.30
+
+-------------------------------------------------------------------
 Wed Sep 23 13:21:38 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "--plain" and "--full" options for the "systemctl"

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.29
+Version:        4.3.30
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- See https://bugzilla.suse.com/show_bug.cgi?id=1176593
- YaST crashed because it wanted to parse `nil` file

## Test

- Tested manually with the latest SP3 build