### PR TITLE
Fix selector without opt

### DIFF
--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -201,7 +201,7 @@ module CWM
   private
 
     def editable?
-      opt.include?(:editable)
+      respond_to?(:opt) && opt.include?(:editable)
     end
   end
 

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -126,12 +126,31 @@ describe CWM::ComboBox do
     end
   end
 
-  subject { MountPointSelector.new }
+  class SelectorWithoutOpt < CWM::ComboBox
+    def label
+      ""
+    end
+
+    def items
+      [["/", "/ (root)"]]
+    end
+  end
 
   describe "#value=" do
     describe "when the widget is editable" do
+      subject { MountPointSelector.new }
+
       it "adds the given value to the list of items" do
         expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
+        subject.value = "/srv"
+      end
+    end
+
+    describe "when the widget is not editable" do
+      subject { SelectorWithoutOpt.new }
+
+      it "does not add the given value to the list of items" do
+        expect(subject).to_not receive(:change_items)
         subject.value = "/srv"
       end
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Sep 28 08:53:39 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Fix non-editable ComboBox handling (bsc#1136454).
+- 4.3.32
+
+-------------------------------------------------------------------
 Fri Sep 25 08:59:57 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Small improvements to CWM based widgets (related to bsc#1136454):

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.31
+Version:        4.3.32
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Fixes #1044 in case that the `opt` method is not defined.