### PR TITLE
Revert the drop of SuSEFirewall2

### DIFF
--- a/library/network/src/lib/network/firewalld.rb
+++ b/library/network/src/lib/network/firewalld.rb
@@ -1,0 +1,355 @@
+#
+# ***************************************************************************
+#
+# Copyright (c) 2016 SUSE LLC.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 or 3 of the GNU General
+# Public License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE about this file by physical or electronic mail,
+# you may find current contact information at www.suse.com
+#
+# ***************************************************************************
+#
+# File: lib/network/firewalld.rb
+# Summary:  FirewallD configuration API
+# Authors:  Karol Mroz <kmroz@suse.de>, Markos Chandras <mchandras@suse.de>
+#
+
+require "yast"
+require "shellwords"
+
+module Firewalld
+  # exception when firewall-cmd fails
+  class FirewallCMDError < StandardError
+  end
+
+  # Execute firewalld commands using firewall-cmd
+  class FWCmd
+    include Yast::Logger
+
+    BASH_SCR_PATH = Yast::Path.new(".target.bash_output")
+    # Base firewall-cmd command
+    COMMAND = "LANG=C /usr/bin/firewall-cmd".freeze
+
+    attr_reader :option_str
+
+    def initialize(option_str)
+      @option_str = option_str
+    end
+
+    def command
+      "#{COMMAND} #{option_str}".strip.squeeze(" ")
+    end
+
+    # @param output [Boolean] Whether command output is desirable or not
+    # @return [String] Firewalld command output if output = true
+    # @return [Boolean] Firewalld command exit code if output = false
+    def fwd_output(output = true)
+      cmd_result = Yast::SCR.Execute(BASH_SCR_PATH, command)
+
+      # See firewall-cmd manpage for exit codes. Not all of them justify an
+      # exception. 0 and 1 can be used as true and false respectively.
+      case cmd_result["exit"]
+      when 0, 1
+        if output
+          cmd_result["stdout"]
+        else
+          log.debug "#{command} returned: #{cmd_result["stdout"]}"
+          cmd_result["exit"].zero? ? true : false
+        end
+      else
+        raise FirewallCMDError, "Calling firewall-cmd (cmd: #{command}) failed: #{cmd_result["stderr"]}"
+      end
+    end
+  end
+
+  # The firewalld API. We only use the command line interface.
+  class FirewalldAPI
+    def self.create(type = :bash)
+      case type
+      when :bash
+        FirewalldBashAPI.new
+      when :dbus
+        nil
+      else
+        raise "Unsupported Firewalld API type: #{type}"
+      end
+    end
+  end
+
+  # The firewalld bash API
+  class FirewalldBashAPI
+    include Yast::Logger
+
+  private
+
+    # Simple wrapper for commands. Returns true on success
+    def fwd_quiet_result(*args)
+      fwcmd = FWCmd.new(args.join(""))
+      fwcmd.fwd_output(false)
+    end
+
+    # Simple wrapper for commands. Returns command output
+    def fwd_result(*args)
+      fwcmd = FWCmd.new(args.join(""))
+      fwcmd.fwd_output(true)
+    end
+
+  public
+
+    ### State ###
+
+    # @return [Boolean] The firewalld service state (exit code)
+    def running?
+      fwd_quiet_result("--state")
+    end
+
+    # @return [Boolean] The firewalld reload result (exit code)
+    def reload
+      fwd_quiet_result("--reload")
+    end
+
+    # @return [Boolean] The firewalld complete-reload result (exit code)
+    def complete_reload
+      fwd_quiet_result("--complete-reload")
+    end
+
+    # @return [Boolean] The firewalld runtime-to-permanent result (exit code)
+    def make_permanent
+      fwd_quiet_result("--runtime-to-permanent")
+    end
+
+    ### Zones ####
+
+    # @return [Array<String>] List of firewall zones
+    def zones
+      fwd_result("--permanent --get-zones").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of zone's interfaces
+    def list_interfaces(zone)
+      fwd_result("--permanent --zone=#{zone.shellescape} --list-interfaces").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Arrray<String>] list of zone's services
+    def list_services(zone)
+      fwd_result("--permanent --zone=#{zone.shellescape} --list-services").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of zone's ports
+    def list_ports(zone)
+      fwd_result("--permanent --zone=#{zone.shellescape} --list-ports").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of zone's protocols
+    def list_protocols(zone)
+      fwd_result("--permanent --zone=#{zone.shellescape} --list-protocols").split(" ")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Array<String>] list of all information for given zone
+    def list_all(zone)
+      fwd_result("--permanent --zone=#{zone.shellescape} --list-all").split(" ")
+    end
+
+    # @return [Array<String>] list of all information for all firewall zones
+    def list_all_zones
+      fwd_result("--permanent --list-all-zones").split("\n")
+    end
+
+    ### Interfaces ###
+
+    # @param zone [String] The firewall zone
+    # @param interface [String] The network interface
+    # @return [Boolean] True if interface is assigned to zone
+    def interface_enabled?(zone, interface)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --query-interface=#{interface.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param interface [String] The network interface
+    # @return [Boolean] True if interface was added to zone
+    def add_interface(zone, interface)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --add-interface=#{interface.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param interface [String] The network interface
+    # @return [Boolean] True if interface was removed from zone
+    def remove_interface(zone, interface)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --remove-interface=#{interface.shellescape}")
+    end
+
+    ### Services ###
+
+    # @return [Array<String>] List of firewall services
+    def services
+      fwd_result("--permanent --get-services").split(" ")
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] list of all information for the given service
+    def info_service(service)
+      fwd_result("--permanent --info-service #{service.shellescape}").split("\n")
+    end
+
+    # @param service [String] The firewall service
+    # @return [String] Short description for service
+    def service_short(service)
+      # these may not exist on early firewalld releases
+      fwd_result("--permanent --service=#{service.shellescape} --get-short").rstrip
+    end
+
+    # @param service [String] the firewall service
+    # @return [String] Description for service
+    def service_description(service)
+      fwd_result("--permanent --service=#{service.shellescape} --get-description").rstrip
+    end
+
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service definition exists
+    def service_supported?(service)
+      services.include?(service)
+    end
+
+    # @param zone [String] The firewall zone
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service is enabled in zone
+    def service_enabled?(zone, service)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --query-service=#{service.shellescape}")
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] The firewall service ports
+    def service_ports(service)
+      fwd_result("--permanent --service=#{service.shellescape} --get-ports").strip
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] The firewall service protocols
+    def service_protocols(service)
+      fwd_result("--permanent --service=#{service.shellescape} --get-protocols").strip
+    end
+
+    # @param service [String] The firewall service
+    # @return [Array<String>] The firewall service modules
+    def service_modules(service)
+      fwd_result("--permanent --service=#{service.shellescape} --get-modules").strip
+    end
+
+    # @param zone [String] The firewall zone
+    # @param port [String] The firewall port
+    # @return [Boolean] True if port is enabled in zone
+    def port_enabled?(zone, port)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --query-port=#{port}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param protocol [String] The zone protocol
+    # @return [Boolean] True if protocol is enabled in zone
+    def protocol_enabled?(zone, protocol)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --query-protocol=#{protocol}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service was added to zone
+    def add_service(zone, service)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --add-service=#{service.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param port [String] The firewall port
+    # @return [Boolean] True if port was added to zone
+    def add_port(zone, port)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --add-port=#{port.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param protocol [String] The firewall protocol
+    # @return [Boolean] True if protocol was added to zone
+    def add_protocol(zone, protocol)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --add-protocol=#{protocol.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param service [String] The firewall service
+    # @return [Boolean] True if service was removed from zone
+    def remove_service(zone, service)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --remove-service=#{service.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param port [String] The firewall port
+    # @return [Boolean] True if port was removed from zone
+    def remove_port(zone, port)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --remove-port=#{port.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @param protocol [String] The firewall protocol
+    # @return [Boolean] True if protocol was removed from zone
+    def remove_protocol(zone, protocol)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --remove-protocol=#{protocol.shellescape}")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Boolean] True if masquerade is enabled in zone
+    def masquerade_enabled?(zone)
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --query-masquerade")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Boolean] True if masquerade was enabled in zone
+    def add_masquerade(zone)
+      return true if masquerade_enabled?(zone)
+
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --add-masquerade")
+    end
+
+    # @param zone [String] The firewall zone
+    # @return [Boolean] True if masquerade was removed in zone
+    def remove_masquerade(zone)
+      return true if !masquerade_enabled?(zone)
+
+      fwd_quiet_result("--permanent --zone=#{zone.shellescape} --remove-masquerade")
+    end
+
+    ### Logging ###
+
+    # @param kind [String] Denied packets to log. Possible values are:
+    # all, unicast, broadcast, multicast and off
+    # @return [Boolean] True if desired packet type is being logged when denied
+    def log_denied_packets?(kind)
+      (fwd_result("--get-log-denied").strip == kind) ? true : false
+    end
+
+    # @param kind [String] Denied packets to log. Possible values are:
+    # all, unicast, broadcast, multicast and off
+    # @return [Boolean] True if desired packet type was set to being logged
+    # when denied
+    def log_denied_packets=(kind)
+      fwd_quiet_result("--set-log-denied=#{kind.to_s.shellescape}")
+    end
+
+    # @return [String] packet type which is being logged when denied
+    def log_denied_packets
+      fwd_result("--get-log-denied").strip
+    end
+  end
+end

--- a/library/network/src/lib/network/susefirewall.rb
+++ b/library/network/src/lib/network/susefirewall.rb
@@ -1,0 +1,1072 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+#
+# Authors:     Markos Chandras <mchandras@suse.de>, Karol Mroz <kmroz@suse.de>
+#
+# $Id$
+#
+# Module for handling SuSEfirewall2 or FirewallD
+require "yast"
+
+module Yast
+  # Factory for construction of appropriate firewall object based on
+  # desired backend.
+  class SuSEFirewallClass < Module
+    # @return [String] the systemd service name: "firewalld" or "SuSEfirewall2"
+    attr_reader :firewall_service
+
+    Yast.import "Mode"
+    Yast.import "NetworkInterfaces"
+    Yast.import "PackageSystem"
+    Yast.import "PortRanges"
+    Yast.import "Service"
+
+    include Yast::Logger
+
+    def initialize
+      textdomain "base"
+    end
+
+    # Function which returns if SuSEfirewall2 should start in Write process.
+    # In fact it means that SuSEfirewall2 will at the end.
+    #
+    # @return  [Boolean] if the firewall should start
+    def GetStartService
+      Ops.get_boolean(@SETTINGS, "start_firewall", false)
+    end
+
+    # Function which sets if SuSEfirewall should start in Write process.
+    #
+    # @param [Boolean] start_service at Write() process
+    # @see #GetStartService()
+    def SetStartService(start_service)
+      if !SuSEFirewallIsSelectedOrInstalled()
+        Builtins.y2warning("Cannot set SetStartService")
+        return nil
+      end
+
+      if GetStartService() != start_service
+        SetModified()
+
+        Builtins.y2milestone("Setting start-firewall to %1", start_service)
+      else
+        # without set modified!
+        Builtins.y2milestone(
+          "start-firewall has been already set to %1",
+          start_service
+        )
+      end
+
+      Ops.set(@SETTINGS, "start_firewall", start_service)
+
+      nil
+    end
+
+    # Function which returns whether SuSEfirewall should be enabled in
+    # /etc/init.d/ starting scripts during the Write() process
+    #
+    # @see #Write()
+    # @see #EnableServices()
+    #
+    # @return  [Boolean] if the firewall should start
+    def GetEnableService
+      Ops.get_boolean(@SETTINGS, "enable_firewall", false)
+    end
+
+    # Function which sets if SuSEfirewall should start in Write process
+    #
+    # @param  boolean start_service at Write() process
+    def SetEnableService(enable_service)
+      if !SuSEFirewallIsSelectedOrInstalled()
+        Builtins.y2warning("Cannot set SetEnableService")
+        return nil
+      end
+
+      if GetEnableService() != enable_service
+        SetModified()
+
+        Builtins.y2milestone("Setting enable-firewall to %1", enable_service)
+      else
+        # without set modified
+        Builtins.y2milestone(
+          "enable-firewall has been already set to %1",
+          enable_service
+        )
+      end
+
+      Ops.set(@SETTINGS, "enable_firewall", enable_service)
+
+      nil
+    end
+
+    # Functions starts services needed for SuSEFirewall
+    #
+    # @return  [Boolean] result
+    def StartServices
+      return true if Mode.testsuite
+
+      return false if !SuSEFirewallIsInstalled()
+
+      if Service.Start(@firewall_service)
+        Builtins.y2milestone("Started")
+        return true
+      else
+        Builtins.y2error("Cannot start service %1", @firewall_service)
+        return false
+      end
+    end
+
+    # Functions stops services needed for SuSEFirewall
+    #
+    # @return  [Boolean] result
+    def StopServices
+      return true if Mode.testsuite
+
+      return false if !SuSEFirewallIsInstalled()
+
+      if Service.Stop(@firewall_service)
+        Builtins.y2milestone("Stopped")
+        return true
+      else
+        Builtins.y2error("Could not stop service %1", @firewall_service)
+        return false
+      end
+    end
+
+    # Functions enables services needed for SuSEFirewall in /etc/inet.d/
+    #
+    # @return  [Boolean] result
+    def EnableServices
+      all_ok = true
+
+      return false if !SuSEFirewallIsInstalled()
+
+      if !Service.Enable(@firewall_service)
+        all_ok = true
+        # TRANSLATORS: a popup error message
+        Report.LongError(Service.Error)
+      end
+
+      all_ok
+    end
+
+    # Functions disables services needed for SuSEFirewall in /etc/inet.d/
+    #
+    # @return  [Boolean] result
+    def DisableServices
+      return false if !SuSEFirewallIsInstalled()
+
+      return true if Service.Disable(@firewall_service)
+
+      Report.LongError(Service.Error)
+      false
+    end
+
+    # Function determines if all SuSEFirewall scripts are enabled in
+    # init scripts /etc/init.d/ now.
+    # For configuration "enabled" status use GetEnableService().
+    #
+    # @return  [Boolean] if enabled
+    def IsEnabled
+      return false if !SuSEFirewallIsInstalled()
+
+      if Service.Enabled(@firewall_service)
+        Builtins.y2milestone("Firewall service is enabled")
+        return true
+      else
+        Builtins.y2milestone("Firewall service is not enabled")
+        return false
+      end
+    end
+
+    # Function determines if at least one SuSEFirewall script is started now.
+    # For configuration "started" status use GetStartService().
+    #
+    # @return  [Boolean] if started
+    def IsStarted
+      return false if !SuSEFirewallIsInstalled()
+
+      return true if Mode.testsuite
+
+      Builtins.y2milestone("Checking firewall status...")
+      if Service.Status(@firewall_service) == 0
+        Builtins.y2milestone("Firewall service is started")
+        return true
+      else
+        Builtins.y2milestone("Firewall service is stopped")
+        return false
+      end
+    end
+
+    # Function returns list of known firewall zones (shortnames)
+    #
+    # @return  [Array<String>] of firewall zones
+    #
+    # @example GetKnownFirewallZones() -> ["DMZ", "EXT", "INT"]
+    def GetKnownFirewallZones
+      deep_copy(@known_firewall_zones)
+    end
+
+    # Function returns map of supported services in all firewall zones.
+    #
+    # @param  list <string> of services
+    # @return  [Hash <String, Hash{String => Boolean>}]
+    #
+    #
+    # **Structure:**
+    #
+    #      Returns $[service : $[ zone_name : supported_status]]
+    #
+    # @example
+    #  // Firewall in not protected from internal zone, that's why
+    #  // all services report that they are enabled in INT zone
+    #  GetServices (["samba-server", "service:irc-server"]) -> $[
+    #    "samba-server" : $["DMZ":false, "EXT":false, "INT":true],
+    #    "service:irc-server" : $["DMZ":false, "EXT":true, "INT":true]
+    #  ]
+    def GetServices(services)
+      services = deep_copy(services)
+      # $[ service : $[ firewall_zone : status ]]
+      services_status = {}
+
+      # for all services requested
+      Builtins.foreach(services) do |service|
+        Ops.set(services_status, service, {})
+        # for all zones in configuration
+        Builtins.foreach(GetKnownFirewallZones()) do |zone|
+          Ops.set(
+            services_status,
+            [service, zone],
+            IsServiceSupportedInZone(service, zone)
+          )
+        end
+      end
+
+      deep_copy(services_status)
+    end
+
+    # Function returns map of supported services all network interfaces.
+    #
+    # @param  list <string> of services
+    # @return  [Hash <String, Hash{String => Boolean} >]
+    #
+    #
+    # **Structure:**
+    #
+    #      Returns $[service : $[ interface : supported_status ]]
+    #
+    # @example
+    #  GetServicesInZones (["service:irc-server"]) -> $["service:irc-server":$["eth1":true]]
+    #  // No such service "something"
+    #  GetServicesInZones (["something"])) -> $["something":$["eth1":nil]]
+    #  GetServicesInZones (["samba-server"]) -> $["samba-server":$["eth1":false]]
+    def GetServicesInZones(services)
+      services = deep_copy(services)
+      # list of interfaces for each zone
+      interfaces_in_zone = {}
+
+      GetListOfKnownInterfaces().each do |i|
+        z = GetZoneOfInterface(i)
+        next if z.nil? || z.empty?
+
+        interfaces_in_zone[z] ||= []
+        interfaces_in_zone[z] << i
+      end
+
+      # $[ service : $[ network_interface : status ]]
+      services_status = {}
+
+      # for all services requested
+      Builtins.foreach(services) do |service|
+        Ops.set(services_status, service, {})
+        # for all zones in configuration
+        Builtins.foreach(interfaces_in_zone) do |zone, interfaces|
+          status = IsServiceSupportedInZone(service, zone)
+          # for all interfaces in zone
+          Builtins.foreach(interfaces) do |interface|
+            Ops.set(services_status, [service, interface], status)
+          end
+        end
+      end
+
+      deep_copy(services_status)
+    end
+
+    # Function sets status for several services on several network interfaces.
+    #
+    # @param  list <string> service ids
+    # @param  list <string> network interfaces
+    # @param  boolean new status of services
+    # @return  [Boolean] if successfull
+    #
+    # @example
+    #  // Disabling services
+    #  SetServices (["samba-server", "service:irc-server"], ["eth1", "modem0"], false)
+    #  // Enabling services
+    #  SetServices (["samba-server", "service:irc-server"], ["eth1", "modem0"], true)
+    # @see #SetServicesForZones()
+
+    def SetServices(services_ids, interfaces, new_status)
+      firewall_zones = GetZonesOfInterfacesWithAnyFeatureSupported(interfaces)
+      if Builtins.size(firewall_zones) == 0
+        Builtins.y2error(
+          "Interfaces '%1' are not in any group of interfaces",
+          interfaces
+        )
+        return false
+      end
+
+      SetModified()
+
+      SetServicesForZones(services_ids, firewall_zones, new_status)
+    end
+
+    # Function sets internal variable, which indicates, that any
+    # "firewall settings were modified", to "true".
+    def SetModified
+      @modified = true
+
+      nil
+    end
+
+    # Do not use this function.
+    # Only for firewall installation proposal.
+    def ResetModified
+      Builtins.y2milestone("Reseting firewall-modified to 'false'")
+      @modified = false
+
+      nil
+    end
+
+    # Functions returns whether any firewall's configuration was modified.
+    #
+    # @return  [Boolean] if the configuration was modified
+    def GetModified
+      Yast.import "SuSEFirewallServices"
+      # Changed SuSEFirewall or
+      # Changed SuSEFirewallServices (needs resatrting as well)
+      @modified || SuSEFirewallServices.GetModified
+    end
+
+    # By default Firewall packages are just checked whether they are installed.
+    # With this function, you can change the behavior to also offer installing
+    # the packages.
+    #
+    # @param [Boolean] new_status, 'true' if packages should be offered for installation
+    def SetInstallPackagesIfMissing(new_status)
+      if new_status.nil?
+        Builtins.y2error("Wrong value: %1", new_status)
+        return
+      end
+
+      @check_and_install_package = new_status
+
+      if @check_and_install_package
+        Builtins.y2milestone("Firewall packages will installed if missing")
+      else
+        Builtins.y2milestone(
+          "Firewall packages will not be installed even if missing"
+        )
+      end
+
+      nil
+    end
+
+    # Function returns list of maps of known interfaces.
+    #
+    # **Structure:**
+    #
+    #     [ $[ "id":"modem1", "name":"Askey 815C", "type":"dialup", "zone":"EXT" ], ... ]
+    #
+    # @return  [Array<Hash{String => String>}]
+    # @return [Array<Hash{String => String>}] of all interfaces
+    def GetAllKnownInterfaces
+      known_interfaces = []
+
+      # All dial-up interfaces
+      dialup_interfaces = NetworkInterfaces.List("dialup")
+      dialup_interfaces = [] if dialup_interfaces.nil?
+
+      # bugzilla #303858 - wrong values from NetworkInterfaces
+      dialup_interfaces = Builtins.filter(dialup_interfaces) do |one_iface|
+        if one_iface.nil? || one_iface == ""
+          Builtins.y2error("Wrong interface definition '%1'", one_iface)
+          next false
+        end
+        true
+      end
+
+      dialup_interfaces = Builtins.filter(dialup_interfaces) do |interface|
+        interface != "" && !Builtins.issubstring(interface, "lo") &&
+          !Builtins.issubstring(interface, "sit")
+      end
+
+      # All non-dial-up interfaces
+      non_dialup_interfaces = NetworkInterfaces.List("")
+      non_dialup_interfaces = [] if non_dialup_interfaces.nil?
+
+      # bugzilla #303858 - wrong values from NetworkInterfaces
+      non_dialup_interfaces = Builtins.filter(non_dialup_interfaces) do |one_iface|
+        if one_iface.nil? || one_iface == ""
+          Builtins.y2error("Wrong interface definition '%1'", one_iface)
+          next false
+        end
+        true
+      end
+
+      non_dialup_interfaces = Builtins.filter(non_dialup_interfaces) do |interface|
+        interface != "" && !Builtins.issubstring(interface, "lo") &&
+          !Builtins.issubstring(interface, "sit") &&
+          !Builtins.contains(dialup_interfaces, interface)
+      end
+
+      Builtins.foreach(dialup_interfaces) do |interface|
+        known_interfaces = Builtins.add(
+          known_interfaces,
+          "id"   => interface,
+          "type" => "dialup",
+          # using function to get name
+          "name" => NetworkInterfaces.GetValue(
+            interface,
+            "NAME"
+          ),
+          "zone" => GetZoneOfInterface(interface)
+        )
+      end
+
+      Builtins.foreach(non_dialup_interfaces) do |interface|
+        known_interfaces = Builtins.add(
+          known_interfaces,
+          "id"   => interface,
+          # using function to get name
+          "name" => NetworkInterfaces.GetValue(
+            interface,
+            "NAME"
+          ),
+          "zone" => GetZoneOfInterface(interface)
+        )
+      end
+
+      deep_copy(known_interfaces)
+    end
+
+    # Function returns list of all known interfaces.
+    #
+    # @return  [Array<String>] of interfaces
+    # @example GetListOfKnownInterfaces() -> ["eth1", "eth2", "modem0", "dsl5"]
+    def GetListOfKnownInterfaces
+      GetAllKnownInterfaces().map { |i| i["id"] }
+    end
+
+    # Function returns list of zones of requested interfaces
+    #
+    # @param [Array<String>] interfaces
+    # @return  [Array<String>] firewall zones
+    #
+    # @example
+    #  GetZonesOfInterfaces (["eth1","eth4"]) -> ["DMZ", "EXT"]
+    def GetZonesOfInterfaces(interfaces)
+      interfaces = deep_copy(interfaces)
+      zones = []
+      zone = ""
+
+      Builtins.foreach(interfaces) do |interface|
+        zone = GetZoneOfInterface(interface)
+        zones = Builtins.add(zones, zone) if !zone.nil?
+      end
+
+      Builtins.toset(zones)
+    end
+
+    # Function returns localized name of the zone identified by zone shortname.
+    #
+    # @param  string short name
+    # @return  [String] zone name
+    #
+    # @example
+    #  LANG=en_US GetZoneFullName ("EXT") -> "External Zone"
+    #  LANG=cs_CZ GetZoneFullName ("EXT") -> "Externí Zóna"
+    def GetZoneFullName(zone)
+      # TRANSLATORS: Firewall zone full-name, used as combo box item or dialog title
+      Ops.get(@zone_names, zone, _("Unknown Zone"))
+    end
+
+    # Function returns if zone (shortname like "EXT") is supported by firewall.
+    # Undefined zones are, for sure, unsupported.
+    #
+    # @param [String] zone shortname
+    # @return  [Boolean] if zone is known and supported.
+    def IsKnownZone(zone)
+      is_zone = false
+
+      Builtins.foreach(GetKnownFirewallZones()) do |known_zone|
+        if known_zone == zone
+          is_zone = true
+          raise Break
+        end
+      end
+
+      is_zone
+    end
+
+    # Returns whether all needed packages are installed (or selected for
+    # installation)
+    #
+    # @return [Boolean] whether the selected firewall backend is installed
+    def SuSEFirewallIsSelectedOrInstalled
+      return true if @needed_packages_installed
+
+      if Stage.initial
+        packages_selected = Pkg.IsSelected(@FIREWALL_PACKAGE)
+        log.info "Selected for installation -> #{packages_selected}"
+
+        return true if packages_selected
+      end
+
+      SuSEFirewallIsInstalled()
+    end
+
+    # Returns whether all needed packages are installed
+    #
+    # @return [Boolean] whether the selected firewall backend is installed
+    def SuSEFirewallIsInstalled
+      return true if @needed_packages_installed
+
+      if Mode.normal
+        @needed_packages_installed = PackageSystem.CheckAndInstallPackages([@FIREWALL_PACKAGE])
+        log.info "CheckAndInstallPackages -> #{@needed_packages_installed}"
+      else
+        @needed_packages_installed = PackageSystem.Installed(@FIREWALL_PACKAGE)
+        log.info "Installed -> #{@needed_packages_installed}"
+      end
+
+      @needed_packages_installed
+    end
+
+    # Function for saving configuration and restarting firewall.
+    # Is is the same as Write() but write is allways forced.
+    #
+    # @return  [Boolean] if successful
+    def SaveAndRestartService
+      Builtins.y2milestone("Forced save and restart")
+      SetModified()
+
+      SetStartService(true)
+
+      return false if !Write()
+
+      true
+    end
+
+    # Local function returns if protocol is supported by firewall.
+    # Protocol name must be in upper-cases.
+    #
+    # @param [String] protocol
+    # @return [Boolean] whether protocol is supported, that is, one of TCP, UDP, IP
+    def IsSupportedProtocol(protocol)
+      @supported_protocols.include?(protocol)
+    end
+
+    # Function sets additional ports/services from taken list. Firstly, all additional services
+    # are removed also with their aliases. Secondly new ports/protocols are added.
+    # It uses GetAdditionalServices() function to get the current state and
+    # then it removes what has been removed and adds what has been added.
+    #
+    # @param [String] protocol
+    # @param [String] zone
+    # @param  list <string> list of ports/protocols
+    # @see #GetAdditionalServices()
+    #
+    # @example
+    #  SetAdditionalServices ("TCP", "EXT", ["53", "128"])
+    def SetAdditionalServices(protocol, zone, new_list_services)
+      new_list_services = deep_copy(new_list_services)
+      old_list_services = Builtins.toset(GetAdditionalServices(protocol, zone))
+      new_list_services = Builtins.toset(new_list_services)
+
+      if new_list_services != old_list_services
+        SetModified()
+
+        add_services = []
+        remove_services = []
+
+        # Add these services
+        Builtins.foreach(new_list_services) do |service|
+          add_services = Builtins.add(add_services, service) if !Builtins.contains(old_list_services, service)
+        end
+        # Remove these services
+        Builtins.foreach(old_list_services) do |service|
+          remove_services = Builtins.add(remove_services, service) if !Builtins.contains(new_list_services, service)
+        end
+
+        if Ops.greater_than(Builtins.size(remove_services), 0)
+          Builtins.y2milestone(
+            "Removing additional services %1/%2 from zone %3",
+            remove_services,
+            protocol,
+            zone
+          )
+          RemoveAllowedPortsOrServices(remove_services, protocol, zone, true)
+        end
+        if Ops.greater_than(Builtins.size(add_services), 0)
+          Builtins.y2milestone(
+            "Adding additional services %1/%2 into zone %3",
+            add_services,
+            protocol,
+            zone
+          )
+          AddAllowedPortsOrServices(add_services, protocol, zone)
+        end
+      end
+
+      nil
+    end
+
+    # Local function removes ports and their aliases (if check_for_aliases is true), for
+    # requested protocol and zone.
+    #
+    # @param  list <string> ports to be removed
+    # @param [String] protocol
+    # @param [String] zone
+    # @param  boolean check for port-aliases
+    def RemoveAllowedPortsOrServices(remove_ports, protocol, zone, check_for_aliases)
+      remove_ports = deep_copy(remove_ports)
+      if Ops.less_than(Builtins.size(remove_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      # all allowed ports
+      allowed_services = PortRanges.DividePortsAndPortRanges(
+        GetAllowedServicesForZoneProto(zone, protocol),
+        false
+      )
+
+      # removing all aliases of ports too, adding aliases into
+      if check_for_aliases
+        remove_ports_with_aliases = []
+        Builtins.foreach(remove_ports) do |remove_port|
+          # skip port ranges, they cannot have any port-alias
+          if PortRanges.IsPortRange(remove_port)
+            remove_ports_with_aliases = Builtins.add(
+              remove_ports_with_aliases,
+              remove_port
+            )
+            next
+          end
+          remove_these_ports = PortAliases.GetListOfServiceAliases(remove_port)
+          remove_these_ports = [remove_port] if remove_these_ports.nil?
+          remove_ports_with_aliases = Convert.convert(
+            Builtins.union(remove_ports_with_aliases, remove_these_ports),
+            from: "list",
+            to:   "list <string>"
+          )
+        end
+        remove_ports = deep_copy(remove_ports_with_aliases)
+      end
+      remove_ports = Builtins.toset(remove_ports)
+
+      # Remove ports only once (because of port aliases), any => integers and strings
+      already_removed = []
+
+      Builtins.foreach(remove_ports) do |remove_port|
+        # Removing from normal ports
+        Ops.set(
+          allowed_services,
+          "ports",
+          Builtins.filter(Ops.get(allowed_services, "ports", [])) do |allowed_port|
+            allowed_port != "" && allowed_port != remove_port
+          end
+        )
+        # Removing also from port ranges
+        if Ops.get(allowed_services, "port_ranges", []) != []
+          # Removing a real port from port ranges
+          if !PortRanges.IsPortRange(remove_port)
+            remove_port_nr = PortAliases.GetPortNumber(remove_port)
+            # Because of all port aliases
+            if !Builtins.contains(already_removed, remove_port_nr)
+              already_removed = Builtins.add(already_removed, remove_port_nr)
+              Ops.set(
+                allowed_services,
+                "port_ranges",
+                PortRanges.RemovePortFromPortRanges(
+                  remove_port_nr,
+                  Ops.get(allowed_services, "port_ranges", [])
+                )
+              )
+            end
+          # Removing a port range from port ranges
+          elsif !Builtins.contains(already_removed, remove_port)
+            # Just filtering the exact port range
+            Ops.set(
+              allowed_services,
+              "port_ranges",
+              Builtins.filter(Ops.get(allowed_services, "port_ranges", [])) do |one_port_range|
+                one_port_range != remove_port
+              end
+            )
+            already_removed = Builtins.add(already_removed, remove_port)
+          end
+        end
+      end
+
+      allowed_services_all = Convert.convert(
+        Builtins.union(
+          Ops.get(allowed_services, "ports", []),
+          Ops.get(allowed_services, "port_ranges", [])
+        ),
+        from: "list",
+        to:   "list <string>"
+      )
+
+      allowed_services_all = PortRanges.FlattenServices(
+        allowed_services_all,
+        protocol
+      )
+
+      SetAllowedServicesForZoneProto(allowed_services_all, zone, protocol)
+
+      nil
+    end
+
+    # Function returns if another firewall is currently running on the
+    # system. It uses command `iptables` to get information about just active
+    # iptables rules and compares the output with current status of the selected
+    # firewall backend
+    #
+    # @return  [Boolean] if other firewall is running
+    def IsOtherFirewallRunning
+      any_firewall_running = true
+
+      # grep must return at least blank lines, else it returns 'exit 1' instead of 'exit 0'
+      command = "LANG=C /usr/sbin/iptables -L -n | /usr/bin/grep -v \"^\\(Chain\\|target\\)\""
+
+      iptables = Convert.to_map(
+        SCR.Execute(path(".target.bash_output"), command)
+      )
+      if Ops.get_integer(iptables, "exit", 0) == 0
+        iptables_list = Builtins.splitstring(
+          Ops.get_string(iptables, "stdout", ""),
+          "\n"
+        )
+        iptables_list = Builtins.filter(iptables_list) do |iptable_rule|
+          iptable_rule != ""
+        end
+
+        Builtins.y2milestone(
+          "Count of active iptables now: %1",
+          Builtins.size(iptables_list)
+        )
+
+        # any iptables rule exist?
+        any_firewall_running = Ops.greater_than(Builtins.size(iptables_list), 0)
+      else
+        # error running command
+        Builtins.y2error(
+          "Services Command: %1 (Exit %2) -> %3",
+          command,
+          Ops.get(iptables, "exit"),
+          Ops.get(iptables, "stderr")
+        )
+        return nil
+      end
+
+      # any firewall is running but it is not desired one
+      if any_firewall_running && !IsStarted()
+        Builtins.y2warning("Any other firewall is running...")
+        return true
+      end
+      # no firewall is running or the running firewall the desired one
+      false
+    end
+
+    def ArePortsOrServicesAllowed(needed_ports, protocol, zone, check_for_aliases)
+      needed_ports = deep_copy(needed_ports)
+      are_allowed = true
+
+      if Ops.less_than(Builtins.size(needed_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return true
+      end
+
+      allowed_ports = {}
+      # BTW: only TCP and UDP ports can have aliases and only TCP and UDP ports can have port ranges
+      if check_for_aliases
+        allowed_ports = PortRanges.DividePortsAndPortRanges(
+          GetAllowedServicesForZoneProto(zone, protocol),
+          true
+        )
+      else
+        Ops.set(
+          allowed_ports,
+          "ports",
+          GetAllowedServicesForZoneProto(zone, protocol)
+        )
+      end
+
+      Builtins.foreach(needed_ports) do |needed_port|
+        if !Builtins.contains(Ops.get(allowed_ports, "ports", []), needed_port) &&
+            !PortRanges.PortIsInPortranges(
+              needed_port,
+              Ops.get(allowed_ports, "port_ranges", [])
+            )
+          are_allowed = false
+          raise Break
+        end
+      end
+
+      are_allowed
+    end
+
+    # Function returns if requested service is allowed in respective zone.
+    # Function takes care for service's aliases (only for TCP and UDP).
+    # Service is defined by set of parameters such as port and protocol.
+    #
+    # @param [String] service (service name, port name, port alias or port number)
+    # @param [String] protocol TCP, UDP, RCP or IP
+    # @param [String] interface name (like modem0), firewall zone (like "EXT") or "any" for all zones.
+    # @return  [Boolean] if service is allowed
+    #
+    # @example
+    #  HaveService ("ssh", "TCP", "EXT") -> true
+    #  HaveService ("ssh", "TCP", "modem0") -> false
+    #  HaveService ("53", "UDP", "dsl") -> false
+    def HaveService(service, protocol, interface)
+      if !IsSupportedProtocol(protocol)
+        Builtins.y2error("Unknown protocol: %1", protocol)
+        return nil
+      end
+
+      # definition of searched zones
+      zones = []
+
+      # "any" for all zones, this is ugly
+      if interface == "any"
+        zones = GetKnownFirewallZones()
+        # string interface is the zone name
+      elsif IsKnownZone(interface)
+        zones = Builtins.add(zones, interface)
+        # interface is the interface name
+      else
+        interface = GetZoneOfInterface(interface)
+        zones = Builtins.add(zones, interface) if !interface.nil?
+      end
+
+      # SuSEFirewall feature FW_PROTECT_FROM_INT
+      # should not be protected and searched zones include also internal (or the zone IS internal, sure)
+      if !GetProtectFromInternalZone() &&
+          Builtins.contains(zones, @int_zone_shortname)
+        Builtins.y2milestone(
+          "Checking for service '%1', in '%2', PROTECT_FROM_INTERNAL='no' => allowed",
+          service,
+          interface
+        )
+        return true
+      end
+
+      # Check and return whether the service (port) is supported anywhere
+      ret = false
+      Builtins.foreach(zones) do |zone|
+        # This function can also handle port ranges
+        if ArePortsOrServicesAllowed([service], protocol, zone, true)
+          ret = true
+          raise Break
+        end
+      end
+
+      ret
+    end
+
+    # Function adds service into selected zone (or zone of interface) for selected protocol.
+    # Function take care about port-aliases, first of all, removes all of them.
+    #
+    # @param [String] service/port
+    # @param [String] protocol TCP, UDP, RPC, IP
+    # @param  string zone name or interface name
+    # @return  [Boolean] success
+    #
+    # @example
+    #  AddService ("ssh", "TCP", "EXT")
+    #  AddService ("ssh", "TCP", "dsl0")
+    def AddService(service, protocol, interface)
+      Builtins.y2milestone(
+        "Adding service %1, protocol %2 to %3",
+        service,
+        protocol,
+        interface
+      )
+
+      if !IsSupportedProtocol(protocol)
+        Builtins.y2error("Unknown protocol: %1", protocol)
+        return false
+      end
+
+      zones_affected = []
+
+      # "all" means for all known zones
+      if interface == "all"
+        zones_affected = GetKnownFirewallZones()
+
+        # zone or interface name
+      else
+        # is probably an interface name
+        if !IsKnownZone(interface)
+          # interface is probably interface-name, checking for respective zone
+          interface = GetZoneOfInterface(interface)
+          # interface is not assigned to any zone
+          if interface.nil?
+            # TRANSLATORS: Error message, %1 = interface name (like eth0)
+            Report.Error(
+              Builtins.sformat(
+                _(
+                  "Interface '%1' is not assigned to any firewall zone.\nRun YaST2 Firewall and assign it.\n"
+                ),
+                interface
+              )
+            )
+            Builtins.y2warning(
+              "Interface '%1' is not assigned to any firewall zone",
+              interface
+            )
+            return false
+          end
+        end
+        zones_affected = [interface]
+      end
+
+      SetModified()
+
+      # Adding service support into each mentioned zone
+      Builtins.foreach(zones_affected) do |zone|
+        # If there isn't already
+        if !ArePortsOrServicesAllowed([service], protocol, zone, true)
+          AddAllowedPortsOrServices([service], protocol, zone)
+        else
+          Builtins.y2milestone(
+            "Port %1 has been already allowed in %2",
+            service,
+            zone
+          )
+        end
+      end
+
+      true
+    end
+
+    # Function removes service from selected zone (or for interface) for selected protocol.
+    # Function takes care about port-aliases, removes all of them.
+    #
+    # @param [String] service/port
+    # @param [String] protocol TCP, UDP, RPC, IP
+    # @param  string zone name or interface name
+    # @return  [Boolean] success
+    #
+    # @example
+    #  RemoveService ("22", "TCP", "DMZ") -> true
+    #  is the same as
+    #  RemoveService ("ssh", "TCP", "DMZ") -> true
+    def RemoveService(service, protocol, interface)
+      Builtins.y2milestone(
+        "Removing service %1, protocol %2 from %3",
+        service,
+        protocol,
+        interface
+      )
+
+      if !IsSupportedProtocol(protocol)
+        Builtins.y2error("Unknown protocol: %1", protocol)
+        return false
+      end
+
+      zones_affected = []
+
+      # "all" means for all known zones
+      if interface == "all"
+        zones_affected = GetKnownFirewallZones()
+
+        # zone or interface name
+      else
+        if !IsKnownZone(interface)
+          # interface is probably interface-name, checking for respective zone
+          interface = GetZoneOfInterface(interface)
+          # interface is not assigned to any zone
+          if interface.nil?
+            # TRANSLATORS: Error message, %1 = interface name (like eth0)
+            Report.Error(
+              Builtins.sformat(
+                _(
+                  "Interface '%1' is not assigned to any firewall zone.\nRun YaST2 Firewall and assign it.\n"
+                ),
+                interface
+              )
+            )
+            Builtins.y2warning(
+              "Interface '%1' is not assigned to any firewall zone",
+              interface
+            )
+            return false
+          end
+        end
+        zones_affected = [interface]
+      end
+
+      SetModified()
+
+      # Adding service support into each mentioned zone
+      Builtins.foreach(zones_affected) do |zone|
+        # if the service is allowed
+        if ArePortsOrServicesAllowed([service], protocol, zone, true)
+          RemoveAllowedPortsOrServices([service], protocol, zone, true)
+        else
+          Builtins.y2milestone(
+            "Port %1 has been already removed from %2",
+            service,
+            zone
+          )
+        end
+      end
+
+      true
+    end
+
+    # Function adds a special interface 'xenbr+' into the FW_FORWARD_ALWAYS_INOUT_DEV variable.
+    #
+    # @see #https://bugzilla.novell.com/show_bug.cgi?id=154133
+    # @see #https://bugzilla.novell.com/show_bug.cgi?id=233934
+    # @see #https://bugzilla.novell.com/show_bug.cgi?id=375482
+    def AddXenSupport
+      Builtins.y2milestone(
+        "The whole functionality is currently handled by SuSEfirewall2 itself"
+      )
+
+      nil
+    end
+  end
+end

--- a/library/network/src/lib/network/susefirewall2.rb
+++ b/library/network/src/lib/network/susefirewall2.rb
@@ -1,0 +1,2825 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+#
+# Module for handling SuSEfirewall2 or FirewallD
+# Package: SuSEFirewall configuration
+# Summary: Interface manipulation of /etc/sysconfig/SuSEFirewall
+# Authors: Lukas Ocilka <locilka@suse.cz
+#
+# $Id$
+#
+# Module for handling SuSEfirewall2
+require "yast"
+require "network/susefirewall"
+
+module Yast
+  # ----------------------------------------------------------------------------
+  # SuSEFirewall2/SF2 Class. The original, simply created from the Firewall
+  # factory class.
+  class SuSEFirewall2Class < SuSEFirewallClass
+    CONFIG_FILE = "/etc/sysconfig/SuSEfirewall2".freeze
+
+    include Yast::Logger
+
+    def main
+      textdomain "base"
+
+      Yast.import "Mode"
+      Yast.import "Service"
+      Yast.import "NetworkInterfaces"
+      Yast.import "PortAliases"
+      Yast.import "Report"
+      Yast.import "Message"
+      Yast.import "Progress"
+      Yast.import "PortRanges"
+      Yast.import "PackageSystem"
+      Yast.import "FileUtils"
+      Yast.import "Directory"
+      Yast.import "Stage"
+      Yast.import "Pkg"
+
+      # <!-- SuSEFirewall VARIABLES //-->
+
+      @FIREWALL_PACKAGE = "SuSEfirewall2"
+
+      # configuration hasn't been read for the default
+      # this should reduce the readings to only ONE
+      @configuration_has_been_read = false
+
+      # String which includes all interfaces not-defined in any zone
+      @special_all_interface_string = "any"
+
+      # Maximal number of port number, they are in the interval 1-65535 included
+      @max_port_number = PortRanges.max_port_number
+
+      # Zone which works with the special_all_interface_string string
+      @special_all_interface_zone = "EXT"
+
+      # firewall settings map
+      @SETTINGS = {}
+
+      # configuration was modified when true
+      @modified = false
+
+      # defines if SuSEFirewall is running
+      @is_running = false
+
+      # default settings for SuSEFirewall
+      @DEFAULT_SETTINGS = {
+        "FW_LOG_ACCEPT_ALL"          => "no",
+        "FW_LOG_ACCEPT_CRIT"         => "yes",
+        "FW_LOG_DROP_ALL"            => "no",
+        "FW_LOG_DROP_CRIT"           => "yes",
+        "FW_PROTECT_FROM_INT"        => "no",
+        "FW_ROUTE"                   => "no",
+        "FW_STOP_KEEP_ROUTING_STATE" => "no",
+        "FW_MASQUERADE"              => "no",
+        "FW_ALLOW_FW_TRACEROUTE"     => "yes",
+        "FW_ALLOW_PING_FW"           => "yes",
+        "FW_ALLOW_FW_BROADCAST_EXT"  => "no",
+        "FW_ALLOW_FW_BROADCAST_INT"  => "no",
+        "FW_ALLOW_FW_BROADCAST_DMZ"  => "no",
+        "FW_IGNORE_FW_BROADCAST_EXT" => "yes",
+        "FW_IGNORE_FW_BROADCAST_INT" => "no",
+        "FW_IGNORE_FW_BROADCAST_DMZ" => "no",
+        "FW_IPSEC_TRUST"             => "no",
+        "FW_BOOT_FULL_INIT"          => "no"
+      }
+
+      # verbose_level -> if verbosity is more than 0, be verbose, starting in verbose mode
+      @verbose_level = 1
+
+      # list of known firewall zones
+      @known_firewall_zones = ["INT", "DMZ", "EXT"]
+
+      # map defines zone name for all known firewall zones
+      @zone_names = {
+        # TRANSLATORS: Firewall zone name - used in combo box or dialog title
+        "EXT" => _(
+          "External Zone"
+        ),
+        # TRANSLATORS: Firewall zone name - used in combo box or dialog title
+        "INT" => _(
+          "Internal Zone"
+        ),
+        # TRANSLATORS: Firewall zone name - used in combo box or dialog title
+        "DMZ" => _(
+          "Demilitarized Zone"
+        )
+      }
+
+      # internal zone identification - useful for protect-from-internal
+      @int_zone_shortname = "INT"
+
+      # list of protocols supported in firewall, use only upper-cases
+      @supported_protocols = ["TCP", "UDP", "RPC", "IP"]
+
+      # list of keys in map of definition well-known services
+      @service_defined_by = [
+        "tcp_ports",
+        "udp_ports",
+        "rpc_ports",
+        "ip_protocols",
+        "broadcast_ports"
+      ]
+
+      # list of services currently allowed, which share ports (for instance RPC services)
+      @allowed_conflict_services = {}
+
+      @firewall_service = "SuSEfirewall2"
+
+      @SuSEFirewall_variables = [
+        # zones and interfaces
+        "FW_DEV_INT",
+        "FW_DEV_DMZ",
+        "FW_DEV_EXT",
+        # services in zones
+        "FW_SERVICES_INT_TCP",
+        "FW_SERVICES_INT_UDP",
+        "FW_SERVICES_INT_RPC",
+        "FW_SERVICES_INT_IP",
+        "FW_SERVICES_DMZ_TCP",
+        "FW_SERVICES_DMZ_UDP",
+        "FW_SERVICES_DMZ_RPC",
+        "FW_SERVICES_DMZ_IP",
+        "FW_SERVICES_EXT_TCP",
+        "FW_SERVICES_EXT_UDP",
+        "FW_SERVICES_EXT_RPC",
+        "FW_SERVICES_EXT_IP",
+        "FW_PROTECT_FROM_INT",
+        # global routing, masquerading
+        "FW_ROUTE",
+        "FW_STOP_KEEP_ROUTING_STATE",
+        "FW_MASQUERADE",
+        "FW_FORWARD_MASQ",
+        "FW_FORWARD_ALWAYS_INOUT_DEV",
+        # broadcast packets
+        "FW_ALLOW_FW_BROADCAST_EXT",
+        "FW_ALLOW_FW_BROADCAST_INT",
+        "FW_ALLOW_FW_BROADCAST_DMZ",
+        "FW_IGNORE_FW_BROADCAST_EXT",
+        "FW_IGNORE_FW_BROADCAST_INT",
+        "FW_IGNORE_FW_BROADCAST_DMZ",
+        # FATE #300970: Support for 'Samba & friends' browsing
+        "FW_SERVICES_ACCEPT_RELATED_EXT",
+        "FW_SERVICES_ACCEPT_RELATED_INT",
+        "FW_SERVICES_ACCEPT_RELATED_DMZ",
+        # logging
+        "FW_LOG_DROP_CRIT",
+        "FW_LOG_DROP_ALL",
+        "FW_LOG_ACCEPT_CRIT",
+        "FW_LOG_ACCEPT_ALL",
+        # IPsec support
+        "FW_IPSEC_TRUST",
+        # Custom rulezz
+        #     net,protocol[,dport][,sport]
+        "FW_SERVICES_ACCEPT_EXT",
+        "FW_SERVICES_ACCEPT_INT",
+        "FW_SERVICES_ACCEPT_DMZ",
+        # Custom kernel modules, e.g., for FTP
+        "FW_LOAD_MODULES",
+        # Services defined in /usr/share/SuSEfirewall2/services/ directory
+        # FATE #300687: Ports for SuSEfirewall added via packages
+        "FW_CONFIGURATIONS_EXT",
+        "FW_CONFIGURATIONS_INT",
+        "FW_CONFIGURATIONS_DMZ",
+        # bsc#916376: Ports need to be open already during boot
+        "FW_BOOT_FULL_INIT"
+      ]
+
+      # FATE #300970: Firewall support for SMB browsing
+      @broadcast_related_module = "nf_conntrack_netbios_ns"
+
+      # Variable for ReportOnlyOnce() function
+      @report_only_once = []
+
+      # <!-- SuSEFirewall LOCAL FUNCTIONS //-->
+
+      # <!-- SuSEFirewall GLOBAL FUNCTIONS //-->
+
+      # bnc #388773
+      # By default needed packages are just checked, not installed
+      @check_and_install_package = false
+
+      # Are needed packages (SuSEfirewall2) installed?
+      @needed_packages_installed = nil
+
+      # Configuration has been read and it's useful
+      @fw_service_can_be_configured = false
+
+      # old internal services definitions are converted to new services defined by packages
+      # but only once
+      @converted_to_services_dbp_file = Ops.add(
+        Directory.vardir,
+        "/yast2-firewall-already-converted-to-sdbp"
+      )
+
+      # services have been already converted
+      @already_converted = false
+
+      @protocol_translations = {
+        # protocol name
+        "tcp"   => _("TCP"),
+        # protocol name
+        "udp"   => _("UDP"),
+        # protocol name
+        "_rpc_" => _("RPC"),
+        # protocol name
+        "ip"    => _("IP")
+      }
+    end
+
+    # <!-- SuSEFirewall VARIABLES //-->
+
+    # <!-- SuSEFirewall GLOBAL FUNCTIONS USED BY LOCAL ONES //-->
+
+    # Report the error, warning, message only once.
+    # Stores the error, warning, message in memory.
+    # This is just a helper function that could avoid from filling y2log up with
+    # a lot of the very same messages - 'foreach()' is a very powerful builtin.
+    #
+    # @param [String] what_to_report error, warning or message
+    # @return [Boolean] whether the message should be reported or not
+    #
+    # @example
+    #   string error = sformat("Port number %1 is invalid.", port_nr);
+    #   if (ReportOnlyOnce(error)) y2error(error);
+    def ReportOnlyOnce(what_to_report)
+      return false if Builtins.contains(@report_only_once, what_to_report)
+
+      @report_only_once = Builtins.add(@report_only_once, what_to_report)
+      true
+    end
+
+    # <!-- SuSEFirewall GLOBAL FUNCTIONS USED BY LOCAL ONES //-->
+
+    # <!-- SuSEFirewall LOCAL FUNCTIONS //-->
+
+    # Function returns whether the feature 'any' network interface is supported in the
+    # firewall configuration. The string 'any' must be in the 'EXT' zone.
+    # Updated: Currently returns only 'true' as every unassigned interface is
+    # automatically assigned to the EXT zone by SuSEfirewall2.
+    #
+    # @return [Boolean] is_supported whether the feature is supported or not
+    def IsAnyNetworkInterfaceSupported
+      # Currently unassigned interfaces belong to the EXT zone by dafault
+      true
+    end
+
+    # Function return list of variables needed for SuSEFirewall's settings.
+    #
+    # @return [Array<String>] of names of variables
+    def GetListOfSuSEFirewallVariables
+      deep_copy(@SuSEFirewall_variables)
+    end
+
+    # Local function for increasing the verbosity level.
+    def IncreaseVerbosity
+      @verbose_level = Ops.add(@verbose_level, 1)
+
+      nil
+    end
+
+    # Local function for decreasing the verbosity level.
+    def DecreaseVerbosity
+      @verbose_level = Ops.subtract(@verbose_level, 1)
+
+      nil
+    end
+
+    # Local function returns if other functions should produce verbose output.
+    # like popups, reporting errors, etc.
+    #
+    # @return [Boolean] is_verbose
+    def IsVerbose
+      # verbose level must be above zero to be verbose
+      Ops.greater_than(@verbose_level, 0)
+    end
+
+    # Local function for returning default values (if defined) for sysconfig variables.
+    #
+    # @param [String] variable sysconfig variable
+    # @return [String] default value
+    def GetDefaultValue(variable)
+      Ops.get(@DEFAULT_SETTINGS, variable, "")
+    end
+
+    # Local function for reading list of sysconfig variables into internal variables.
+    #
+    # @param [Array<String>] variables of sysconfig variables
+    def ReadSysconfigSuSEFirewall(variables)
+      variables = deep_copy(variables)
+      Builtins.foreach(variables) do |variable|
+        value = Convert.to_string(
+          SCR.Read(Builtins.add(path(".sysconfig.SuSEfirewall2"), variable))
+        )
+        # if value is undefined, get default value
+        value = GetDefaultValue(variable) if value.nil? || value == ""
+        # BNC #426000
+        # backslash at the end
+        if Builtins.regexpmatch(value, "[ \t]*\\\\[ \t]*\n")
+          rules = Builtins.splitstring(value, "\\ \t\n")
+          rules = Builtins.filter(rules) do |one_rule|
+            !one_rule.nil? && one_rule != ""
+          end
+          value = Builtins.mergestring(rules, " ")
+        end
+        # BNC #194419
+        # replace all "\n" with " " in variables
+        value = Builtins.mergestring(Builtins.splitstring(value, "\n"), " ") if Builtins.regexpmatch(value, "\n")
+        # replace all "\t" with " " in variables
+        value = Builtins.mergestring(Builtins.splitstring(value, "\t"), " ") if Builtins.regexpmatch(value, "\t")
+        Ops.set(@SETTINGS, variable, value)
+      end
+
+      nil
+    end
+
+    # Local function for resetting list of sysconfig variables in internal variables.
+    #
+    # @param [Array<String>] variables of sysconfig variables
+    def ResetSysconfigSuSEFirewall(variables)
+      variables = deep_copy(variables)
+      Builtins.foreach(variables) do |variable|
+        # reseting means getting default variables
+        Ops.set(@SETTINGS, variable, GetDefaultValue(variable))
+      end
+
+      nil
+    end
+
+    # Local function for writing the list of internal variables into sysconfig.
+    # List of variables is list of keys in SETTINGS map, to sync configuration
+    # into the disk, use `nil` as the last list item.
+    #
+    # @param [Array<String>] variables of sysconfig variables
+    # @return [Boolean] if successful
+    def WriteSysconfigSuSEFirewall(variables)
+      variables = deep_copy(variables)
+      write_status = true
+      value = ""
+
+      Builtins.foreach(variables) do |variable|
+        # if variable is undefined, get default value
+        value = Ops.get_string(@SETTINGS, variable) { GetDefaultValue(variable) }
+        write_status = SCR.Write(
+          Builtins.add(path(".sysconfig.SuSEfirewall2"), variable),
+          value
+        )
+        if !write_status
+          Report.Error(
+            Message.CannotWriteSettingsTo("/etc/sysconfig/SuSEFirewall2")
+          )
+          raise Break
+        end
+      end
+
+      write_status = SCR.Write(path(".sysconfig.SuSEfirewall2"), nil)
+      if !write_status
+        Report.Error(
+          Message.CannotWriteSettingsTo("/etc/sysconfig/SuSEFirewall2")
+        )
+      end
+
+      write_status
+    end
+
+    # Local function returns configuration string used in configuration for zone.
+    # For instance "ext" for "EXT" zone.
+    #
+    # @param [String] zone shortname
+    # @return [String] zone configuration string
+    def GetZoneConfigurationString(zone)
+      if IsKnownZone(zone)
+        # zones in SuSEFirewall configuration are identified by lowercased zone shorters
+        return Builtins.tolower(zone)
+      end
+
+      nil
+    end
+
+    # Local function returns zone name (shortname) for configuration string.
+    # For instance "EXT" for "ext" zone.
+    #
+    # @param [String] zone_string configuration string
+    # @return [String] zone shortname
+    def GetConfigurationStringZone(zone_string)
+      if IsKnownZone(Builtins.toupper(zone_string))
+        # zones in SuSEFirewall configuration are identified by lowercased zone shorters
+        return Builtins.toupper(zone_string)
+      end
+
+      nil
+    end
+
+    # Function returns list of allowed services for zone and protocol
+    #
+    # @param [String] zone
+    # @param [String] protocol
+    # @return [Array<String>] of allowed services/ports
+    def GetAllowedServicesForZoneProto(zone, protocol)
+      Builtins.splitstring(
+        Ops.get_string(
+          @SETTINGS,
+          Ops.add(Ops.add(Ops.add("FW_SERVICES_", zone), "_"), protocol),
+          ""
+        ),
+        " "
+      )
+    end
+
+    # Function sets list of services as allowed ports for zone and protocol
+    #
+    # @param [Array<String>] allowed_services of allowed ports/services
+    # @param [String] zone
+    # @param [String] protocol
+    def SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+      allowed_services = deep_copy(allowed_services)
+      SetModified()
+
+      Ops.set(
+        @SETTINGS,
+        Ops.add(Ops.add(Ops.add("FW_SERVICES_", zone), "_"), protocol),
+        Builtins.mergestring(Builtins.toset(allowed_services), " ")
+      )
+
+      nil
+    end
+
+    # Local function returns configuration string for broadcast packets.
+    #
+    # @return [String] with broadcast configuration
+    def GetBroadcastConfiguration(zone)
+      Ops.get_string(@SETTINGS, Ops.add("FW_ALLOW_FW_BROADCAST_", zone), "no")
+    end
+
+    # Local function saves configuration string for broadcast packets.
+    #
+    # @param [String] zone
+    # @param [String] broadcast_configuration with broadcast configuration
+    def SetBroadcastConfiguration(zone, broadcast_configuration)
+      SetModified()
+
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_ALLOW_FW_BROADCAST_", zone),
+        broadcast_configuration
+      )
+
+      nil
+    end
+
+    # Local function returns map of allowed ports (without aliases).
+    # If any list for zone is defined but empty, all allowed
+    # UDP ports for this zone also accept broadcast packets.
+    # This function returns only ports that are mentioned in configuration,
+    # it doesn't return ports that are listed in some service (defined by package)
+    # which is enabled.
+    #
+    # @return [Hash{String => Array<String>}] strings are allowed ports or port ranges
+    #
+    #
+    # **Structure:**
+    #
+    #     $[
+    #        "ZONE1" : [ "port1", "port2" ],
+    #        "ZONE2" : [ "port3", "port4" ],
+    #        "ZONE3" : [ ]
+    #      ]
+    #      or
+    #      $[
+    #        "ZONE1" : [ "yes" ],  // will work for all ports automatically
+    #        "ZONE3" : [ ],
+    #        "ZONE3" : [ ]
+    #      ]
+    def GetBroadcastAllowedPorts
+      allowed_ports = {}
+
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        broadcast = GetBroadcastConfiguration(zone)
+        # no broadcast allowed for this zone
+        if broadcast == "no"
+          Ops.set(allowed_ports, zone, [])
+          # BNC #694782: "yes" is automatically translated by SuSEfirewall2
+        elsif broadcast == "yes"
+          Ops.set(allowed_ports, zone, ["yes"])
+          # only listed ports allow broadcast
+        else
+          Ops.set(allowed_ports, zone, Builtins.splitstring(broadcast, " "))
+          Ops.set(
+            allowed_ports,
+            zone,
+            Builtins.filter(Builtins.splitstring(broadcast, " ")) do |not_space|
+              not_space != ""
+            end
+          )
+        end
+      end
+
+      Builtins.y2debug("Allowed Broadcast Ports: %1", allowed_ports)
+
+      deep_copy(allowed_ports)
+    end
+
+    # Function creates allowed-broadcast-ports string from broadcast map and saves it.
+    #
+    # @param [Hash<String,Array<String>>] broadcast strings are allowed ports or port ranges
+    # @see GetBroadcastAllowedPorts() for an example of data
+    def SetBroadcastAllowedPorts(broadcast)
+      broadcast = deep_copy(broadcast)
+      SetModified()
+
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        Ops.set(broadcast, zone, ["no"]) if Ops.get(broadcast, zone, []) == []
+        SetBroadcastConfiguration(
+          zone,
+          Builtins.mergestring(Ops.get(broadcast, zone, []), " ")
+        )
+      end
+
+      nil
+    end
+
+    # Function returns if broadcast is allowed for needed ports in zone.
+    #
+    # @param [Array<String>] needed_ports
+    # @param [String] zone
+    # @return [Boolean] if is allowed
+    #
+    # @example
+    #    IsBroadcastAllowed (["port-xyz", "53"], "EXT") -> true
+    def IsBroadcastAllowed(needed_ports, zone)
+      needed_ports = deep_copy(needed_ports)
+      if Builtins.size(needed_ports) == 0
+        Builtins.y2warning("Unknown service with no needed ports!")
+        return nil
+      end
+
+      # getting broadcast allowed ports
+      allowed_ports_map = GetBroadcastAllowedPorts()
+
+      # Divide allowed port ranges and aliases (also with their port aliases)
+      allowed_ports_divided = PortRanges.DividePortsAndPortRanges(
+        Ops.get(allowed_ports_map, zone, []),
+        true
+      )
+
+      # If there are no allowed ports at all
+      if Ops.get(allowed_ports_divided, "ports", []) == [] &&
+          Ops.get(allowed_ports_divided, "port_ranges", []) == []
+        return false
+      end
+
+      is_allowed = true
+      # checking all needed ports;
+      Builtins.foreach(needed_ports) do |needed_port|
+        # allowed ports don't contain the needed one and also portranges don't
+        if !Builtins.contains(
+          Ops.get(allowed_ports_divided, "ports", []),
+          needed_port
+        ) &&
+            !PortRanges.PortIsInPortranges(
+              needed_port,
+              Ops.get(allowed_ports_divided, "port_ranges", [])
+            )
+          is_allowed = false
+          raise Break
+        end
+      end
+
+      is_allowed
+    end
+
+    # Local function removes list of ports from port allowing broadcast packets in zone.
+    #
+    # @param [Array<String>] needed_ports to be removed
+    # @param [String] zone
+    def RemoveAllowedBroadcast(needed_ports, zone)
+      needed_ports = deep_copy(needed_ports)
+      SetModified()
+
+      allowed_ports = GetBroadcastAllowedPorts()
+      list_ports_allowed = Ops.get(allowed_ports, zone, [])
+
+      # ports to be allowed one by one
+      Builtins.foreach(needed_ports) do |allow_this_port|
+        # remove all aliases of ports yet mentioned in zone
+        aliases_of_port = PortAliases.GetListOfServiceAliases(allow_this_port)
+        list_ports_allowed = Builtins.filter(list_ports_allowed) do |just_allowed|
+          !Builtins.contains(aliases_of_port, just_allowed)
+        end
+      end
+      Ops.set(allowed_ports, zone, list_ports_allowed)
+
+      # save it using function
+      SetBroadcastAllowedPorts(allowed_ports)
+
+      nil
+    end
+
+    # Local function adds list of ports to ports accepting broadcast
+    #
+    # @param [Array<String>] needed_ports of ports
+    # @param [String] zone
+    def AddAllowedBroadcast(needed_ports, zone)
+      needed_ports = deep_copy(needed_ports)
+      # changing only if ports are not allowed
+      if !IsBroadcastAllowed(needed_ports, zone)
+        SetModified()
+
+        allowed_ports = GetBroadcastAllowedPorts()
+        list_ports_allowed = Ops.get(allowed_ports, zone, [])
+
+        # ports to be allowed one by one
+        Builtins.foreach(needed_ports) do |allow_this_port|
+          # at first: remove all aliases of ports yet mentioned in zone
+          aliases_of_port = PortAliases.GetListOfServiceAliases(allow_this_port)
+          list_ports_allowed = Builtins.filter(list_ports_allowed) do |just_allowed|
+            !Builtins.contains(aliases_of_port, just_allowed)
+          end
+          # at second: add only one
+          list_ports_allowed = Builtins.add(list_ports_allowed, allow_this_port)
+        end
+        Ops.set(allowed_ports, zone, list_ports_allowed)
+
+        # save it using function
+        SetBroadcastAllowedPorts(allowed_ports)
+      end
+
+      nil
+    end
+
+    # Local function for removing (disallowing) single service/port
+    # for defined protocol and zone. Functions doesn't take care of
+    # port-aliases.
+    #
+    # @param [String] remove_service service/port
+    # @param [String] protocol
+    # @param [String] zone
+    # @return [Boolean] success
+    def RemoveServiceFromProtocolZone(remove_service, protocol, zone)
+      SetModified()
+
+      key = Ops.add(Ops.add(Ops.add("FW_SERVICES_", zone), "_"), protocol)
+
+      allowed = Builtins.splitstring(Ops.get_string(@SETTINGS, key, ""), " ")
+      allowed = Builtins.filter(allowed) do |single_service|
+        single_service != "" && single_service != remove_service
+      end
+      Ops.set(
+        @SETTINGS,
+        key,
+        Builtins.mergestring(Builtins.toset(allowed), " ")
+      )
+
+      true
+    end
+
+    # Removes service defined by package (FATE #300687) from enabled services.
+    #
+    # @param [String] service
+    # @param [String] zone
+    #
+    # @example
+    #    RemoveServiceDefinedByPackageFromZone ("service:irc-server", "EXT");
+    def RemoveServiceDefinedByPackageFromZone(service, zone)
+      return nil if !IsKnownZone(zone)
+
+      if service.nil?
+        Builtins.y2error("Service Id can't be nil!")
+        return nil
+      elsif Builtins.regexpmatch(service, "^service:.*")
+        service = Builtins.regexpsub(service, "^service:(.*)", "\\1")
+      end
+
+      # services defined by package are listed without "service:" which is here
+      # just to distinguish between dynamic and static definitions
+      supported_services = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_CONFIGURATIONS_", zone), ""),
+        " "
+      )
+      # Removing the service
+      supported_services = Builtins.filter(supported_services) do |one_service|
+        one_service != service
+      end
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_CONFIGURATIONS_", zone),
+        Builtins.mergestring(supported_services, " ")
+      )
+
+      SetModified()
+
+      nil
+    end
+
+    # Adds service defined by package (FATE #300687) into list of enabled services.
+    #
+    # @param [String] service
+    # @param [String] zone
+    #
+    # @example
+    #    AddServiceDefinedByPackageIntoZone ("service:irc-server", "EXT");
+    def AddServiceDefinedByPackageIntoZone(service, zone)
+      return nil if !IsKnownZone(zone)
+
+      if service.nil?
+        Builtins.y2error("Service Id can't be nil!")
+        return nil
+      elsif Builtins.regexpmatch(service, "^service:.*")
+        service = Builtins.regexpsub(service, "^service:(.*)", "\\1")
+      end
+
+      # services defined by package are listed without "service:" which is here
+      # just to distinguish between dynamic and static definitions
+      supported_services = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_CONFIGURATIONS_", zone), ""),
+        " "
+      )
+      # Adding the service
+      supported_services = Builtins.toset(
+        Builtins.add(supported_services, service)
+      )
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_CONFIGURATIONS_", zone),
+        Builtins.mergestring(supported_services, " ")
+      )
+
+      SetModified()
+
+      nil
+    end
+
+    # Local function removes well-known service's support from zone.
+    # Allowed ports are removed with all of their port-aliases.
+    #
+    # @param [String] service id
+    # @param [String] zone
+    def RemoveServiceSupportFromZone(service, zone)
+      Yast.import "SuSEFirewallServices" # lazy import due to circular dependencies
+
+      needed = SuSEFirewallServices.GetNeededPortsAndProtocols(service)
+      # unknown service
+      if needed.nil?
+        Builtins.y2error("Undefined service '%1'", service)
+        return nil
+      end
+
+      # FATE #300687: Ports for SuSEfirewall added via packages
+      if SuSEFirewallServices.ServiceDefinedByPackage(service)
+        RemoveServiceDefinedByPackageFromZone(service, zone) if IsServiceSupportedInZone(service, zone) == true
+
+        return nil
+      end
+
+      SetModified()
+
+      # Removing service ports (and also port aliases for TCP and UDP)
+      Builtins.foreach(@service_defined_by) do |key|
+        needed_ports = Ops.get(needed, key, [])
+        next if needed_ports == []
+
+        if key == "tcp_ports"
+          RemoveAllowedPortsOrServices(needed_ports, "TCP", zone, true)
+        elsif key == "udp_ports"
+          RemoveAllowedPortsOrServices(needed_ports, "UDP", zone, true)
+        elsif key == "rpc_ports"
+          RemoveAllowedPortsOrServices(needed_ports, "RPC", zone, false)
+        elsif key == "ip_protocols"
+          RemoveAllowedPortsOrServices(needed_ports, "IP", zone, false)
+        elsif "broadcast_ports" == key
+          RemoveAllowedBroadcast(needed_ports, zone)
+        else
+          Builtins.y2error("Unknown key '%1'", key)
+        end
+      end
+
+      nil
+    end
+
+    # Local function adds well-known service's support into zone. It first of all
+    # removes the current support for service with port-aliases.
+    #
+    # @param [String] service id
+    # @param [String] zone
+    def AddServiceSupportIntoZone(service, zone)
+      Yast.import "SuSEFirewallServices" # lazy import due to circular dependencies
+
+      needed = SuSEFirewallServices.GetNeededPortsAndProtocols(service)
+      # unknown service
+      if needed.nil?
+        Builtins.y2error("Undefined service '%1'", service)
+        return nil
+      end
+
+      SetModified()
+
+      # FATE #300687: Ports for SuSEfirewall added via packages
+      if SuSEFirewallServices.ServiceDefinedByPackage(service)
+        AddServiceDefinedByPackageIntoZone(service, zone)
+
+        return nil
+      end
+
+      # Removing service ports first (and also port aliases for TCP and UDP)
+      RemoveServiceSupportFromZone(service, zone) if IsServiceSupportedInZone(service, zone) == true
+
+      Builtins.foreach(@service_defined_by) do |key|
+        needed_ports = Ops.get(needed, key, [])
+        next if needed_ports == []
+
+        if key == "tcp_ports"
+          AddAllowedPortsOrServices(needed_ports, "TCP", zone)
+        elsif key == "udp_ports"
+          AddAllowedPortsOrServices(needed_ports, "UDP", zone)
+        elsif key == "rpc_ports"
+          AddAllowedPortsOrServices(needed_ports, "RPC", zone)
+        elsif key == "ip_protocols"
+          AddAllowedPortsOrServices(needed_ports, "IP", zone)
+        elsif "broadcast_ports" == key
+          AddAllowedBroadcast(needed_ports, zone)
+        else
+          Builtins.y2error("Unknown key '%1'", key)
+        end
+      end
+
+      nil
+    end
+
+    # Function resets flag which doesn't allow to read configuration from disk again.
+    # So you actually can reread the configuration from disk. Currently, only the first
+    # Read() call reads the configuration from disk.
+    def ResetReadFlag
+      @configuration_has_been_read = false
+
+      nil
+    end
+
+    # Function sets if firewall should be protected from internal zone.
+    #
+    # @param [Boolean] set_protect set to be protected from internal zone
+    def SetProtectFromInternalZone(set_protect)
+      SetModified()
+
+      if set_protect
+        Ops.set(@SETTINGS, "FW_PROTECT_FROM_INT", "yes")
+      else
+        Ops.set(@SETTINGS, "FW_PROTECT_FROM_INT", "no")
+      end
+
+      nil
+    end
+
+    # Function returns if firewall is protected from internal zone.
+    #
+    # @return [Boolean] if protected from internal
+    def GetProtectFromInternalZone
+      Ops.get_string(@SETTINGS, "FW_PROTECT_FROM_INT", "no") == "yes"
+    end
+
+    # Function sets if firewall should support routing.
+    #
+    # @param [Boolean] set_route set to support route or not
+    def SetSupportRoute(set_route)
+      SetModified()
+
+      if set_route
+        Ops.set(@SETTINGS, "FW_STOP_KEEP_ROUTING_STATE", "yes")
+        Ops.set(@SETTINGS, "FW_ROUTE", "yes")
+      else
+        Ops.set(@SETTINGS, "FW_STOP_KEEP_ROUTING_STATE", "no")
+        Ops.set(@SETTINGS, "FW_ROUTE", "no")
+      end
+
+      nil
+    end
+
+    # Function returns if firewall supports routing.
+    #
+    # @return [Boolean] if route is supported
+    def GetSupportRoute
+      Ops.get_string(@SETTINGS, "FW_ROUTE", "no") == "yes"
+    end
+
+    # Function sets how firewall should trust successfully decrypted IPsec packets.
+    # It should be the zone name (shortname) or 'no' to trust packets the same as
+    # firewall trusts the zone from which IPsec packet came.
+    #
+    # @param [String] zone or "no"
+    def SetTrustIPsecAs(zone)
+      SetModified()
+
+      # do not trust
+      if zone == "no"
+        Ops.set(@SETTINGS, "FW_IPSEC_TRUST", "no")
+      # trust IPsec is a known zone
+      elsif IsKnownZone(zone)
+        zone = GetZoneConfigurationString(zone)
+        Ops.set(@SETTINGS, "FW_IPSEC_TRUST", zone)
+        # unknown zone, changing to default value
+      else
+        defaultv = GetDefaultValue("FW_IPSEC_TRUST")
+        Builtins.y2warning(
+          "Trust IPsec as '%1' (unknown zone) changed to '%2'",
+          zone,
+          defaultv
+        )
+        Ops.set(@SETTINGS, "FW_IPSEC_TRUST", defaultv)
+      end
+
+      nil
+    end
+
+    # Function returns the trust level of IPsec packets.
+    # See SetTrustIPsecAs() for more information.
+    #
+    # @return [String] zone or "no"
+    def GetTrustIPsecAs
+      # do not trust
+      return "no" if Ops.get(@SETTINGS, "FW_IPSEC_TRUST") == "no"
+
+      # default value for 'yes" ~= "INT"
+      return "INT" if Ops.get(@SETTINGS, "FW_IPSEC_TRUST") == "yes"
+
+      zone = GetConfigurationStringZone(
+        Ops.get_string(@SETTINGS, "FW_IPSEC_TRUST", "")
+      )
+
+      # trust as named zone (if known)
+      return zone if IsKnownZone(zone)
+
+      # unknown zone, change to default value
+      SetModified()
+      defaultv = GetDefaultValue("FW_IPSEC_TRUST")
+      Builtins.y2warning(
+        "Trust IPsec as '%1' (unknown zone) changed to '%2'",
+        Ops.get_string(@SETTINGS, "FW_IPSEC_TRUST", ""),
+        defaultv
+      )
+      SetTrustIPsecAs(defaultv)
+      "no"
+    end
+
+    # Function for getting exported SuSEFirewall configuration
+    #
+    # @return [Hash{String => Object}] with configuration
+    def Export
+      deep_copy(@SETTINGS)
+    end
+
+    # Function for setting SuSEFirewall configuration from input
+    #
+    # @param [Hash<String, Object>] import_settings with configuration
+    def Import(import_settings)
+      Read()
+      @SETTINGS.merge!(import_settings || {})
+      @configuration_has_been_read = true
+
+      SetModified()
+
+      nil
+    end
+
+    # Function returns if the interface is in zone.
+    #
+    # @param [String] interface
+    # @param [String] zone firewall zone
+    # @return [Boolean] is in zone
+    #
+    # @example IsInterfaceInZone ("eth-id-01:11:DA:9C:8A:2F", "INT") -> false
+    def IsInterfaceInZone(interface, zone)
+      interfaces = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+      Builtins.contains(interfaces, interface)
+    end
+
+    # Function returns the firewall zone of interface, nil if no zone includes
+    # the interface. Error is reported when interface is found in multiple
+    # firewall zones, then the first appearance is returned.
+    #
+    # @param [String] interface
+    # @return [String] zone
+    #
+    # @example GetZoneOfInterface ("eth-id-01:11:DA:9C:8A:2F") -> "DMZ"
+    def GetZoneOfInterface(interface)
+      interface_zone = []
+
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        interface_zone = Builtins.add(interface_zone, zone) if IsInterfaceInZone(interface, zone)
+      end
+
+      # Fallback handling for 'any' in the FW_DEV_* configuration
+      if interface == @special_all_interface_string &&
+          Builtins.size(interface_zone) == 0
+        interface_zone = [@special_all_interface_zone]
+      end
+
+      if IsVerbose() && Ops.greater_than(Builtins.size(interface_zone), 1)
+        # TRANSLATORS: Error message, %1 = interface name (like eth0)
+        Report.Error(
+          Builtins.sformat(
+            _(
+              "Interface '%1' is included in multiple firewall zones.\n" \
+                "Continuing with configuration can produce errors.\n" \
+                "\n" \
+                "It is recommended to leave the configuration and repair it manually in\n" \
+                "the file '/etc/sysconfig/SuSEFirewall'."
+            ),
+            interface
+          )
+        )
+      end
+
+      # return the first existence of interface in zones
+      # if it is not presented anywhere, nil is returned
+      Ops.get_string(interface_zone, 0)
+    end
+
+    # Function returns list of zones of requested interfaces.
+    # Special string 'any' in 'EXT' zone is supported.
+    #
+    # @param [Array<String>] interfaces
+    # @return [Array<String>] firewall zones
+    #
+    # @example
+    #    GetZonesOfInterfaces (["eth1","eth4"]) -> ["EXT"]
+    def GetZonesOfInterfacesWithAnyFeatureSupported(interfaces)
+      interfaces = deep_copy(interfaces)
+      zones = []
+      zone = ""
+
+      # 'any' in 'EXT'
+      interfaces_covered_by_any = GetInterfacesInZoneSupportingAnyFeature(
+        @special_all_interface_zone
+      )
+
+      Builtins.foreach(interfaces) do |interface|
+        # interface is covered by 'any' in 'EXT'
+        zone = if Builtins.contains(interfaces_covered_by_any, interface)
+          @special_all_interface_zone
+        else
+          # interface is explicitely mentioned in some zone
+          GetZoneOfInterface(interface)
+        end
+        zones = Builtins.add(zones, zone) if !zone.nil?
+      end
+
+      Builtins.toset(zones)
+    end
+
+    # Function returns list of non-dial-up interfaces.
+    #
+    # @return [Array<String>] of non-dial-up interface names
+    # @example GetAllNonDialUpInterfaces() -> ["eth1", "eth2"]
+    def GetAllNonDialUpInterfaces
+      non_dial_up_interfaces = []
+      Builtins.foreach(GetAllKnownInterfaces()) do |interface|
+        if Ops.get(interface, "type") != "dial_up"
+          non_dial_up_interfaces = Builtins.add(
+            non_dial_up_interfaces,
+            Ops.get(interface, "id", "")
+          )
+        end
+      end
+
+      deep_copy(non_dial_up_interfaces)
+    end
+
+    # Function returns list of dial-up interfaces.
+    #
+    # @return [Array<String>] of dial-up interface names
+    # @example GetAllDialUpInterfaces() -> ["modem0", "dsl5"]
+    def GetAllDialUpInterfaces
+      dial_up_interfaces = []
+      Builtins.foreach(GetAllKnownInterfaces()) do |interface|
+        if Ops.get(interface, "type") == "dial_up"
+          dial_up_interfaces = Builtins.add(
+            dial_up_interfaces,
+            Ops.get(interface, "id", "")
+          )
+        end
+      end
+
+      deep_copy(dial_up_interfaces)
+    end
+
+    # Function removes interface from defined zone.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    # @example RemoveInterfaceFromZone ("modem0", "EXT")
+    def RemoveInterfaceFromZone(interface, zone)
+      SetModified()
+
+      Builtins.y2milestone(
+        "Removing interface '%1' from '%2' zone.",
+        interface,
+        zone
+      )
+
+      interfaces_in_zone = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+      interfaces_in_zone = Builtins.filter(interfaces_in_zone) do |single_interface|
+        single_interface != "" && single_interface != interface
+      end
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_DEV_", zone),
+        Builtins.mergestring(interfaces_in_zone, " ")
+      )
+
+      nil
+    end
+
+    # Functions adds interface into defined zone.
+    # All appearances of interface in other zones are removed.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    # @example AddInterfaceIntoZone ("eth5", "DMZ")
+    def AddInterfaceIntoZone(interface, zone)
+      SetModified()
+
+      current_zone = GetZoneOfInterface(interface)
+
+      DecreaseVerbosity()
+      # removing all appearances of interface in zones, excepting current_zone==new_zone
+      while !current_zone.nil? && current_zone != zone
+        # interface is in any zone already, removing it at first
+        RemoveInterfaceFromZone(interface, current_zone) if current_zone != zone
+        current_zone = GetZoneOfInterface(interface)
+      end
+      IncreaseVerbosity()
+
+      Builtins.y2milestone(
+        "Adding interface '%1' into '%2' zone.",
+        interface,
+        zone
+      )
+      interfaces_in_zone = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+      interfaces_in_zone = Builtins.toset(
+        Builtins.add(interfaces_in_zone, interface)
+      )
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_DEV_", zone),
+        Builtins.mergestring(interfaces_in_zone, " ")
+      )
+
+      nil
+    end
+
+    # Function returns list of known interfaces in requested zone.
+    # Special strings like 'any' or 'auto' and unknown interfaces are removed from list.
+    #
+    # @param [String] zone
+    # @return [Array<String>] of interfaces
+    # @example GetInterfacesInZone ("DMZ") -> ["eth4", "eth5"]
+    def GetInterfacesInZone(zone)
+      interfaces_in_zone = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+
+      known_interfaces_now = GetListOfKnownInterfaces()
+
+      # filtering special strings
+      interfaces_in_zone = Builtins.filter(interfaces_in_zone) do |interface|
+        interface != "" && Builtins.contains(known_interfaces_now, interface)
+      end
+
+      deep_copy(interfaces_in_zone)
+    end
+
+    # Function returns all interfaces already configured in firewall.
+    #
+    # @return [Array<String>] of configured interfaces
+    def GetFirewallInterfaces
+      firewall_configured_devices = []
+
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        firewall_configured_devices = Convert.convert(
+          Builtins.union(firewall_configured_devices, GetInterfacesInZone(zone)),
+          from: "list",
+          to:   "list <string>"
+        )
+      end
+
+      Builtins.toset(firewall_configured_devices)
+    end
+
+    # Returns list of interfaces not mentioned in any zone and covered by the
+    # special string 'any' in zone 'EXT' if such string exists there and the zone
+    # is EXT. If the feature 'any' is not set, function returns empty list.
+    #
+    # @param [String] zone
+    # @return [Array<String>] of interfaces covered by special string 'any'
+    # @see #IsAnyNetworkInterfaceSupported()
+    def InterfacesSupportedByAnyFeature(zone)
+      result = []
+
+      if zone == @special_all_interface_zone && IsAnyNetworkInterfaceSupported()
+        known_interfaces_now = GetListOfKnownInterfaces()
+        configured_interfaces = GetFirewallInterfaces()
+        Builtins.foreach(known_interfaces_now) do |one_interface|
+          if !Builtins.contains(configured_interfaces, one_interface)
+            Builtins.y2milestone(
+              "Interface '%1' supported by special string '%2' in zone '%3'",
+              one_interface,
+              @special_all_interface_string,
+              @special_all_interface_zone
+            )
+            result = Builtins.add(result, one_interface)
+          end
+        end
+      end
+
+      deep_copy(result)
+    end
+
+    # Function returns list of known interfaces in requested zone.
+    # Special string 'any' in EXT zone covers all interfaces without
+    # any zone assignment.
+    #
+    # @param [String] zone
+    # @return [Array<String>] of interfaces
+    def GetInterfacesInZoneSupportingAnyFeature(zone)
+      interfaces_in_zone = GetInterfacesInZone(zone)
+
+      # 'any' in EXT zone, add all interfaces without zone to this one
+      interfaces_covered_by_any = InterfacesSupportedByAnyFeature(zone)
+      if Ops.greater_than(Builtins.size(interfaces_covered_by_any), 0)
+        interfaces_in_zone = Convert.convert(
+          Builtins.union(interfaces_in_zone, interfaces_covered_by_any),
+          from: "list",
+          to:   "list <string>"
+        )
+      end
+
+      deep_copy(interfaces_in_zone)
+    end
+
+    # Returns whether a service is mentioned in FW_CONFIGURATIONS_[EXT|INT|DMZ].
+    # These services are defined by random packages.
+    #
+    # @param [String] service e.g., "service:sshd"
+    # @param [String] zone e.g., "EXT"
+    # @return [Boolean] if service is supported in zone
+    #
+    # @example
+    #    IsServiceDefinedByPackageSupportedInZone ("service:sshd", "EXT") -> true
+    def IsServiceDefinedByPackageSupportedInZone(service, zone)
+      return nil if !IsKnownZone(zone)
+
+      if service.nil?
+        Builtins.y2error("Service Id can't be nil!")
+        return nil
+      elsif Builtins.regexpmatch(service, "^service:.*")
+        service = Builtins.regexpsub(service, "^service:(.*)", "\\1")
+      end
+
+      # services defined by package are listed without "service:" which is here
+      # just to distinguish between dynamic and static definitions
+      supported_services = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_CONFIGURATIONS_", zone), ""),
+        " "
+      )
+      Builtins.contains(supported_services, service)
+    end
+
+    # Function returns if service is supported (allowed) in zone. Service must be defined
+    # in the SuSEFirewallServices. Works transparently also with services defined by packages.
+    # Such service starts with "service:" prefix.
+    #
+    # @see YCP Module SuSEFirewallServices
+    # @param [String] service id
+    # @param [String] zone
+    # @return [Boolean] if supported
+    #
+    # @example
+    #    // All ports defined by dns-server service in SuSEFirewallServices module
+    #    // are enabled in the respective zone
+    #    IsServiceSupportedInZone ("dns-server", "EXT") -> true
+    #  // irc-server definition exists on the system and the irc-server
+    #  // is mentioned in FW_CONFIGURATIONS_EXT variable of SuSEfirewall2
+    #  IsServiceSupportedInZone ("service:irc-server", "EXT") -> true
+    def IsServiceSupportedInZone(service, zone)
+      return nil if !IsKnownZone(zone)
+
+      Yast.import "SuSEFirewallServices" # lazy import due to circular dependencies
+
+      needed = SuSEFirewallServices.GetNeededPortsAndProtocols(service)
+
+      # SuSEFirewall feature FW_PROTECT_FROM_INT
+      # should not be protected and searched zones include also internal (or the zone IS internal, sure)
+      if zone == @int_zone_shortname && !GetProtectFromInternalZone()
+        Builtins.y2milestone(
+          "Checking for service '%1', in '%2', PROTECT_FROM_INTERNAL='no' => allowed",
+          service,
+          zone
+        )
+        return true
+      end
+
+      # FATE #300687: Ports for SuSEfirewall added via packages
+      if SuSEFirewallServices.ServiceDefinedByPackage(service)
+        supported = IsServiceDefinedByPackageSupportedInZone(service, zone)
+        return supported
+      end
+
+      # starting with nil value, any false means that the service is not supported
+      service_is_supported = nil
+      Builtins.foreach(@service_defined_by) do |key|
+        needed_ports = Ops.get(needed, key, [])
+        next if needed_ports == []
+
+        if key == "tcp_ports"
+          service_is_supported = ArePortsOrServicesAllowed(
+            needed_ports,
+            "TCP",
+            zone,
+            true
+          )
+        elsif key == "udp_ports"
+          service_is_supported = ArePortsOrServicesAllowed(
+            needed_ports,
+            "UDP",
+            zone,
+            true
+          )
+        elsif key == "rpc_ports"
+          service_is_supported = ArePortsOrServicesAllowed(
+            needed_ports,
+            "RPC",
+            zone,
+            false
+          )
+        elsif key == "ip_protocols"
+          service_is_supported = ArePortsOrServicesAllowed(
+            needed_ports,
+            "IP",
+            zone,
+            false
+          )
+        elsif "broadcast_ports" == key
+          # testing for allowed broadcast ports
+          service_is_supported = IsBroadcastAllowed(needed_ports, zone)
+        else
+          Builtins.y2error("Unknown key '%1'", key)
+        end
+        # service is not supported, we don't have to do more tests
+        raise Break if service_is_supported == false
+      end
+
+      service_is_supported
+    end
+
+    # Function sets status for several services in several firewall zones.
+    #
+    # @param [Array<String>] services_ids
+    # @param [Array<String>] firewall_zones (EXT|INT|DMZ...)
+    # @param [Boolean] new_status of services
+    # @return nil
+    #
+    # @example
+    #    SetServicesForZones (["samba-server", "service:irc-server"], ["DMZ", "EXT"], false);
+    #    SetServicesForZones (["samba-server", "service:irc-server"], ["EXT", "DMZ"], true);
+    #
+    # @see #GetServicesInZones()
+    # @see #GetServices()
+    def SetServicesForZones(services_ids, firewall_zones, new_status)
+      # setting for each service
+      Builtins.foreach(services_ids) do |service_id|
+        Builtins.foreach(firewall_zones) do |firewall_zone|
+          # zone must be known one
+          if !IsKnownZone(firewall_zone)
+            Builtins.y2error(
+              "Zone '%1' is unknown firewall zone, skipping...",
+              firewall_zone
+            )
+            next
+          end
+          SetModified()
+          # setting new status
+          if new_status == true
+            Builtins.y2milestone(
+              "Adding '%1' into '%2' zone",
+              service_id,
+              firewall_zone
+            )
+            AddServiceSupportIntoZone(service_id, firewall_zone)
+          else
+            Builtins.y2milestone(
+              "Removing '%1' from '%2' zone",
+              service_id,
+              firewall_zone
+            )
+            RemoveServiceSupportFromZone(service_id, firewall_zone)
+          end
+        end
+      end
+
+      nil
+    end
+
+    # Local function sets the default configuration and fills internal values.
+    def ReadDefaultConfiguration
+      @SETTINGS = {}
+
+      ResetSysconfigSuSEFirewall(GetListOfSuSEFirewallVariables())
+
+      nil
+    end
+
+    # Local function reads current configuration and fills internal values.
+    def ReadCurrentConfiguration
+      @SETTINGS = {}
+
+      # is firewall enabled in /etc/init.d/ ?
+      Ops.set(@SETTINGS, "enable_firewall", IsEnabled())
+      # is firewall started now?
+      Ops.set(@SETTINGS, "start_firewall", IsStarted())
+
+      ReadSysconfigSuSEFirewall(GetListOfSuSEFirewallVariables())
+
+      nil
+    end
+
+    # Fills the configuration with default settings,
+    # adjusts internal variables that firewall cannot be configured.
+    def FillUpEmptyConfig
+      # do not call it again
+      @configuration_has_been_read = true
+
+      # Default settings, services are disabled
+      @SETTINGS = deep_copy(@DEFAULT_SETTINGS)
+      Ops.set(@SETTINGS, "enable_firewall", false)
+      Ops.set(@SETTINGS, "start_firewall", false)
+
+      # Cannot be configured, packages weren't installed
+      @fw_service_can_be_configured = false
+
+      nil
+    end
+
+    # Function for reading SuSEFirewall configuration.
+    # Fills internal variables only.
+    #
+    # @return [Boolean] if successful
+    def Read
+      # Do not read it again and again
+      # to avoid rewriting changes already made
+      if @configuration_has_been_read
+        Builtins.y2milestone(
+          "SuSEfirewall2 configuration has been read already."
+        )
+        return @fw_service_can_be_configured
+      end
+
+      # bnc #887406
+      if !FileUtils.Exists(CONFIG_FILE) || !SuSEFirewallIsSelectedOrInstalled()
+        log.warn "No firewall config -> firewall can't be read"
+        FillUpEmptyConfig()
+        return false
+      end
+
+      # Can be configured, packages were installed
+      @fw_service_can_be_configured = true
+
+      # Progress only for normal configuration
+      have_progress = Mode.normal
+
+      if have_progress
+        # TRANSLATORS: Dialog caption
+        read_caption = _("Initializing Firewall Configuration")
+
+        Progress.New(
+          read_caption,
+          " ",
+          3,
+          [
+            # TRANSLATORS: Progress step
+            _("Check for network devices"),
+            # TRANSLATORS: Progress step
+            _("Read current configuration"),
+            # TRANSLATORS: Progress step
+            _("Check possibly conflicting services")
+          ],
+          [
+            # TRANSLATORS: Progress step
+            _("Checking for network devices..."),
+            # TRANSLATORS: Progress step
+            _("Reading current configuration..."),
+            # TRANSLATORS: Progress step
+            _("Checking possibly conflicting services..."),
+            Message.Finished
+          ],
+          ""
+        )
+
+        Progress.NextStage
+      end
+
+      # Always call NI::Read, bnc #396646
+      NetworkInterfaces.Read
+
+      Progress.NextStage if have_progress
+
+      ReadCurrentConfiguration()
+
+      Progress.NextStage if have_progress
+
+      # checking if any possibly conficting services were turned on in configuration
+      # filling internal values for later checkings
+      # CheckAllPossiblyConflictingServices();
+      # -- Function has been turned off as we don't support services defined by YaST itself anymore --
+
+      Builtins.y2milestone(
+        "Firewall configuration has been read: %1.",
+        @SETTINGS
+      )
+      # to read configuration only once
+      @configuration_has_been_read = true
+
+      Progress.NextStage if have_progress
+
+      # bnc #399217
+      # Converting built-in service definitions to services defined by packages
+      ConvertToServicesDefinedByPackages()
+
+      Progress.Finish if have_progress
+
+      true
+    end
+
+    # Function returns whether some RPC service is allowed in the configuration.
+    # These services reallocate their ports when restarted. See details in
+    # bugzilla bug #186186.
+    #
+    # @return [Boolean] some_RPC_service_used
+    def AnyRPCServiceInConfiguration
+      ret = false
+
+      Builtins.foreach(GetKnownFirewallZones()) do |fw_zone|
+        fw_rule = Builtins.sformat("FW_SERVICES_%1_RPC", fw_zone)
+        listed_services = Ops.get_string(@SETTINGS, fw_rule) do
+          GetDefaultValue(fw_rule)
+        end
+        # easy case
+        next if listed_services.nil? || listed_services == ""
+
+        # something listed but it still might be empty definition
+        services_list = Builtins.splitstring(listed_services, " \n\t")
+        services_list = Builtins.filter(services_list) do |service|
+          service != ""
+        end
+        if Ops.greater_than(Builtins.size(services_list), 0)
+          ret = true
+          raise Break
+        end
+      end
+
+      Builtins.y2milestone("Some RPC service found: %1", ret)
+      ret
+    end
+
+    # Function which stops firewall. Then firewall is started immediately when firewall
+    # is wanted to be started: SetStartService(boolean).
+    #
+    # @return [Boolean] if successful
+    def ActivateConfiguration
+      # just disabled
+      return true if !SuSEFirewallIsInstalled()
+
+      # starting firewall during second stage can cause deadlock in systemd - bnc#798620
+      # Moreover, it is not needed. Firewall gets started via dependency on multi-user.target
+      # when second stage is over.
+      if Mode.installation && !Mode.autoinst
+        Builtins.y2milestone("Do not touch firewall services during installation")
+
+        return true
+      end
+
+      # Firewall should start after Write()
+      if GetStartService()
+        # Not started - start it
+        if !IsStarted()
+          Builtins.y2milestone("Starting firewall services")
+          return StartServices()
+        # Started - restart it
+        # modified - restart it, or ...
+        # bugzilla #186186
+        # If any RPC service is configured to be allowed, always restart the firewall
+        # Some of these service's ports might have been reallocated (when SuSEFirewall
+        # is used from outside, e.g., yast2-nfs-server)
+        elsif GetModified() || AnyRPCServiceInConfiguration()
+          Builtins.y2milestone("Stopping firewall services")
+          StopServices()
+          Builtins.y2milestone("Starting firewall services")
+          return StartServices()
+        # not modified - skip restart
+        else
+          Builtins.y2milestone(
+            "Configuration hasn't modified, skipping restarting services"
+          )
+          return true
+        end
+      # Firewall should stop after Write()
+      # started - stop
+      elsif IsStarted()
+        Builtins.y2milestone("Stopping firewall services")
+        return StopServices()
+        # stopped - skip stopping
+      else
+        Builtins.y2milestone("Firewall has been stopped already")
+        return true
+      end
+    end
+
+    # Function writes configuration into /etc/sysconfig/ and enables or disables
+    # firewall in /etc/init.d/ by the setting SetEnableService(boolean).
+    # This is a write-only configuration, firewall is never started only enabled
+    # or disabled.
+    #
+    # @return [Boolean] if successful
+    def WriteConfiguration
+      # just disabled
+      return true if !SuSEFirewallIsInstalled()
+
+      # Progress only for normal configuration and command line
+      have_progress = Mode.normal
+
+      if have_progress
+        # TRANSLATORS: Dialog caption
+        write_caption = _("Writing Firewall Configuration")
+
+        Progress.New(
+          write_caption,
+          " ",
+          2,
+          [
+            # TRANSLATORS: Progress step
+            _("Write firewall settings"),
+            # TRANSLATORS: Progress step
+            _("Adjust firewall service")
+          ],
+          [
+            # TRANSLATORS: Progress step
+            _("Writing firewall settings..."),
+            # TRANSLATORS: Progress step
+            _("Adjusting firewall service..."),
+            # TRANSLATORS: Progress step
+            Message.Finished
+          ],
+          ""
+        )
+
+        Progress.NextStage
+      end
+
+      # only modified configuration is written
+      if GetModified()
+        Builtins.y2milestone(
+          "Firewall configuration has been changed. Writing: %1.",
+          @SETTINGS
+        )
+
+        if !WriteSysconfigSuSEFirewall(GetListOfSuSEFirewallVariables())
+          # TRANSLATORS: a popup error message
+          Report.Error(_("Writing settings failed"))
+          return false
+        end
+      else
+        Builtins.y2milestone("Firewall settings weren't modified, skipping...")
+      end
+
+      Progress.NextStage if have_progress
+
+      # Adjusting services
+      if GetModified()
+        # enabling firewall in /etc/init.d/
+        if Ops.get_boolean(@SETTINGS, "enable_firewall", false)
+          Builtins.y2milestone("Enabling firewall services")
+          return false if !EnableServices()
+          # disabling firewall in /etc/init.d/
+        else
+          Builtins.y2milestone("Disabling firewall services")
+          return false if !DisableServices()
+        end
+      else
+        Builtins.y2milestone(
+          "Firewall enable/disable wasn't modified, skipping..."
+        )
+      end
+
+      Progress.NextStage if have_progress
+
+      if @already_converted &&
+          !FileUtils.Exists(@converted_to_services_dbp_file)
+        Builtins.y2milestone(
+          "Writing %1: %2",
+          @converted_to_services_dbp_file,
+          SCR.Write(path(".target.string"), @converted_to_services_dbp_file, "")
+        )
+      end
+
+      Progress.Finish if have_progress
+
+      true
+    end
+
+    # Helper function for backward compatibility.
+    # See WriteConfiguration(). Remove from code ASAP.
+    #
+    # @return [Boolean] if succesful
+    def WriteOnly
+      WriteConfiguration()
+    end
+
+    # Function for writing and enabling configuration, it is a union of
+    # WriteConfiguration() and ActivateConfiguration().
+    #
+    # @return [Boolean] if succesfull
+    def Write
+      CheckKernelModules()
+
+      # just disabled
+      return true if !SuSEFirewallIsInstalled()
+
+      return false if !WriteConfiguration()
+
+      return false if !ActivateConfiguration()
+
+      true
+    end
+
+    # This powerful function returns list of services/ports which are
+    # not assigned to any fully-supported known-services.
+    # This function doesn't check for services defined by packages.
+    # They are listed by a different method.
+    #
+    # @return [Array<String>] of additional (unassigned) services
+    #
+    # @example
+    #    GetAdditionalServices("TCP", "EXT") -> ["53", "128"]
+    def GetAdditionalServices(protocol, zone)
+      if !IsSupportedProtocol(protocol)
+        Builtins.y2error("Unknown protocol '%1'", protocol)
+        return nil
+      end
+      if !IsKnownZone(zone)
+        Builtins.y2error("Unknown zone '%1'", zone)
+        return nil
+      end
+
+      # all ports or services allowed in zone for protocol
+      all_allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+
+      # all ports or services used by known service
+      all_used_services = []
+
+      Yast.import "SuSEFirewallServices" # lazy import due to circular dependencies
+
+      # trying all possible (known) services
+      Builtins.foreach(SuSEFirewallServices.GetSupportedServices) do |service_id, _service_name|
+        # only when the service is allowed in zone - remove all its needed ports
+        if IsServiceSupportedInZone(service_id, zone) == true
+          # all needed ports etc for service/protocol
+          needed_all = []
+          if protocol == "TCP"
+            needed_all = SuSEFirewallServices.GetNeededTCPPorts(service_id)
+          elsif protocol == "UDP"
+            needed_all = SuSEFirewallServices.GetNeededUDPPorts(service_id)
+          elsif protocol == "RPC"
+            needed_all = SuSEFirewallServices.GetNeededRPCPorts(service_id)
+          elsif protocol == "IP"
+            needed_all = SuSEFirewallServices.GetNeededIPProtocols(service_id)
+          end
+          Builtins.foreach(needed_all) do |remove_port|
+            # all used services and their aliases
+            all_used_services = Convert.convert(
+              Builtins.union(
+                all_used_services,
+                PortAliases.GetListOfServiceAliases(remove_port)
+              ),
+              from: "list",
+              to:   "list <string>"
+            )
+          end
+        end
+      end
+
+      # some services are used by known defined-services
+      if Ops.greater_than(Builtins.size(all_used_services), 0)
+        all_used_services = Builtins.toset(all_used_services)
+        # removing all used services from all allowed
+        all_allowed_services = Builtins.filter(all_allowed_services) do |port|
+          !Builtins.contains(all_used_services, port)
+        end
+      end
+
+      # well, actually it returns list of services not-assigned to any well-known service
+      deep_copy(all_allowed_services)
+    end
+
+    # Function returns map of `interfaces in zones`.
+    #
+    # @return [Hash{String => Array<String>}] interface in zones
+    #
+    #
+    # **Structure:**
+    #
+    #        map $[zone : [list of interfaces]]
+    #
+    # @example
+    #    GetFirewallInterfacesMap() -> $["DMZ":[], "EXT":["dsl0"], "INT":["eth1", "eth2"]]
+    def GetFirewallInterfacesMap
+      firewall_interfaces_now = {}
+
+      # list of all known interfaces
+      known_interfaces = GetListOfKnownInterfaces()
+
+      # searching each zone
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        # filtering non-existing interfaces
+        Ops.set(
+          firewall_interfaces_now,
+          zone,
+          Builtins.filter(GetInterfacesInZone(zone)) do |interface|
+            Builtins.contains(known_interfaces, interface)
+          end
+        )
+      end
+
+      deep_copy(firewall_interfaces_now)
+    end
+
+    # Function returns list of special strings like 'any' or 'auto' and uknown interfaces.
+    #
+    # @param [String] zone
+    # @return [Array<String>] special strings or unknown interfaces
+    #
+    # @example
+    #    GetSpecialInterfacesInZone("EXT") -> ["any", "unknown-1", "wrong-3"]
+    def GetSpecialInterfacesInZone(zone)
+      interfaces_in_zone = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+
+      known_interfaces_now = GetInterfacesInZone(zone)
+
+      # filtering known interfaces and spaces
+      interfaces_in_zone = Builtins.filter(interfaces_in_zone) do |interface|
+        interface != "" && !Builtins.contains(known_interfaces_now, interface)
+      end
+
+      deep_copy(interfaces_in_zone)
+    end
+
+    # Function removes special string from defined zone.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    def RemoveSpecialInterfaceFromZone(interface, zone)
+      SetModified()
+
+      Builtins.y2milestone(
+        "Removing special string '%1' from '%2' zone.",
+        interface,
+        zone
+      )
+
+      interfaces_in_zone = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+      interfaces_in_zone = Builtins.filter(interfaces_in_zone) do |single_interface|
+        single_interface != "" && single_interface != interface
+      end
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_DEV_", zone),
+        Builtins.mergestring(interfaces_in_zone, " ")
+      )
+
+      nil
+    end
+
+    # Function adds special string into defined zone.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    def AddSpecialInterfaceIntoZone(interface, zone)
+      SetModified()
+
+      Builtins.y2milestone(
+        "Adding special string '%1' into '%2' zone.",
+        interface,
+        zone
+      )
+      interfaces_in_zone = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, Ops.add("FW_DEV_", zone), ""),
+        " "
+      )
+      interfaces_in_zone = Builtins.toset(
+        Builtins.add(interfaces_in_zone, interface)
+      )
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_DEV_", zone),
+        Builtins.mergestring(interfaces_in_zone, " ")
+      )
+
+      nil
+    end
+
+    # Function returns actual state of Masquerading support.
+    #
+    # @param _zone Ignored
+    # @return [Boolean] if supported
+    def GetMasquerade(_zone = nil)
+      Ops.get_string(@SETTINGS, "FW_MASQUERADE", "no") == "yes" &&
+        Ops.get_string(@SETTINGS, "FW_ROUTE", "no") == "yes"
+    end
+
+    # Function sets Masquerade support.
+    #
+    # @param enable [Boolean] to support or not to support it
+    # @param _zone ignored
+    def SetMasquerade(enable, _zone = nil)
+      SetModified()
+
+      Ops.set(@SETTINGS, "FW_MASQUERADE", enable ? "yes" : "no")
+
+      # routing is needed for masquerading, but we can't switch it off when disabling masquerading
+      Ops.set(@SETTINGS, "FW_ROUTE", "yes") if enable
+
+      nil
+    end
+
+    # Function returns list of rules of forwarding ports
+    # to masqueraded IPs.
+    #
+    # @return  [Array<Hash{String => String>}] list of rules
+    #
+    #
+    # **Structure:**
+    #
+    #     list [$[ key: value ]]
+    #
+    # @example
+    #    GetListOfForwardsIntoMasquerade() -> [
+    # $[
+    #   "forward_to":"172.24.233.1",
+    #   "protocol":"tcp",
+    #   "req_ip":"192.168.0.3",
+    #   "req_port":"355",
+    #   "source_net":"192.168.0.0/20",
+    #   "to_port":"533"],
+    #   ...
+    # ]
+    def GetListOfForwardsIntoMasquerade
+      list_of_rules = []
+
+      Builtins.foreach(
+        Builtins.splitstring(
+          Ops.get_string(@SETTINGS, "FW_FORWARD_MASQ", ""),
+          " "
+        )
+      ) do |forward_rule|
+        next if forward_rule == ""
+
+        # Format: <source network>,<ip to forward to>,<protocol>,<port>[,redirect port,[destination ip]]
+        fw_rul = Builtins.splitstring(forward_rule, ",")
+        # first four parameters has to be defined
+        if Ops.get(fw_rul, 0, "") == "" || Ops.get(fw_rul, 1, "") == "" ||
+            Ops.get(fw_rul, 2, "") == "" ||
+            Ops.get(fw_rul, 3, "") == ""
+          Builtins.y2warning(
+            "Wrong definition of redirect rule: '%1', part of '%2'",
+            forward_rule,
+            Ops.get_string(@SETTINGS, "FW_FORWARD_MASQ", "")
+          )
+        end
+        list_of_rules = Builtins.add(
+          list_of_rules,
+          "source_net" => Ops.get(fw_rul, 0, ""),
+          "forward_to" => Ops.get(fw_rul, 1, ""),
+          "protocol"   => Builtins.tolower(Ops.get(fw_rul, 2, "")),
+          "req_port"   => Builtins.tolower(Ops.get(fw_rul, 3, "")),
+          # to_port is req_port when undefined
+          "to_port"    => Builtins.tolower(
+            Ops.get(fw_rul, 4, Ops.get(fw_rul, 3, ""))
+          ),
+          "req_ip"     => Builtins.tolower(Ops.get(fw_rul, 5, ""))
+        )
+      end
+
+      deep_copy(list_of_rules)
+    end
+
+    # Function removes rule for forwarding into masquerade
+    # from the list of current rules returned by GetListOfForwardsIntoMasquerade().
+    #
+    # @param remove_item [Integer] item number
+    #
+    # @see #GetListOfForwardsIntoMasquerade()
+    def RemoveForwardIntoMasqueradeRule(remove_item)
+      SetModified()
+
+      forward_rules = []
+
+      row_counter = 0
+      Builtins.foreach(
+        Builtins.splitstring(
+          Ops.get_string(@SETTINGS, "FW_FORWARD_MASQ", ""),
+          " "
+        )
+      ) do |forward_rule|
+        next if forward_rule == ""
+
+        forward_rules = Builtins.add(forward_rules, forward_rule) if row_counter != remove_item
+        row_counter = Ops.add(row_counter, 1)
+      end
+
+      Ops.set(
+        @SETTINGS,
+        "FW_FORWARD_MASQ",
+        Builtins.mergestring(forward_rules, " ")
+      )
+
+      nil
+    end
+
+    # Adds forward into masquerade rule.
+    #
+    # @param [String] source_net
+    # @param [String] forward_to_ip
+    # @param [String] protocol
+    # @param [String] req_port
+    # @param [String] redirect_to_port
+    # @param [String] requested_ip
+    #
+    # @example
+    #    AddForwardIntoMasqueradeRule ("0/0", "192.168.32.1", "TCP", "80", "8080", "10.0.0.1")
+    def AddForwardIntoMasqueradeRule(source_net, forward_to_ip, protocol, req_port, redirect_to_port, requested_ip)
+      SetModified()
+
+      masquerade_rules = Ops.get_string(@SETTINGS, "FW_FORWARD_MASQ", "")
+
+      masquerade_rules = Ops.add(
+        Ops.add(
+          Ops.add(
+            Ops.add(
+              Ops.add(
+                Ops.add(
+                  Ops.add(
+                    Ops.add(masquerade_rules, (masquerade_rules != "") ? " " : ""),
+                    source_net
+                  ),
+                  ","
+                ),
+                forward_to_ip
+              ),
+              ","
+            ),
+            protocol
+          ),
+          ","
+        ),
+        req_port
+      )
+
+      if redirect_to_port != "" || requested_ip != ""
+        if requested_ip != ""
+          masquerade_rules = Ops.add(
+            Ops.add(
+              Ops.add(Ops.add(masquerade_rules, ","), redirect_to_port),
+              ","
+            ),
+            requested_ip
+          )
+          # port1 -> port2 are same
+        elsif redirect_to_port != req_port
+          masquerade_rules = Ops.add(
+            Ops.add(masquerade_rules, ","),
+            redirect_to_port
+          )
+        end
+      end
+
+      Ops.set(@SETTINGS, "FW_FORWARD_MASQ", masquerade_rules)
+
+      nil
+    end
+
+    # Function returns actual state of logging for rule taken as parameter.
+    #
+    # @param [String] rule definition 'ACCEPT' or 'DROP'
+    # @return [String] 'ALL', 'CRIT', or 'NONE'
+    #
+    # @example
+    #   GetLoggingSettings("ACCEPT") -> "CRIT"
+    #   GetLoggingSettings("DROP") -> "CRIT"
+    def GetLoggingSettings(rule)
+      ret_val = nil
+
+      if rule == "ACCEPT"
+        ret_val = if Ops.get_string(@SETTINGS, "FW_LOG_ACCEPT_ALL", "no") == "yes"
+          "ALL"
+        elsif Ops.get_string(@SETTINGS, "FW_LOG_ACCEPT_CRIT", "yes") == "yes"
+          "CRIT"
+        else
+          "NONE"
+        end
+      elsif rule == "DROP"
+        ret_val = if Ops.get_string(@SETTINGS, "FW_LOG_DROP_ALL", "no") == "yes"
+          "ALL"
+        elsif Ops.get_string(@SETTINGS, "FW_LOG_DROP_CRIT", "yes") == "yes"
+          "CRIT"
+        else
+          "NONE"
+        end
+      else
+        Builtins.y2error("Possible rules are only 'ACCEPT' or 'DROP'")
+      end
+
+      ret_val
+    end
+
+    # Function sets state of logging for rule taken as parameter.
+    #
+    # @param [String] rule definition 'ACCEPT' or 'DROP'
+    # @param [String] state new logging state 'ALL', 'CRIT', or 'NONE'
+    #
+    # @example
+    #   SetLoggingSettings ("ACCEPT", "ALL")
+    #   SetLoggingSettings ("DROP", "NONE")
+    def SetLoggingSettings(rule, state)
+      SetModified()
+
+      if rule == "ACCEPT"
+        if state == "ALL"
+          Ops.set(@SETTINGS, "FW_LOG_ACCEPT_CRIT", "yes")
+          Ops.set(@SETTINGS, "FW_LOG_ACCEPT_ALL", "yes")
+        elsif state == "CRIT"
+          Ops.set(@SETTINGS, "FW_LOG_ACCEPT_CRIT", "yes")
+          Ops.set(@SETTINGS, "FW_LOG_ACCEPT_ALL", "no")
+        else
+          Ops.set(@SETTINGS, "FW_LOG_ACCEPT_CRIT", "no")
+          Ops.set(@SETTINGS, "FW_LOG_ACCEPT_ALL", "no")
+        end
+      elsif rule == "DROP"
+        if state == "ALL"
+          Ops.set(@SETTINGS, "FW_LOG_DROP_CRIT", "yes")
+          Ops.set(@SETTINGS, "FW_LOG_DROP_ALL", "yes")
+        elsif state == "CRIT"
+          Ops.set(@SETTINGS, "FW_LOG_DROP_CRIT", "yes")
+          Ops.set(@SETTINGS, "FW_LOG_DROP_ALL", "no")
+        else
+          Ops.set(@SETTINGS, "FW_LOG_DROP_CRIT", "no")
+          Ops.set(@SETTINGS, "FW_LOG_DROP_ALL", "no")
+        end
+      else
+        Builtins.y2error("Possible rules are only 'ACCEPT' or 'DROP'")
+      end
+
+      nil
+    end
+
+    # Function returns yes/no - ignoring broadcast for zone
+    #
+    # @param [String] zone
+    # @return [String] "yes" or "no"
+    #
+    # @example
+    #    # Does not log ignored broadcast packets
+    #    GetIgnoreLoggingBroadcast ("EXT") -> "yes"
+    def GetIgnoreLoggingBroadcast(zone)
+      if !IsKnownZone(zone)
+        Builtins.y2error("Unknown zone '%1'", zone)
+        return nil
+      end
+
+      Ops.get_string(@SETTINGS, Ops.add("FW_IGNORE_FW_BROADCAST_", zone), "no")
+    end
+
+    # Function sets yes/no - ignoring broadcast for zone
+    #
+    # @param [String] zone
+    # @param [String] bcast ignore 'yes' or 'no'
+    #
+    # @example
+    #   # Does not log broadcast packets from DMZ
+    #   SetIgnoreLoggingBroadcast ("DMZ", "yes")
+    def SetIgnoreLoggingBroadcast(zone, bcast)
+      if !IsKnownZone(zone)
+        Builtins.y2error("Unknown zone '%1'", zone)
+        return nil
+      end
+
+      SetModified()
+
+      Ops.set(@SETTINGS, Ops.add("FW_IGNORE_FW_BROADCAST_", zone), bcast)
+
+      nil
+    end
+
+    # Firewall Expert Rules
+
+    # Returns list of rules describing protocols and ports that are allowed
+    # to be accessed from listed hosts. All is returned as a single string.
+    # Zone needs to be defined.
+    #
+    # @param [String] zone
+    # @return [String] with rules
+    def GetAcceptExpertRules(zone)
+      zone = Builtins.toupper(zone)
+
+      # Check for zone
+      if !Builtins.contains(GetKnownFirewallZones(), zone)
+        Builtins.y2error("Unknown firewall zone: %1", zone)
+        return nil
+      end
+
+      Ops.get_string(@SETTINGS, Ops.add("FW_SERVICES_ACCEPT_", zone), "")
+    end
+
+    # Sets expert allow rules for zone.
+    #
+    # @param [String] zone
+    # @param [String] expert_rules whitespace-separated expert_rules
+    # @return [Boolean] if successful
+    def SetAcceptExpertRules(zone, expert_rules)
+      zone = Builtins.toupper(zone)
+
+      # Check for zone
+      if !Builtins.contains(GetKnownFirewallZones(), zone)
+        Builtins.y2error("Unknown firewall zone: %1", zone)
+        return false
+      end
+
+      Ops.set(@SETTINGS, Ops.add("FW_SERVICES_ACCEPT_", zone), expert_rules)
+      SetModified()
+
+      true
+    end
+
+    # Returns list of additional kernel modules, that are loaded by firewall on startup.
+    # For instance "ip_conntrack_ftp" and "ip_nat_ftp" for FTP service.
+    #
+    # @return [Array<String>] of kernel modules
+    #
+    # @see /etc/sysconfig/SuSEfirewall2 option nr. 32 (FW_LOAD_MODULES)
+    def GetFirewallKernelModules
+      k_modules = Builtins.splitstring(
+        Ops.get_string(@SETTINGS, "FW_LOAD_MODULES", ""),
+        " \t\n"
+      )
+
+      k_modules = Builtins.filter(k_modules) { |one_module| one_module != "" }
+
+      Builtins.toset(k_modules)
+    end
+
+    # Sets list of additional kernel modules to be loaded by firewall on startup.
+    #
+    # @param [Array<String>] k_modules list of kernel modules
+    #
+    # @see /etc/sysconfig/SuSEfirewall2 option nr. 32
+    #
+    # @example
+    #   SuSEFirewall::SetFirewallKernelModules (["ip_conntrack_ftp","ip_nat_ftp"]);
+    def SetFirewallKernelModules(k_modules)
+      k_modules = deep_copy(k_modules)
+      k_modules = Builtins.filter(k_modules) do |one_module|
+        if one_module.nil?
+          Builtins.y2error(
+            "List of modules %1 contains 'nil'! It will be ignored.",
+            k_modules
+          )
+          next false
+        elsif one_module == ""
+          Builtins.y2warning(
+            "List of modules %1 contains an empty string, it will be ignored.",
+            k_modules
+          )
+          next false
+        end
+        if Builtins.regexpmatch(one_module, " ") ||
+            Builtins.regexpmatch(one_module, "\t")
+          Builtins.y2warning(
+            "Additional module '%1' contains spaces. They will be evaluated as two or more modules later.",
+            one_module
+          )
+        end
+        true
+      end
+
+      Ops.set(
+        @SETTINGS,
+        "FW_LOAD_MODULES",
+        Builtins.mergestring(k_modules, " ")
+      )
+      SetModified()
+
+      nil
+    end
+
+    # Returns translated protocol name. Translation is provided from
+    # SuSEfirewall2 sysconfig format to l10n format.
+    #
+    # @param protocol [String] from sysconfig (e.g., _rpc_)
+    # @return [String] translated string (e.g., RPC)
+    def GetProtocolTranslatedName(protocol)
+      protocol = Builtins.tolower(protocol)
+
+      if protocol == ""
+        ""
+      elsif Ops.get(@protocol_translations, protocol).nil?
+        Builtins.y2error("Unknown protocol: %1", protocol)
+        # table item, %1 stands for the buggy protocol name
+        Builtins.sformat(_("Unknown protocol (%1)"), protocol)
+      else
+        Ops.get(@protocol_translations, protocol, "")
+      end
+    end
+
+    # Returns list of FW_SERVICES_ACCEPT_RELATED_*: Services to allow that are
+    # considered RELATED by the connection tracking engine, e.g., SLP browsing
+    # reply or Samba browsing reply.
+    #
+    # @param [String] zone
+    # @return [Array<String>] list of definitions
+    #
+    # @example
+    #   GetServicesAcceptRelated ("EXT") -> ["0/0,udp,427", "0/0,udp,137"]
+    #
+    # @see #SetServicesAcceptRelated()
+    def GetServicesAcceptRelated(zone)
+      if !IsKnownZone(zone)
+        Builtins.y2error("Uknown zone '%1'", zone)
+        return []
+      end
+
+      Builtins.splitstring(
+        Ops.get_string(
+          @SETTINGS,
+          Ops.add("FW_SERVICES_ACCEPT_RELATED_", zone),
+          ""
+        ),
+        " \t\n"
+      )
+    end
+
+    # Functions sets FW_SERVICES_ACCEPT_RELATED_*: Services to allow that are
+    # considered RELATED by the connection tracking engine, e.g., SLP browsing
+    # reply or Samba browsing reply.
+    #
+    # @param [String] zone
+    # @param [Array<String>] ruleset list of rules
+    #
+    # @example
+    #   SetServicesAcceptRelated ("EXT", ["0/0,udp,427", "0/0,udp,137"])
+    #
+    # @see #GetServicesAcceptRelated()
+    def SetServicesAcceptRelated(zone, ruleset)
+      ruleset = deep_copy(ruleset)
+      if !IsKnownZone(zone)
+        Builtins.y2error("Uknown zone '%1'", zone)
+        return
+      end
+
+      ruleset = Builtins.filter(ruleset) { |one_rule| !one_rule.nil? }
+
+      SetModified()
+
+      Ops.set(
+        @SETTINGS,
+        Ops.add("FW_SERVICES_ACCEPT_RELATED_", zone),
+        Builtins.mergestring(ruleset, "\n")
+      )
+
+      nil
+    end
+
+    def CheckKernelModules
+      needs_additional_module = false
+
+      Builtins.foreach(GetKnownFirewallZones()) do |one_zone|
+        if Ops.greater_or_equal(
+          Builtins.size(GetServicesAcceptRelated(one_zone)),
+          0
+        )
+          Builtins.y2milestone("Some ServicesAcceptRelated are defined")
+          needs_additional_module = true
+          raise Break
+        end
+      end
+
+      if needs_additional_module
+        k_modules = Builtins.splitstring(
+          Ops.get_string(@SETTINGS, "FW_LOAD_MODULES", ""),
+          " "
+        )
+
+        if !Builtins.contains(k_modules, @broadcast_related_module)
+          Builtins.y2warning(
+            "FW_LOAD_MODULES doesn't contain %1, adding",
+            @broadcast_related_module
+          )
+          k_modules = Builtins.add(k_modules, @broadcast_related_module)
+          Ops.set(
+            @SETTINGS,
+            "FW_LOAD_MODULES",
+            Builtins.mergestring(k_modules, " ")
+          )
+          SetModified()
+        end
+      end
+
+      nil
+    end
+
+    # Removes old-service definitions before they are added as services defined
+    # by packages.
+    def RemoveOldAllowedServiceFromZone(old_service_def, zone)
+      old_service_def = deep_copy(old_service_def)
+      Builtins.y2milestone("Removing: %1 from zone %2", old_service_def, zone)
+
+      if Ops.get_list(old_service_def, "tcp_ports", []) != []
+        Builtins.foreach(Ops.get_list(old_service_def, "tcp_ports", [])) do |one_service|
+          RemoveService(one_service, "TCP", zone)
+        end
+      end
+
+      if Ops.get_list(old_service_def, "udp_ports", []) != []
+        Builtins.foreach(Ops.get_list(old_service_def, "udp_ports", [])) do |one_service|
+          RemoveService(one_service, "UDP", zone)
+        end
+      end
+
+      if Ops.get_list(old_service_def, "rpc_ports", []) != []
+        Builtins.foreach(Ops.get_list(old_service_def, "rpc_ports", [])) do |one_service|
+          RemoveService(one_service, "RPC", zone)
+        end
+      end
+
+      if Ops.get_list(old_service_def, "ip_protocols", []) != []
+        Builtins.foreach(Ops.get_list(old_service_def, "ip_protocols", [])) do |one_service|
+          RemoveService(one_service, "IP", zone)
+        end
+      end
+
+      if Ops.get_list(old_service_def, "broadcast_ports", []) != []
+        broadcast = GetBroadcastAllowedPorts()
+
+        Ops.set(broadcast, zone, Builtins.filter(Ops.get(broadcast, zone, [])) do |one_port|
+          !Builtins.contains(
+            Ops.get_list(old_service_def, "broadcast_ports", []),
+            one_port
+          )
+        end)
+
+        SetBroadcastAllowedPorts(broadcast)
+      end
+
+      nil
+    end
+
+    # Converts old built-in service definitions to services defined by packages.
+    #
+    # @see #bnc 399217
+    def ConvertToServicesDefinedByPackages
+      return if @already_converted
+
+      if FileUtils.Exists(@converted_to_services_dbp_file)
+        @already_converted = true
+        return
+      end
+
+      # $[ zone : $[ protocol : [ list of ports ] ] ]
+      current_conf = {}
+
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        Ops.set(current_conf, zone, {})
+        Builtins.foreach(@supported_protocols) do |protocol|
+          Ops.set(
+            current_conf,
+            [zone, protocol],
+            GetAllowedServicesForZoneProto(zone, protocol)
+          )
+          Ops.set(
+            current_conf,
+            [zone, "broadcast"],
+            Builtins.splitstring(GetBroadcastConfiguration(zone), " \n")
+          )
+        end
+      end
+
+      Builtins.y2milestone("Current conf: %1", current_conf)
+
+      Yast.import "SuSEFirewallServices" # lazy import due to circular dependencies
+
+      Builtins.foreach(GetKnownFirewallZones()) do |zone|
+        Builtins.foreach(SuSEFirewallServices.OLD_SERVICES) do |old_service_id, old_service_def|
+          Builtins.y2milestone("Checking %1 in %2 zone", old_service_id, zone)
+          if Ops.get_list(old_service_def, "tcp_ports", []) != [] &&
+              ArePortsOrServicesAllowed(
+                Ops.get_list(old_service_def, "tcp_ports", []),
+                "TCP",
+                zone,
+                true
+              ) != true
+            next
+          end
+          if Ops.get_list(old_service_def, "udp_ports", []) != [] &&
+              ArePortsOrServicesAllowed(
+                Ops.get_list(old_service_def, "udp_ports", []),
+                "UDP",
+                zone,
+                true
+              ) != true
+            next
+          end
+          if Ops.get_list(old_service_def, "rpc_ports", []) != [] &&
+              ArePortsOrServicesAllowed(
+                Ops.get_list(old_service_def, "rpc_ports", []),
+                "RPC",
+                zone,
+                false
+              ) != true
+            next
+          end
+          if Ops.get_list(old_service_def, "ip_protocols", []) != [] &&
+              ArePortsOrServicesAllowed(
+                Ops.get_list(old_service_def, "ip_protocols", []),
+                "IP",
+                zone,
+                false
+              ) != true
+            next
+          end
+          if Ops.get_list(old_service_def, "broadcast_ports", []) != [] &&
+              IsBroadcastAllowed(
+                Ops.get_list(old_service_def, "broadcast_ports", []),
+                zone
+              ) != true
+            next
+          end
+
+          if Ops.get_list(old_service_def, "convert_to", []) == []
+            Builtins.y2milestone(
+              "Service %1 supported, but it doesn't have any replacement",
+              old_service_id
+            )
+            next
+          end
+          replaced = false
+          Builtins.foreach(Ops.get_list(old_service_def, "convert_to", [])) do |replacement|
+            if SuSEFirewallServices.IsKnownService(replacement)
+              Builtins.y2milestone(
+                "Old service %1 matches %2",
+                old_service_id,
+                replacement
+              )
+              RemoveOldAllowedServiceFromZone(old_service_def, zone)
+              SetServicesForZones([replacement], [zone], true)
+              replaced = true
+              raise Break
+            end
+          end
+          if !replaced
+            Builtins.y2warning(
+              "Old service %1 matches %2 but none are installed",
+              old_service_id,
+              Ops.get_list(old_service_def, "convert_to", [])
+            )
+          end
+        end
+      end
+
+      Builtins.y2milestone("Converting done")
+      @already_converted = true
+
+      nil
+    end
+
+    # Local function allows ports for requested protocol and zone.
+    #
+    # @param [Array<string>] add_ports ports to be added
+    # @param [String] protocol
+    # @param [String] zone
+    def AddAllowedPortsOrServices(add_ports, protocol, zone)
+      add_ports = deep_copy(add_ports)
+      if Ops.less_than(Builtins.size(add_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      # all allowed ports
+      allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+
+      allowed_services = Convert.convert(
+        Builtins.union(allowed_services, add_ports),
+        from: "list",
+        to:   "list <string>"
+      )
+      allowed_services = PortRanges.FlattenServices(allowed_services, protocol)
+
+      SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+
+      nil
+    end
+
+    # Sets whether ports need to be open already during boot
+    # bsc#916376
+    #
+    # @param [Boolean] new_state
+    # @return [Boolean] current state
+    def full_init_on_boot(new_state)
+      @SETTINGS["FW_BOOT_FULL_INIT"] = new_state ? "yes" : "no"
+      SetModified()
+      @SETTINGS["FW_BOOT_FULL_INIT"] == "yes"
+    end
+
+    publish variable: :FIREWALL_PACKAGE, type: "const string"
+    publish variable: :configuration_has_been_read, type: "boolean", private: true
+    publish variable: :special_all_interface_string, type: "string"
+    publish variable: :max_port_number, type: "integer"
+    publish variable: :special_all_interface_zone, type: "string"
+    publish variable: :SETTINGS, type: "map <string, any>", private: true
+    publish variable: :modified, type: "boolean", private: true
+    publish variable: :is_running, type: "boolean", private: true
+    publish variable: :DEFAULT_SETTINGS, type: "map <string, string>", private: true
+    publish variable: :verbose_level, type: "integer", private: true
+    publish variable: :known_firewall_zones, type: "list <string>", private: true
+    publish variable: :zone_names, type: "map <string, string>", private: true
+    publish variable: :int_zone_shortname, type: "string", private: true
+    publish variable: :supported_protocols, type: "list <string>", private: true
+    publish variable: :service_defined_by, type: "list <string>", private: true
+    publish variable: :allowed_conflict_services, type: "map <string, list <string>>", private: true
+    publish variable: :firewall_service, type: "string", private: true
+    publish variable: :SuSEFirewall_variables, type: "list <string>", private: true
+    publish variable: :broadcast_related_module, type: "string", private: true
+    publish function: :SetModified, type: "void ()"
+    publish function: :ResetModified, type: "void ()"
+    publish function: :GetKnownFirewallZones, type: "list <string> ()"
+    publish function: :IsServiceSupportedInZone, type: "boolean (string, string)"
+    publish function: :GetSpecialInterfacesInZone, type: "list <string> (string)"
+    publish function: :AddSpecialInterfaceIntoZone, type: "void (string, string)"
+    publish variable: :report_only_once, type: "list <string>", private: true
+    publish function: :ReportOnlyOnce, type: "boolean (string)", private: true
+    publish function: :IsAnyNetworkInterfaceSupported, type: "boolean ()"
+    publish function: :GetListOfSuSEFirewallVariables, type: "list <string> ()", private: true
+    publish function: :IncreaseVerbosity, type: "void ()", private: true
+    publish function: :DecreaseVerbosity, type: "void ()", private: true
+    publish function: :IsVerbose, type: "boolean ()", private: true
+    publish function: :GetDefaultValue, type: "string (string)", private: true
+    publish function: :ReadSysconfigSuSEFirewall, type: "void (list <string>)", private: true
+    publish function: :ResetSysconfigSuSEFirewall, type: "void (list <string>)", private: true
+    publish function: :WriteSysconfigSuSEFirewall, type: "boolean (list <string>)", private: true
+    publish function: :IsSupportedProtocol, type: "boolean (string)", private: true
+    publish function: :IsKnownZone, type: "boolean (string)", private: true
+    publish function: :GetZoneConfigurationString, type: "string (string)", private: true
+    publish function: :GetConfigurationStringZone, type: "string (string)", private: true
+    publish function: :GetAllowedServicesForZoneProto, type: "list <string> (string, string)", private: true
+    publish function: :SetAllowedServicesForZoneProto, type: "void (list <string>, string, string)", private: true
+    publish function: :GetBroadcastConfiguration, type: "string (string)", private: true
+    publish function: :SetBroadcastConfiguration, type: "void (string, string)", private: true
+    publish function: :GetBroadcastAllowedPorts, type: "map <string, list <string>> ()"
+    publish function: :SetBroadcastAllowedPorts, type: "void (map <string, list <string>>)"
+    publish function: :IsBroadcastAllowed, type: "boolean (list <string>, string)", private: true
+    publish function: :RemoveAllowedBroadcast, type: "void (list <string>, string)", private: true
+    publish function: :AddAllowedBroadcast, type: "void (list <string>, string)", private: true
+    publish function: :RemoveServiceFromProtocolZone, type: "boolean (string, string, string)", private: true
+    publish function: :RemoveAllowedPortsOrServices, type: "void (list <string>, string, string, boolean)", private: true
+    publish function: :AddAllowedPortsOrServices, type: "void (list <string>, string, string)", private: true
+    publish function: :RemoveServiceDefinedByPackageFromZone, type: "void (string, string)", private: true
+    publish function: :AddServiceDefinedByPackageIntoZone, type: "void (string, string)", private: true
+    publish function: :RemoveServiceSupportFromZone, type: "void (string, string)", private: true
+    publish function: :AddServiceSupportIntoZone, type: "void (string, string)", private: true
+    publish variable: :check_and_install_package, type: "boolean", private: true
+    publish function: :SetInstallPackagesIfMissing, type: "void (boolean)"
+    publish function: :SuSEFirewallIsInstalled, type: "boolean ()"
+    publish variable: :fw_service_can_be_configured, type: "boolean", private: true
+    publish function: :GetModified, type: "boolean ()"
+    publish function: :ResetReadFlag, type: "void ()"
+    publish function: :GetZoneFullName, type: "string (string)"
+    publish function: :SetProtectFromInternalZone, type: "void (boolean)"
+    publish function: :GetProtectFromInternalZone, type: "boolean ()"
+    publish function: :SetSupportRoute, type: "void (boolean)"
+    publish function: :GetSupportRoute, type: "boolean ()"
+    publish function: :SetTrustIPsecAs, type: "void (string)"
+    publish function: :GetTrustIPsecAs, type: "string ()"
+    publish function: :GetStartService, type: "boolean ()"
+    publish function: :SetStartService, type: "void (boolean)"
+    publish function: :GetEnableService, type: "boolean ()"
+    publish function: :SetEnableService, type: "void (boolean)"
+    publish function: :StartServices, type: "boolean ()"
+    publish function: :StopServices, type: "boolean ()"
+    publish function: :EnableServices, type: "boolean ()"
+    publish function: :DisableServices, type: "boolean ()"
+    publish function: :IsEnabled, type: "boolean ()"
+    publish function: :IsStarted, type: "boolean ()"
+    publish function: :Export, type: "map <string, any> ()"
+    publish function: :Import, type: "void (map <string, any>)"
+    publish function: :read_and_import, type: "void (map <string, any>)"
+    publish function: :IsInterfaceInZone, type: "boolean (string, string)"
+    publish function: :GetZoneOfInterface, type: "string (string)"
+    publish function: :GetZonesOfInterfaces, type: "list <string> (list <string>)"
+    publish function: :GetInterfacesInZoneSupportingAnyFeature, type: "list <string> (string)"
+    publish function: :GetZonesOfInterfacesWithAnyFeatureSupported, type: "list <string> (list <string>)"
+    publish function: :GetAllKnownInterfaces, type: "list <map <string, string>> ()"
+    publish function: :GetAllNonDialUpInterfaces, type: "list <string> ()"
+    publish function: :GetAllDialUpInterfaces, type: "list <string> ()"
+    publish function: :GetListOfKnownInterfaces, type: "list <string> ()"
+    publish function: :RemoveInterfaceFromZone, type: "void (string, string)"
+    publish function: :AddInterfaceIntoZone, type: "void (string, string)"
+    publish function: :GetInterfacesInZone, type: "list <string> (string)"
+    publish function: :GetFirewallInterfaces, type: "list <string> ()"
+    publish function: :InterfacesSupportedByAnyFeature, type: "list <string> (string)"
+    publish function: :ArePortsOrServicesAllowed, type: "boolean (list <string>, string, string, boolean)", private: true
+    publish function: :HaveService, type: "boolean (string, string, string)"
+    publish function: :AddService, type: "boolean (string, string, string)"
+    publish function: :RemoveService, type: "boolean (string, string, string)"
+    publish function: :IsServiceDefinedByPackageSupportedInZone, type: "boolean (string, string)", private: true
+    publish function: :GetServicesInZones, type: "map <string, map <string, boolean>> (list <string>)"
+    publish function: :GetServices, type: "map <string, map <string, boolean>> (list <string>)"
+    publish function: :SetServicesForZones, type: "boolean (list <string>, list <string>, boolean)"
+    publish function: :SetServices, type: "boolean (list <string>, list <string>, boolean)"
+    publish function: :ReadDefaultConfiguration, type: "void ()", private: true
+    publish function: :ReadCurrentConfiguration, type: "void ()", private: true
+    publish variable: :converted_to_services_dbp_file, type: "string", private: true
+    publish variable: :already_converted, type: "boolean", private: true
+    publish function: :ConvertToServicesDefinedByPackages, type: "void ()"
+    publish function: :FillUpEmptyConfig, type: "void ()", private: true
+    publish function: :Read, type: "boolean ()"
+    publish function: :AnyRPCServiceInConfiguration, type: "boolean ()", private: true
+    publish function: :ActivateConfiguration, type: "boolean ()"
+    publish function: :WriteConfiguration, type: "boolean ()"
+    publish function: :CheckKernelModules, type: "void ()", private: true
+    publish function: :WriteOnly, type: "boolean ()"
+    publish function: :Write, type: "boolean ()"
+    publish function: :SaveAndRestartService, type: "boolean ()"
+    publish function: :GetAdditionalServices, type: "list <string> (string, string)"
+    publish function: :SetAdditionalServices, type: "void (string, string, list <string>)"
+    publish function: :IsOtherFirewallRunning, type: "boolean ()"
+    publish function: :GetFirewallInterfacesMap, type: "map <string, list <string>> ()"
+    publish function: :RemoveSpecialInterfaceFromZone, type: "void (string, string)"
+    publish function: :GetMasquerade, type: "boolean ()"
+    publish function: :SetMasquerade, type: "void (boolean)"
+    publish function: :GetListOfForwardsIntoMasquerade, type: "list <map <string, string>> ()"
+    publish function: :RemoveForwardIntoMasqueradeRule, type: "void (integer)"
+    publish function: :AddForwardIntoMasqueradeRule, type: "void (string, string, string, string, string, string)"
+    publish function: :GetLoggingSettings, type: "string (string)"
+    publish function: :SetLoggingSettings, type: "void (string, string)"
+    publish function: :GetIgnoreLoggingBroadcast, type: "string (string)"
+    publish function: :SetIgnoreLoggingBroadcast, type: "void (string, string)"
+    publish function: :AddXenSupport, type: "void ()"
+    publish function: :GetAcceptExpertRules, type: "string (string)"
+    publish function: :SetAcceptExpertRules, type: "boolean (string, string)"
+    publish function: :GetFirewallKernelModules, type: "list <string> ()"
+    publish function: :SetFirewallKernelModules, type: "void (list <string>)"
+    publish variable: :protocol_translations, type: "map <string, string>", private: true
+    publish function: :GetProtocolTranslatedName, type: "string (string)"
+    publish function: :GetServicesAcceptRelated, type: "list <string> (string)"
+    publish function: :SetServicesAcceptRelated, type: "void (string, list <string>)"
+    publish function: :RemoveOldAllowedServiceFromZone, type: "void (map <string, any>, string)", private: true
+    publish variable: :needed_packages_installed, type: "boolean"
+    publish function: :full_init_on_boot, type: "boolean (boolean)"
+  end
+end

--- a/library/network/src/lib/network/susefirewall2services.rb
+++ b/library/network/src/lib/network/susefirewall2services.rb
@@ -1,0 +1,527 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+
+require "yast"
+require "network/susefirewallservices"
+
+module Yast
+  # Global Definition of Firewall Services
+  # Defined using TCP, UDP and RPC ports and IP protocols and Broadcast UDP
+  # ports. Results are cached, so repeating requests are answered faster.
+  class SuSEFirewall2ServicesClass < SuSEFirewallServicesClass
+    include Yast::Logger
+
+    SERVICES_DIR = "/etc/sysconfig/SuSEfirewall2.d/services/".freeze
+
+    # please, check it with configuration in refresh-srv-def-by-pkgs-trans.sh script
+    SERVICES_TEXTDOMAIN = "firewall-services".freeze
+
+    READ_ONLY_SERVICE_FEATURES = ["name", "description"].freeze
+
+    IGNORED_SERVICES = ["TEMPLATE", "..", "."].freeze
+
+    TEMPLATE_SERVICE_NAME = "template service".freeze
+    TEMPLATE_SERVICE_DESCRIPTION = "opens ports for foo in order to allow bar".freeze
+
+    def main
+      textdomain "base"
+
+      Yast.import "FileUtils"
+
+      #
+      # IF YOU NEED TO ADD ANOTHER SERVICE, CREATE THE SERVICE DEFINITION
+      # IN A FILE AND ADD IT TO THE PACKAGE TO WHICH IT BELONGS.
+      # USE /etc/sysconfig/SuSEfirewall2.d/services/TEMPLATE FOR THAT.
+      #
+      # MORE INFORMATION IN FEATURE #300687: Ports for SuSEfirewall added via packages.
+      # ANOTHER REFERENCE: Bugzilla #246911.
+      #
+      # See also http://kobliha-suse.blogspot.cz/2008/06/firewall-services-defined-by-packages.html
+      #
+      #
+      # Names assigned to Port and Protocol numbers can be found
+      # here:
+      #
+      # http://www.iana.org/assignments/protocol-numbers
+      # http://www.iana.org/assignments/port-numbers
+      #
+      # Format of SERVICES
+      #
+      #   "service-id" : $[
+      #     "name"            : _("Service Name"),
+      #     "tcp_ports"       : list <tcp_ports>,
+      #     "udp_ports"       : list <udp_ports>,
+      #     "rpc_ports"       : list <rpc_ports>,
+      #     "ip_protocols"    : list <ip_protocols>,
+      #     "broadcast_ports" : list <broadcast_ports>,
+      #   ],
+      #
+      @services = nil
+
+      # firewall needs restarting
+      @sfws_modified = false
+
+      @known_services_features = {
+        "TCP"       => "tcp_ports",
+        "UDP"       => "udp_ports",
+        "RPC"       => "rpc_ports",
+        "IP"        => "ip_protocols",
+        "BROADCAST" => "broadcast_ports"
+      }
+
+      @known_metadata = { "Name" => "name", "Description" => "description" }
+
+      # Services definitions for conversion to the new ones.
+      @OLD_SERVICES = {
+        "http"         => {
+          "tcp_ports"  => ["http"],
+          "convert_to" => ["service:apache2", "service:lighttpd"]
+        },
+        "https"        => {
+          "tcp_ports"  => ["https"],
+          "convert_to" => ["service:apache2-ssl", "service:lighttpd-ssl"]
+        },
+        "smtp"         => { "tcp_ports" => ["smtp"], "convert_to" => [] },
+        "pop3"         => { "tcp_ports" => ["pop3"], "convert_to" => [] },
+        "pop3s"        => { "tcp_ports" => ["pop3s"], "convert_to" => [] },
+        "imap"         => {
+          "tcp_ports"  => ["imap"],
+          "convert_to" => ["service:courier-imapd"]
+        },
+        "imaps"        => {
+          "tcp_ports"  => ["imaps"],
+          "convert_to" => ["service:courier-imap-ssl"]
+        },
+        "samba-server" => {
+          "tcp_ports"       => ["netbios-ssn", "microsoft-ds"],
+          # TCP: 139, 445
+          "udp_ports"       => ["netbios-ns", "netbios-dgm"],
+          # UDP: 137, 138
+          "broadcast_ports" => ["netbios-ns", "netbios-dgm"],
+          # UDP: 137, 138
+          "convert_to"      => []
+        },
+        "ssh"          => {
+          "tcp_ports"  => ["ssh"],
+          "convert_to" => ["service:sshd"]
+        },
+        "rsync"        => { "tcp_ports" => ["rsync"], "convert_to" => [] },
+        "dhcp-server"  => {
+          "udp_ports"       => ["bootps"],
+          "broadcast_ports" => ["bootps"],
+          "convert_to"      => ["service:dhcp-server"]
+        },
+        "dhcp-client"  => { "udp_ports" => ["bootpc"], "convert_to" => [] },
+        "dns-server"   => {
+          "tcp_ports"  => ["domain"],
+          "udp_ports"  => ["domain"],
+          "convert_to" => ["service:bind"]
+        },
+        "nfs-client"   => {
+          "rpc_ports"  => ["portmap", "status", "nlockmgr"],
+          "convert_to" => ["service:nfs-client"]
+        },
+        "nfs-server"   => {
+          "rpc_ports"  => [
+            "portmap",
+            "status",
+            "nlockmgr",
+            "mountd",
+            "nfs",
+            "nfs_acl"
+          ],
+          "convert_to" => []
+        },
+        "nis-client"   => {
+          "rpc_ports"  => ["portmap", "ypbind"],
+          "convert_to" => ["service:ypserv"]
+        },
+        "nis-server"   => {
+          "rpc_ports"  => [
+            "portmap",
+            "ypserv",
+            "fypxfrd",
+            "ypbind",
+            "yppasswdd"
+          ],
+          "convert_to" => []
+        },
+        # Default SUSE installation
+        "vnc"          => {
+          "tcp_ports"  => ["5801", "5901"],
+          "convert_to" => []
+        },
+        "tftp"         => { "udp_ports" => ["tftp"], "convert_to" => [] },
+        # Internet Printing Protocol as a Server
+        "ipp-tcp"      => {
+          "tcp_ports"  => ["ipp"],
+          "convert_to" => []
+        },
+        # Internet Printing Protocol as a Client
+        # IPP Client needs to listen for broadcast messages
+        "ipp-udp"      => {
+          "udp_ports"       => ["ipp"],
+          "broadcast_ports" => ["ipp"],
+          "convert_to"      => []
+        },
+        "ntp-server"   => {
+          "udp_ports"       => ["ntp"],
+          "broadcast_ports" => ["ntp"],
+          "convert_to"      => ["service:ntp"]
+        },
+        "ldap"         => {
+          "tcp_ports"  => ["ldap"],
+          "convert_to" => ["service:openldap"]
+        },
+        "ldaps"        => { "tcp_ports" => ["ldaps"], "convert_to" => [] },
+        "ipsec"        => {
+          "udp_ports"    => ["isakmp", "ipsec-nat-t"],
+          "ip_protocols" => ["esp"],
+          "convert_to"   => []
+        },
+        "slp-daemon"   => {
+          "tcp_ports"       => ["svrloc"],
+          "udp_ports"       => ["svrloc"],
+          "broadcast_ports" => ["svrloc"],
+          "convert_to"      => []
+        },
+        # See bug #118200 for more information
+        "xdmcp"        => {
+          "tcp_ports"       => ["xdmcp"],
+          "udp_ports"       => ["xdmcp"],
+          "broadcast_ports" => ["xdmcp"],
+          "convert_to"      => []
+        },
+        # See bug #118196 for more information
+        "fam"          => {
+          "rpc_ports"  => ["sgi_fam"],
+          "convert_to" => []
+        },
+        # requested by thofmann
+        "open-pbs"     => {
+          # /etc/services says: The following entries are invalid, but needed
+          "tcp_ports"  => [
+            "pbs",
+            "pbs_mom",
+            "pbs_resmom",
+            "pbs_sched"
+          ],
+          "udp_ports"  => ["pbs_resmom"],
+          "convert_to" => []
+        },
+        "mysql-server" => {
+          "tcp_ports"  => ["mysql"],
+          "convert_to" => ["service:mysql"]
+        },
+        "iscsi-server" => {
+          "tcp_ports"  => ["iscsi-target"],
+          "convert_to" => ["service:iscsitarget"]
+        }
+      }
+    end
+
+    # Returns service definition.
+    # See @services for the format.
+    # If *silent* is `false` (the default), the method throws an exception
+    # {Yast::SuSEFirewalServiceNotFound} if service is not found on disk.
+    #
+    # @param [String] service_name name including the "service:" prefix
+    # @param [String] silent whether to silently return nil
+    #                 when service is not found
+    # @api private
+    def service_details(service_name, silent = false)
+      service = all_services[service_name]
+      if service.nil? && !silent
+        log.error "Unknown service '#{service_name}'"
+        log.info "Known services: #{all_services.keys}"
+
+        raise(
+          SuSEFirewalServiceNotFound,
+          format(_("Service with name '%{service_name}' does not exist"), service_name: service_name)
+        )
+      end
+
+      service
+    end
+
+    # Reads definition of services that can be used in FW_CONFIGURATIONS_[EXT|INT|DMZ]
+    # in SuSEfirewall2.
+    #
+    # @return [Boolean] if successful
+    # @api private
+    def ReadServicesDefinedByRPMPackages
+      log.info "Reading SuSEfirewall2 services from #{SERVICES_DIR}"
+      @services ||= {}
+
+      if !FileUtils.Exists(SERVICES_DIR) ||
+          !FileUtils.IsDirectory(SERVICES_DIR)
+        log.error "Cannot read #{SERVICES_DIR}"
+        return false
+      end
+
+      all_definitions = SCR.Read(path(".target.dir"), SERVICES_DIR)
+      all_definitions.reject! do |service|
+        IGNORED_SERVICES.include?(service)
+      end
+
+      service_name = nil
+      filefullpath = nil
+
+      # for all files in that directory
+      Builtins.foreach(all_definitions) do |filename|
+        # "service:abc_server" to distinguis between dynamic definition and the static one
+        service_name = DEFINED_BY_PKG_PREFIX + filename
+        # Do not read already known services
+        next unless @services[service_name].nil?
+
+        filefullpath = SERVICES_DIR + filename
+        @services[service_name] = {}
+
+        # Registering sysconfig agent for this file
+        if !SCR.RegisterAgent(
+          path(".firewall_service_definition"),
+          term(:ag_ini, term(:SysConfigFile, filefullpath))
+        )
+          log.error "Cannot register agent for #{filefullpath}"
+          next
+        end
+
+        definition = nil
+        definition_values = nil
+
+        Builtins.foreach(@known_services_features) do |known_feature, map_key|
+          definition = Convert.to_string(
+            SCR.Read(
+              Builtins.add(path(".firewall_service_definition"), known_feature)
+            )
+          )
+          definition = "" if definition.nil?
+          # map of services contains list of entries
+          definition_values = Builtins.splitstring(definition, " \t\n")
+          definition_values = Builtins.filter(definition_values) do |one_value|
+            one_value != ""
+          end
+          @services[service_name][map_key] = definition_values
+        end
+
+        # Unregistering sysconfig agent for this file
+        SCR.UnregisterAgent(path(".firewall_service_definition"))
+
+        # Fallback for presented service
+        @services[service_name]["name"] = format(_("Service: %{filename}"), filename: filename)
+        @services[service_name]["description"] = ""
+
+        # Registering sysconfig agent for this file (to get metadata)
+        if SCR.RegisterAgent(
+          path(".firewall_service_metadata"),
+          term(:ag_ini, GetMetadataAgent(filefullpath))
+        )
+          Builtins.foreach(@known_metadata) do |metadata_feature, metadata_key|
+            definition = Convert.to_string(
+              SCR.Read(
+                Builtins.add(
+                  path(".firewall_service_metadata"),
+                  metadata_feature
+                )
+              )
+            )
+            next if definition.nil? || definition.empty?
+
+            # call gettext to translate the metadata
+            @services[service_name][metadata_key] = Builtins.dgettext(SERVICES_TEXTDOMAIN, definition)
+
+            # bnc#893583: Sanitize metadata, do not allow using texts from template service
+            case metadata_key
+            when "name"
+              @services[service_name][metadata_key] = filename if definition == TEMPLATE_SERVICE_NAME
+            when "description"
+              @services[service_name][metadata_key] = "" if definition == TEMPLATE_SERVICE_DESCRIPTION
+            end
+          end
+
+          SCR.UnregisterAgent(path(".firewall_service_metadata"))
+        else
+          log.error "Cannot register agent for #{filefullpath} (metadata)"
+        end
+      end
+
+      log.info "Services found: #{@services.keys.sort}"
+
+      true
+    end
+
+    # Sets that configuration was modified
+    def SetModified
+      @sfws_modified = true
+
+      nil
+    end
+
+    # Function returns needed ports allowing broadcast
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [Array<String>] of needed broadcast ports
+    def GetNeededBroadcastPorts(service)
+      service_details(service)["broadcast_ports"] || []
+    end
+
+    # Immediately writes the configuration of service defined by package to the
+    # service definition file. Service must be defined by package, this function
+    # doesn't work for hard-coded services (SuSEFirewallServices).
+    # Function throws an exception {Yast::SuSEFirewalServiceNotFound}
+    # if service is not known (undefined) or it is not a service
+    # defined by package.
+    #
+    # @param [String] service ID (e.g., "service:ssh")
+    # @param [Hash<String, Array<String>>] store_definition of full service definition
+    # @return [Boolean] if successful (nil in case of developer's mistake)
+    #
+    # @see #IsKnownService
+    # @see #ServiceDefinedByPackage
+    #
+    # @example
+    #   SetNeededPortsAndProtocols (
+    #           "service:something",
+    #           {
+    #                   "tcp_ports"      => [ "22", "ftp-data", "400:420" ],
+    #                   "udp_ports"      => [ ],
+    #                   "rpc_ports"      => [ "portmap", "ypbind" ],
+    #                   "ip_protocols"   => [ "esp" ],
+    #                   "broadcast_ports"=> [ ],
+    #           }
+    #   )
+    def SetNeededPortsAndProtocols(service, store_definition)
+      if !IsKnownService(service)
+        log.error "Service #{service} is unknown"
+        raise(
+          SuSEFirewalServiceNotFound,
+          format(_("Service with name '%{service_name}' does not exist"), service_name: service)
+        )
+      end
+
+      # create the filename from service name
+      filename = GetFilenameFromServiceDefinedByPackage(service)
+      if filename.nil? || filename == ""
+        log.error "Can't operate with filename '#{filename}' created from '#{service}'"
+        return false
+      end
+
+      # full path to the filename
+      filefullpath = SERVICES_DIR + filename
+
+      if !FileUtils.Exists(filefullpath)
+        log.error "File '#{filefullpath}' doesn't exist"
+        return false
+      end
+
+      # Registering sysconfig agent for that file
+      if !SCR.RegisterAgent(
+        path(".firewall_service_definition"),
+        term(:ag_ini, term(:SysConfigFile, filefullpath))
+      )
+        log.error "Cannot register agent for #{filefullpath}"
+        return false
+      end
+
+      ks_features_backward = Builtins.mapmap(@known_services_features) do |sysconfig_id, ycp_id|
+        { ycp_id => sysconfig_id }
+      end
+
+      write_ok = true
+
+      # we can have this service already in memory
+      new_store_definition = deep_copy(store_definition)
+
+      Builtins.foreach(store_definition) do |ycp_id, one_def|
+        # Skipping read-only features
+        next if READ_ONLY_SERVICE_FEATURES.include? ycp_id
+
+        sysconfig_id = Ops.get(ks_features_backward, ycp_id)
+        if sysconfig_id.nil?
+          log.error "Unknown key '#{ycp_id}'"
+          write_ok = false
+          next
+        end
+        one_def = Builtins.filter(one_def) do |one_def_item|
+          !one_def_item.nil? && one_def_item != "" &&
+            !Builtins.regexpmatch(one_def_item, "^ *$")
+        end
+        service_entry_path = Path.new(".firewall_service_definition.#{sysconfig_id}")
+        service_entry_value = one_def.join(" ")
+        if !SCR.Write(service_entry_path, service_entry_value)
+          log.error "Cannot write #{service_entry_value} to #{service_entry_path}",
+            write_ok = false
+          next
+        end
+        # new definition of the service
+        Ops.set(new_store_definition, ycp_id, one_def)
+      end
+
+      # flush the cache to the disk
+      if write_ok
+        if !SCR.Write(path(".firewall_service_definition"), nil)
+          log.error "Cannot write to disk!"
+          write_ok = false
+        else
+          # not only store to disk but also to the memory
+          @services[service] = new_store_definition
+          SetModified()
+        end
+      end
+
+      # Unregistering sysconfig agent for that file
+      SCR.UnregisterAgent(path(".firewall_service_definition"))
+
+      log.info "Call SetNeededPortsAndProtocols(#{service}, ...) result is #{write_ok}"
+      write_ok
+    end
+
+    # Function returns list of possibly conflicting services.
+    # Conflicting services are for instance nis-client and nis-server.
+    # @deprecated we currently don't have such services - services are defined by packages.
+    #
+    # @return  [Array<String>] of conflicting services
+    def GetPossiblyConflictServices
+      []
+    end
+
+    publish variable: :OLD_SERVICES, type: "map <string, map <string, any>>"
+    publish function: :ServiceDefinedByPackage, type: "boolean (string)"
+    publish function: :GetFilenameFromServiceDefinedByPackage, type: "string (string)"
+    publish function: :ReadServicesDefinedByRPMPackages, type: "boolean ()"
+    publish function: :IsKnownService, type: "boolean (string)"
+    publish function: :GetSupportedServices, type: "map <string, string> ()"
+    publish function: :GetListOfServicesAddedByPackage, type: "list <string> ()"
+    publish function: :GetNeededTCPPorts, type: "list <string> (string)"
+    publish function: :GetNeededUDPPorts, type: "list <string> (string)"
+    publish function: :GetNeededRPCPorts, type: "list <string> (string)"
+    publish function: :GetNeededIPProtocols, type: "list <string> (string)"
+    publish function: :GetDescription, type: "string (string)"
+    publish function: :SetModified, type: "void ()"
+    publish function: :ResetModified, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
+    publish function: :GetNeededBroadcastPorts, type: "list <string> (string)"
+    publish function: :GetNeededPortsAndProtocols, type: "map <string, list <string>> (string)"
+    publish function: :SetNeededPortsAndProtocols, type: "boolean (string, map <string, list <string>>)"
+    publish function: :GetPossiblyConflictServices, type: "list <string> ()"
+  end
+end

--- a/library/network/src/lib/network/susefirewalld.rb
+++ b/library/network/src/lib/network/susefirewalld.rb
@@ -1,0 +1,1367 @@
+# ***************************************************************************
+#
+# Copyright (c) 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+#
+# Package: SuSEFirewall configuration
+# Summary: Interface manipulation of /etc/sysconfig/SuSEFirewall
+# Authors: Lukas Ocilka <locilka@suse.cz
+#
+# $Id$
+#
+# Module for handling SuSEfirewall2
+require "yast"
+require "y2firewall/firewalld/api"
+require "network/susefirewall"
+
+module Yast
+  # ----------------------------------------------------------------------------
+  # SuSEFirewalld Class. Trying to provide relevent pieces of SF2 functionality via
+  # firewalld.
+  class SuSEFirewalldClass < SuSEFirewallClass
+    require "set"
+    attr_reader :special_all_interface_zone
+
+    # Valid attributes for firewalld zones
+    # :interfaces = [Array<String>]
+    # :masquerade = Boolean
+    # :modified   = [Set<Symbols>]
+    # :ports      = [Array<String>]
+    # :protocols  = [Array<String>]
+    # :services   = [Array<String>]
+    ZONE_ATTRIBUTES = [:interfaces, :masquerade, :modified, :ports, :protocols, :services].freeze
+    # <enable,start>_firewall are "inherited" from SF2 so we can't use symbols
+    # there without having to change all the SF2 callers.
+    KEY_SETTINGS = ["enable_firewall", "logging", "routing", "start_firewall"].freeze
+
+    EMPTY_ZONE = {
+      interfaces: [],
+      masquerade: false,
+      modified:   Set.new,
+      ports:      [],
+      protocols:  [],
+      services:   []
+    }.freeze
+
+    # We need that for the tests. Nothing else should access the API
+    # directly
+    def api
+      @fwd_api
+    end
+
+    def initialize
+      textdomain "base"
+
+      # firewalld API interface.
+      @fwd_api = Y2Firewall::Firewalld::Api.new
+      # firewalld service
+      @firewall_service = "firewalld"
+      # firewalld package
+      @FIREWALL_PACKAGE = "firewalld"
+      # flag to indicate that FirewallD configuration has been read
+      @configuration_has_been_read = false
+      # firewall settings map
+      @SETTINGS = {}
+      # list of known firewall zones
+      @known_firewall_zones = ["block", "dmz", "drop", "external", "home",
+                               "internal", "public", "trusted", "work"]
+      # map defines zone name for all known firewall zones
+      @zone_names = {
+        # TRANSLATORS: Firewall zone name - used in combo box or dialog title
+        "block"    => _(
+          "Block Zone"
+        ),
+        "dmz"      => _(
+          "Demilitarized Zone"
+        ),
+        "drop"     => _(
+          "Drop Zone"
+        ),
+        "external" => _(
+          "External Zone"
+        ),
+        "home"     => _(
+          "Home Zone"
+        ),
+        "internal" => _(
+          "Internal Zone"
+        ),
+        "public"   => _(
+          "Public Zone"
+        ),
+        "trusted"  => _(
+          "Trusted Zone"
+        ),
+        "work"     => _(
+          "Work Zone"
+        )
+      }
+
+      # Zone which works with the special_all_interface_string string. In our case,
+      # we don't want to deal with this just yet. FIXME
+      @special_all_interface_zone = ""
+
+      # Initialize the @SETTINGS hash
+      KEY_SETTINGS.each { |x| @SETTINGS[x] = nil }
+      GetKnownFirewallZones().each { |zone| @SETTINGS[zone] = deep_copy(EMPTY_ZONE) }
+
+      # Are needed packages installed?
+      @needed_packages_installed = nil
+
+      # bnc #388773
+      # By default needed packages are just checked, not installed
+      @check_and_install_package = false
+
+      # internal zone identification - useful for protect-from-internal
+      @int_zone_shortname = "internal"
+
+      # list of protocols supported in firewall, use only upper-cases
+      @supported_protocols = ["TCP", "UDP", "IP"]
+    end
+
+    # Function which attempts to convert a sf2_service name to a firewalld
+    # equivalent.
+    def sf2_to_firewalld_service(service)
+      # First, let's strip off 'service:' from service name if present.
+      tmp_service = if service.include?("service:")
+        service.partition(":")[2]
+      else
+        service
+      end
+
+      sf2_to_firewalld_map = {
+        # netbios is covered in the samba service file
+        "netbios-server"    => ["samba"],
+        "nfs-client"        => ["nfs"],
+        "nfs-kernel-server" => ["mountd", "nfs", "rpc-bind"],
+        "samba-server"      => ["samba"],
+        "sshd"              => ["ssh"]
+      }
+
+      if sf2_to_firewalld_map.key?(tmp_service)
+        sf2_to_firewalld_map[tmp_service]
+      else
+        [tmp_service]
+      end
+    end
+
+    # Function for getting exported SuSEFirewall configuration
+    #
+    # @return  [Hash{String => Object}] with configuration
+    def Export
+      # FIXME: Temporal export until a new schema is defined for firewalld
+      @SETTINGS.select { |k, v| KEY_SETTINGS.include?(k) && !v.nil? }
+    end
+
+    # Function for setting SuSEFirewall configuration from input
+    #
+    # @param [Hash<String, Object>] import_settings with configuration
+    def Import(import_settings)
+      Read()
+      import_settings = deep_copy(import_settings || {})
+      # Sanitize it
+      import_settings.keys.each do |k|
+        if !GetKnownFirewallZones().include?(k) && !KEY_SETTINGS.include?(k)
+          Builtins.y2warning("Removing invalid key: %1 from imported settings", k)
+          import_settings.delete(k)
+        elsif import_settings[k].is_a?(Hash)
+          import_settings[k].keys.each do |v|
+            if !ZONE_ATTRIBUTES.include?(v)
+              Builtins.y2warning("Removing invalid value: %1 from key %2", v, k)
+              import_settings[k].delete(v)
+            end
+          end
+        end
+      end
+
+      # Ruby's merge will probably not work since we have nested hashes
+      @SETTINGS.keys.each do |key|
+        next unless import_settings.include?(key)
+
+        if import_settings[key].class == Hash
+          # Merge them
+          @SETTINGS[key].merge!(import_settings[key])
+        else
+          @SETTINGS[key] = import_settings[key]
+        end
+      end
+
+      # Merge missing attributes
+      @SETTINGS.keys.each do |key|
+        next unless GetKnownFirewallZones().include?(key)
+
+        # is this a zone?
+        @SETTINGS[key] = EMPTY_ZONE.merge(@SETTINGS[key])
+        # Everything may have been modified
+        @SETTINGS[key][:modified] = [:interfaces, :masquerade, :ports, :protocols, :services]
+      end
+
+      # Tests mock the read method so read the NetworkInterface list again
+      NetworkInterfaces.Read if !@configuration_has_been_read
+
+      SetModified()
+
+      nil
+    end
+
+    def sf2_to_firewalld_zone(zone)
+      sf2_to_firewalld_map = {
+        "INT" => "trusted",
+        "EXT" => "external",
+        "DMZ" => "dmz"
+      }
+
+      sf2_to_firewalld_map[zone] || zone
+    end
+
+    def Read
+      # Do not read it again and again
+      # to avoid overwritting live configuration.
+      if @configuration_has_been_read
+        Builtins.y2milestone(
+          "FirewallD configuration has been read already."
+        )
+        return true
+      end
+
+      ReadCurrentConfiguration()
+
+      Builtins.y2milestone(
+        "Firewall configuration has been read: %1.",
+        @SETTINGS
+      )
+      # Always call NI::Read, bnc #396646
+      NetworkInterfaces.Read
+
+      # to read configuration only once
+      @configuration_has_been_read = true
+    end
+
+    def read_zones
+      # Get all the information from zones and load them to @SETTINGS["zones"]
+      # The following may seem somewhat complicated or fragile but it is more
+      # efficient to only invoke a single firewall-cmd command instead of
+      # iterating over the zones and then using all the different
+      # firewall-cmd commands to get service, port, masquerade etc
+      # information from them.
+      all_zone_info = @fwd_api.list_all_zones
+      # Drop empty lines
+      all_zone_info.reject!(&:empty?)
+      # And now build the hash
+      zone = nil
+      all_zone_info.each do |e|
+        # is it a zone?
+        z = e.split("\s")[0]
+        if GetKnownFirewallZones().include?(z)
+          zone = z
+          next
+        end
+        if ZONE_ATTRIBUTES.any? { |w| e.include?(w.to_s) }
+          attrs = e.split(":\s")
+          attr = attrs[0].lstrip.to_sym
+          # do not bother if empty
+          next if attrs[1].nil?
+
+          vals = attrs[1].split("\s")
+          # Fix up for masquerade
+          if attr == :masquerade
+            set_to_zone_attr(zone, attr, ((vals == "no") ? false : true))
+          else
+            vals.each { |x| add_to_zone_attr(zone, attr, x) }
+          end
+        end
+      end
+    end
+
+    def ReadCurrentConfiguration
+      if SuSEFirewallIsInstalled()
+        read_zones
+        @SETTINGS["logging"] = @fwd_api.log_denied_packets
+      end
+
+      @SETTINGS["enable_firewall"] = IsEnabled()
+      @SETTINGS["start_firewall"] = IsStarted()
+
+      true
+    end
+
+    def WriteConfiguration
+      # just disabled
+      return true if !SuSEFirewallIsInstalled()
+
+      return false if !GetModified()
+
+      Builtins.y2milestone(
+        "Firewall configuration has been changed. Writing: %1.",
+        @SETTINGS
+      )
+      # FIXME: Need to improve that to not re-write everything
+      begin
+        # Set logging
+        if !@SETTINGS["logging"].nil?
+          @fwd_api.log_denied_packets(@SETTINGS["logging"]) if !@fwd_api.log_denied_packets?(@SETTINGS["logging"])
+        end
+        # Configure the zones
+        GetKnownFirewallZones().each do |zone|
+          if zone_attr_modified?(zone)
+            Builtins.y2milestone("zone=#{zone} hasn't been modified. Skipping...")
+            next
+          end
+
+          write_zone_masquerade(zone)
+          write_zone_interfaces(zone)
+          write_zone_services(zone)
+          write_zone_ports(zone)
+          write_zone_protocols(zone)
+
+          # Configuration is now live. Move on
+          ResetModified()
+        end
+      rescue FirewallCMDError
+        Builtins.y2error("firewall-cmd failed")
+        raise
+      end
+
+      # FIXME: perhaps "== true" can be dropped since this should
+      # always be boolean?
+      if !@SETTINGS["enable_firewall"].nil?
+        if @SETTINGS["enable_firewall"] == true
+          Builtins.y2milestone("Enabling firewall services")
+          return false if !EnableServices()
+        else
+          Builtins.y2milestone("Disabling firewall services")
+          return false if !DisableServices()
+        end
+      end
+
+      true
+    end
+
+    # In SF2, it's used to write configuration, but not activate. For firewalld
+    # this is simply here to satisfy callers, like modules/Nfs.rb.
+    # @return true
+    def WriteOnly
+      # This does not check if firewalld is running
+      return false if !WriteConfiguration()
+    end
+
+    # Function which starts/stops firewall. Then firewall is started immediately
+    # when firewall is wanted to be started: SetStartService(boolean). FirewallD
+    # needs to be reloaded instead of doing a full-blown restart to get the new
+    # configuration up and running.
+    #
+    # @return  [Boolean] if successful
+    def ActivateConfiguration
+      # starting firewall during second stage can cause deadlock in systemd - bnc#798620
+      # Moreover, it is not needed. Firewall gets started via dependency on multi-user.target
+      # when second stage is over.
+      if Mode.installation
+        Builtins.y2milestone("Do not touch firewall services during installation")
+
+        return true
+      end
+
+      if GetStartService()
+        # Not started - start it
+        if !IsStarted()
+          Builtins.y2milestone("Starting firewall services")
+          return StartServices()
+          # Started - restart it
+        else
+          Builtins.y2milestone("Firewall has been started already")
+          # Make it real
+          @fwd_api.reload
+          return true
+        end
+      # Firewall should stop after Write()
+      # started - stop
+      elsif IsStarted()
+        Builtins.y2milestone("Stopping firewall services")
+        return StopServices()
+        # stopped - skip stopping
+      else
+        Builtins.y2milestone("Firewall has been stopped already")
+        return true
+      end
+    end
+
+    def Write
+      # Make the firewall changes permanent.
+      return false if !WriteConfiguration()
+      return false if !ActivateConfiguration()
+
+      true
+    end
+
+    # Function returns if the interface is in zone.
+    #
+    # @param [String] interface
+    # @param [String] zone firewall zone
+    # @return  [Boolean] is in zone
+    #
+    # @example IsInterfaceInZone ("eth-id-01:11:DA:9C:8A:2F", "INT") -> false
+    def IsInterfaceInZone(interface, zone)
+      interfaces = get_zone_attr(zone, :interfaces)
+      interfaces.include?(interface)
+    end
+
+    # Function returns the firewall zone of interface, nil if no zone includes
+    # the interface. Firewalld does not allow an interface to be in more than
+    # one zone, so no error detection for this case is needed.
+    #
+    # @param [String] interface
+    # @return string zone, or nil
+    def GetZoneOfInterface(interface)
+      GetKnownFirewallZones().each do |zone|
+        return zone if IsInterfaceInZone(interface, zone)
+      end
+
+      nil
+    end
+
+    # Function returns list of zones of requested interfaces.
+    # Special string 'any' in 'EXT' zone is supported.
+    #
+    # @param [Array<String>] interfaces
+    # @return  [Array<String>] firewall zones
+    #
+    # @example
+    #   GetZonesOfInterfaces (["eth1","eth4"]) -> ["EXT"]
+    def GetZonesOfInterfacesWithAnyFeatureSupported(interfaces)
+      interfaces = deep_copy(interfaces)
+      zones = []
+      interfaces.each { |interface| zones << GetZoneOfInterface(interface) }
+      zones
+    end
+
+    # Function returns whether the feature 'any' network interface is supported.
+    # This is a SF2 specific construct. For firewalld, we simply return false.
+    # We may decide to change this in the future.
+    #
+    # @return boolean false
+    def IsAnyNetworkInterfaceSupported
+      false
+    end
+
+    # Function returns true if service is supported (allowed) in zone. Service must be defined
+    # already be defined.
+    #
+    # @see Module SuSEFirewallServices
+    # @param [String] service id
+    # @param [String] zone
+    # @return  [Boolean] if supported
+    #
+    # @example
+    #   # All ports defined by dns-server service in SuSEFirewallServices module
+    #   # are enabled in the respective zone
+    #   IsServiceSupportedInZone ("dns-server", "external") -> true
+    def IsServiceSupportedInZone(service, zone)
+      return nil if !IsKnownZone(zone)
+
+      # We may have more than one FirewallD service per SF2 service
+      sf2_to_firewalld_service(service).each do |s|
+        return false if !in_zone_attr?(zone, :services, s)
+      end
+
+      true
+    end
+
+    # Function returns if firewall is protected from internal zone. For
+    # firewalld, we just return true since the internal zone is treated
+    # like any other zone.
+    #
+    # @return  [Boolean] if protected from internal
+    def GetProtectFromInternalZone
+      true
+    end
+
+    # Function returns list of known interfaces in requested zone.
+    # Special strings like 'any' or 'auto' and unknown interfaces are removed from list.
+    #
+    # @param [String] zone
+    # @return  [Array<String>] of interfaces
+    # @example GetInterfacesInZone ("external") -> ["eth4", "eth5"]
+    def GetInterfacesInZone(zone)
+      return [] unless IsKnownZone(zone)
+
+      known_interfaces_now = GetListOfKnownInterfaces()
+      get_zone_attr(zone, :interfaces).find_all { |i| known_interfaces_now.include?(i) }
+    end
+
+    # Function removes interface from defined zone.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    # @example RemoveInterfaceFromZone ("modem0", "EXT")
+    def RemoveInterfaceFromZone(interface, zone)
+      return nil if !IsKnownZone(zone)
+
+      SetModified()
+
+      Builtins.y2milestone(
+        "Removing interface '%1' from '%2' zone.",
+        interface,
+        zone
+      )
+
+      del_from_zone_attr(zone, :interfaces, interface)
+      add_zone_modified(zone, :interfaces)
+
+      nil
+    end
+
+    # Functions adds interface into defined zone.
+    # All appearances of interface in other zones are removed.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    # @example AddInterfaceIntoZone ("eth5", "DMZ")
+    def AddInterfaceIntoZone(interface, zone)
+      return nil if !IsKnownZone(zone)
+
+      SetModified()
+
+      current_zone = GetZoneOfInterface(interface)
+
+      # removing all appearances of interface in zones, excepting current_zone==new_zone
+      while !current_zone.nil? && current_zone != zone
+        # interface is in any zone already, removing it at first
+        RemoveInterfaceFromZone(interface, current_zone) if current_zone != zone
+        current_zone = GetZoneOfInterface(interface)
+      end
+
+      Builtins.y2milestone(
+        "Adding interface '%1' into '%2' zone.",
+        interface,
+        zone
+      )
+
+      add_to_zone_attr(zone, :interfaces, interface)
+      add_zone_modified(zone, :interfaces)
+
+      nil
+    end
+
+    # Function returns list of known interfaces in requested zone.
+    # In the firewalld case, we don't support the special 'any' string.
+    # Thus, interfaces not in a zone will not be included.
+    #
+    # @param [String] zone
+    # @return  [Array<String>] of interfaces
+    def GetInterfacesInZoneSupportingAnyFeature(zone)
+      GetInterfacesInZone(zone)
+    end
+
+    # Function returns map of supported services all network interfaces.
+    #
+    # @param services [Array<String>] list of services
+    # @return [Hash<String, Hash<String, Boolean>>] Returns in format
+    #   `{service => { interface => supported_status }}`
+    #
+    # @example
+    #   GetServicesInZones (["service:irc-server"]) -> $["service:irc-server":$["eth1":true]]
+    #   # No such service "something"
+    #   GetServicesInZones (["something"])) -> $["something":$["eth1":nil]]
+    #   GetServicesInZones (["samba-server"]) -> $["samba-server":$["eth1":false]]
+    def GetServicesInZones(services)
+      services = deep_copy(services)
+      tmp_services = deep_copy(services)
+      services = []
+      Builtins.foreach(tmp_services) do |service|
+        sf2_to_firewalld_service(service).each do |s|
+          s = service.include?("service:") ? "service:" + s : s
+          services << s
+        end
+      end
+      super(services)
+    end
+
+    # Function sets status for several services in several firewall zones.
+    #
+    # @param services_ids [Array<String>] service ids
+    # @param firewall_zones [Array<String>] firewall zones (EXT|INT|DMZ...)
+    # @param new_status [true, false] new status of services
+    # @return  nil
+    #
+    # @example
+    #   SetServicesForZones (["samba-server", "service:irc-server"], ["DMZ", "EXT"], false);
+    #   SetServicesForZones (["samba-server", "service:irc-server"], ["EXT", "DMZ"], true);
+    #
+    # @see #GetServicesInZones()
+    # @see #GetServices()
+    def SetServicesForZones(services_ids, firewall_zones, new_status)
+      Yast.import "SuSEFirewallServices"
+
+      services_ids = deep_copy(services_ids)
+      zones = deep_copy(firewall_zones)
+
+      tmp_services_ids = deep_copy(services_ids)
+      services_ids = []
+      tmp_services_ids.each do |service|
+        sf2_to_firewalld_service(service).each do |s|
+          services_ids << s
+        end
+      end
+
+      # setting for each service
+      services_ids.each do |service|
+        # Service is not supported by firewalld.
+        # We can only do such error checking if backend is running
+        if IsStarted() && !@fwd_api.service_supported?(service)
+          Builtins.y2error("Undefined service '#{service}'")
+          raise(SuSEFirewalServiceNotFound, "Service with name '#{service}' does not exist")
+        end
+        zones.each do |zone|
+          # Add/remove service to/from zone only if zone is not 'trusted',
+          # 'blocked' or 'drop'. For these zones there is no need to
+          # explicitly add/remove
+          # services as all connections are by default accepted.
+          next if ["block", "drop", "trusted"].include?(zone)
+
+          # zone must be known one
+          if !IsKnownZone(zone)
+            Builtins.y2error(
+              "Zone '%1' is unknown firewall zone, skipping...",
+              zone
+            )
+            next
+          end
+
+          if new_status == true # enable
+            Builtins.y2milestone(
+              "Adding '%1' into '%2' zone",
+              service, zone
+            )
+            # Only add it if it is not there
+            if !in_zone_attr?(zone, :services, service)
+              add_to_zone_attr(zone, :services, service)
+              SetModified()
+              add_zone_modified(zone, :services)
+            end
+          else # disable
+            Builtins.y2milestone(
+              "Removing '%1' from '%2' zone",
+              service, zone
+            )
+            del_from_zone_attr(zone, :services, service)
+            SetModified()
+            add_zone_modified(zone, :services)
+          end
+        end
+      end
+
+      nil
+    end
+
+    # Function returns actual state of Masquerading support.
+    # In FirewallD, masquerade is enabled per-zone so this
+    # function treats the 'internal' zone as the default
+    # zone if no zone is given as parameter.
+    #
+    # @param    zone [String] zone to get masqurade status from (default: internal)
+    # @return  [Boolean] if supported
+    def GetMasquerade(zone = "internal")
+      if !IsKnownZone(zone)
+        Builtins.y2error("zone %1 is not valid", zone)
+        return nil
+      end
+      get_zone_attr(zone, :masquerade)
+    end
+
+    # Function sets Masquerade support.
+    #
+    # @param  enable [Boolean] Enable or Disable masquerade
+    # @param  zone [String] Zone to enable masquerade on.
+    # @return nil
+    def SetMasquerade(enable, zone = "internal")
+      if !IsKnownZone(zone)
+        Builtins.y2error("zone %1 is not valid", zone)
+        return nil
+      end
+      SetModified()
+      set_to_zone_attr(zone, :masquerade, enable)
+      add_zone_modified(zone, :masquerade)
+
+      nil
+    end
+
+    # Function returns list of special strings like 'any' or 'auto' and unknown interfaces.
+    # This function is only valid for SF2. For firewalld, we return an empty array.
+    #
+    # @param [String] zone
+    # @return  [Array<String>] special strings or unknown interfaces
+    #
+    # @example
+    #   GetSpecialInterfacesInZone("EXT") -> ["any", "unknown-1", "wrong-3"]
+    def GetSpecialInterfacesInZone(zone)
+      known_interfaces_now = GetListOfKnownInterfaces()
+      get_zone_attr(zone, :interfaces).reject { |i| known_interfaces_now.include?(i) }
+    end
+
+    # Function removes special string from defined zone. For firewalld we
+    # return nil.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    def RemoveSpecialInterfaceFromZone(interface, zone)
+      RemoveInterfaceFromZone(interface, zone)
+    end
+
+    # Functions adds special string into defined zone. For firewalld we
+    # return nil.
+    #
+    # @param [String] interface
+    # @param [String] zone
+    def AddSpecialInterfaceIntoZone(interface, zone)
+      AddInterfaceIntoZone(interface, zone)
+    end
+
+    # Function returns actual state of logging.
+    # @ note There is no 1-1 matching between SF2 and FirewallD when
+    # @ note it comes to logging. We need to be backwards compatible and
+    # @ note so we use the following conventions:
+    # @ note ACCEPT -> FirewallD can't log accepted packets so we always return
+    # @ note false.
+    # @ note DROP -> We map "all" to "ALL", "broadcast, multicast or unicast"
+    # @ note to "CRIT" and "off" to "NONE".
+    # @ note As a result of which, this method has little value in FirewallD
+    # @param [String] rule definition 'ACCEPT' or 'DROP'
+    # @return  [String] 'ALL' or 'NONE'
+    #
+    def GetLoggingSettings(rule)
+      return false if rule == "ACCEPT"
+
+      if rule == "DROP"
+        drop_rule = @SETTINGS["logging"]
+        case drop_rule
+        when "off"
+          return "NONE"
+        when "broadcast", "multicast", "unicast"
+          return "CRIT"
+        when "all"
+          return "ALL"
+        end
+      else
+        Builtins.y2error("Possible rules are only 'ACCEPT' or 'DROP'")
+      end
+    end
+
+    # Function sets state of logging.
+    # @note Similar restrictions to GetLoggingSettings apply
+    # @param [String] rule definition 'ACCEPT' or 'DROP'
+    # @param [String] state new logging state 'ALL', 'CRIT', or 'NONE'
+    def SetLoggingSettings(rule, state)
+      return nil if rule == "ACCEPT"
+
+      if rule == "DROP"
+        drop_rule = state.downcase
+        case drop_rule
+        when "none"
+          @SETTINGS["logging"] = "off"
+        when "crit"
+          # Choosing unicast since it's likely to be the most common case
+          @SETTINGS["logging"] = "unicast"
+        when "all"
+          @SETTINGS["logging"] = "all"
+        end
+      else
+        Builtins.y2error("Possible rules are only 'ACCEPT' or 'DROP'")
+      end
+
+      SetModified()
+
+      nil
+    end
+
+    # Function returns yes/no - ingoring broadcast for zone
+    #
+    # @param _zone [String] unused
+    # @return [String] "yes" or "no"
+    #
+    # @example
+    #   # Does not log ignored broadcast packets
+    #   GetIgnoreLoggingBroadcast () -> "yes"
+    def GetIgnoreLoggingBroadcast(_zone)
+      return "no" if @SETTINGS["logging"] == "broadcast"
+
+      "yes"
+    end
+
+    # Function sets yes/no - ingoring broadcast for zone
+    # @note Since Firewalld only accepts a single packet type to log,
+    # @note we simply disable logging if broadcast logging is not desirable.
+    # @note If you used SetIgnoreLoggingBroadcast is your code, make sure you
+    # @note use SetLoggingSettings afterwards to enable the type of logging you
+    # @note want.
+    #
+    # @param _zone [String] unused
+    # @param bcast [String] ignore 'yes' or 'no'
+    #
+    # @example
+    #   # Do not log broadcast packetes from DMZ
+    #   SetIgnoreLoggingBroadcast ("DMZ", "yes")
+    def SetIgnoreLoggingBroadcast(_zone, bcast)
+      bcast = bcast.casecmp("no").zero? ? "broadcast" : "off"
+
+      return nil if @SETTINGS["logging"] == bcast
+
+      SetModified()
+
+      @SETTINGS["logging"] = bcast.downcase
+
+      nil
+    end
+
+    # Function returns list of allowed ports for zone and protocol
+    #
+    # @param [String] zone
+    # @param [String] protocol
+    # @return  [Array<String>] of allowed ports
+    def GetAllowedServicesForZoneProto(zone, protocol)
+      Yast.import "SuSEFirewallServices"
+
+      result = []
+      protocol = protocol.downcase
+
+      get_zone_attr(zone, :ports).each do |p|
+        port_proto = p.split("/")
+        result << port_proto[0] if port_proto[1] == protocol
+      end
+      result = get_zone_attr(zone, :protocols) if protocol == "ip"
+      # We return the name of service instead of its ports
+      get_zone_attr(zone, :services).each do |s| # to be SF2 compatible.
+        if protocol == "tcp"
+          result << s if !SuSEFirewallServices.GetNeededTCPPorts(s).empty?
+        elsif protocol == "udp"
+          result << s if !SuSEFirewallServices.GetNeededUDPPorts(s).empty?
+        end
+      end
+      # FIXME: Is this really needed?
+      result.flatten!
+
+      deep_copy(result)
+    end
+
+    # This powerful function returns list of services/ports which are
+    # not assigned to any fully-supported known-services.
+    # This function doesn't check for services defined by packages.
+    # They are listed by a different way.
+    #
+    # @return  [Array<String>] of additional (unassigned) services
+    #
+    # @example
+    #   GetAdditionalServices("TCP", "EXT") -> ["53", "128"]
+    def GetAdditionalServices(protocol, zone)
+      protocol = protocol.upcase
+
+      if !IsSupportedProtocol(protocol.upcase)
+        Builtins.y2error("Unknown protocol '%1'", protocol)
+        return nil
+      end
+      if !IsKnownZone(zone)
+        Builtins.y2error("Unknown zone '%1'", zone)
+        return nil
+      end
+
+      # all ports or services allowed in zone for protocol
+      all_allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+
+      # And now drop the known ones
+      all_allowed_services -= SuSEFirewallServices.GetSupportedServices().keys
+
+      # well, actually it returns list of services not-assigned to any well-known service
+      deep_copy(all_allowed_services)
+    end
+
+    # Function sets list of services as allowed ports for zone and protocol
+    #
+    # @param [Array<string>] allowed_services list of allowed ports/services
+    # @param [String] zone
+    # @param [String] protocol
+    def SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+      allowed_services = deep_copy(allowed_services)
+
+      SetModified()
+
+      protocol = protocol.downcase
+
+      # allowed_services can contain both services and port definitions so the
+      # first step is to split them up
+      services, ports = sanitize_services_and_ports(allowed_services, protocol)
+
+      # First we drop existing services and ports.
+      delete_ports_with_protocol_from_zone(protocol, zone)
+      delete_services_with_protocol_from_zone(protocol, zone)
+
+      # And now add the new ports and services
+      set_ports_with_protocol_to_zone(ports, protocol, zone)
+      set_services_to_zone(services, zone)
+
+      nil
+    end
+
+    # Local function removes ports and their aliases (if check_for_aliases is true), for
+    # requested protocol and zone.
+    #
+    # @param remove_ports [Array<String>] ports to be removed
+    # @param protocol [String] Protocol
+    # @param zone [String] Zone
+    # @param _check_for_aliases [Boolean] unused
+    def RemoveAllowedPortsOrServices(remove_ports, protocol, zone, _check_for_aliases)
+      remove_ports = deep_copy(remove_ports)
+      if Ops.less_than(Builtins.size(remove_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+      Builtins.y2debug("RemoveAdditionalServices: currently allowed services for %1_%2 -> %3",
+        zone, protocol, allowed_services)
+      # and this is what we keep
+      allowed_services -= remove_ports
+      Builtins.y2debug("RemoveAdditionalServices: new allowed services for %1_%2 -> %3",
+        zone, protocol, allowed_services)
+      SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+    end
+
+    def ArePortsOrServicesAllowed(needed_ports, protocol, zone, _check_for_aliases)
+      super(needed_ports, protocol, zone, false)
+    end
+
+    # Local function allows ports for requested protocol and zone.
+    #
+    # @param [Array<String>] add_ports ports to be added
+    # @param [String] protocol
+    # @param [String] zone
+    def AddAllowedPortsOrServices(add_ports, protocol, zone)
+      add_ports = deep_copy(add_ports)
+      if Ops.less_than(Builtins.size(add_ports), 1)
+        Builtins.y2warning(
+          "Undefined list of %1 services/ports for service",
+          protocol
+        )
+        return
+      end
+
+      SetModified()
+
+      # all allowed ports
+      allowed_services = GetAllowedServicesForZoneProto(zone, protocol)
+
+      allowed_services = Convert.convert(
+        Builtins.union(allowed_services, add_ports),
+        from: "list",
+        to:   "list <string>"
+      )
+
+      SetAllowedServicesForZoneProto(allowed_services, zone, protocol)
+
+      nil
+    end
+
+    # Firewall Expert Rulezz
+
+    # Returns list of rules describing protocols and ports that are allowed
+    # to be accessed from listed hosts. All is returned as a single string.
+    # Zone needs to be defined.
+    #
+    # @param [String] zone
+    # @return [String] with rules
+    def GetAcceptExpertRules(zone)
+      zone = Builtins.toupper(zone)
+
+      # Check for zone
+      if !Builtins.contains(GetKnownFirewallZones(), zone)
+        Builtins.y2error("Unknown firewall zone: %1", zone)
+        return nil
+      end
+
+      Ops.get_string(@SETTINGS, Ops.add("FW_SERVICES_ACCEPT_", zone), "")
+    end
+
+    # Sets expert allow rules for zone.
+    #
+    # @param [String] zone
+    # @param [String] expert_rules whitespace-separated expert_rules
+    # @return [Boolean] if successful
+    def SetAcceptExpertRules(zone, expert_rules)
+      zone = Builtins.toupper(zone)
+
+      # Check for zone
+      if !Builtins.contains(GetKnownFirewallZones(), zone)
+        Builtins.y2error("Unknown firewall zone: %1", zone)
+        return false
+      end
+
+      Ops.set(@SETTINGS, Ops.add("FW_SERVICES_ACCEPT_", zone), expert_rules)
+      SetModified()
+
+      true
+    end
+
+    # FIXME: this method currently does nothing at all and has been added just
+    # for having the same API than SuSEFirewall2 but it is deprecated
+    def full_init_on_boot(new_state)
+      new_state
+    end
+
+  private
+
+    def set_zone_modified(zone, zone_params)
+      # Do nothing if the parameters are not valid
+      return nil if zone_params.nil? || \
+        !@known_firewall_zones.include?(zone) || \
+        !zone_params.is_a?(Array)
+
+      @SETTINGS[zone][:modified] = zone_params.to_set
+    end
+
+    def add_zone_modified(zone, zone_param)
+      # Do nothing if the parameters are not valid
+      return nil if zone_param.nil? || \
+        !@known_firewall_zones.include?(zone)
+
+      @SETTINGS[zone][:modified] << zone_param
+    end
+
+    def del_zone_modified(zone, zone_param)
+      # Do nothing if the parameters are not valid
+      return nil if zone_param.nil? || \
+        !@known_firewall_zones.include?(zone)
+
+      @SETTINGS[zone][:modified].delete(zone_param)
+    end
+
+    def zone_attr_modified?(zone, zone_param = nil)
+      return !!@SETTINGS[zone].empty? if zone_param.nil?
+      # Do nothing if the parameters are not valid
+      return nil if !@known_firewall_zones.include?(zone)
+
+      @SETTINGS[zone][:modified].include?(zone_param)
+    end
+
+    def add_to_zone_attr(zone, attr, val)
+      return nil if !ZONE_ATTRIBUTES.include?(attr)
+
+      # No sanity checking. callers must be careful
+      @SETTINGS[zone][attr] << val
+    end
+
+    def set_to_zone_attr(zone, attr, val)
+      return nil if !ZONE_ATTRIBUTES.include?(attr)
+
+      # No sanity checking. callers must be careful
+      @SETTINGS[zone][attr] = val
+    end
+
+    def get_zone_attr(zone, attr)
+      @SETTINGS[zone][attr]
+    end
+
+    def del_from_zone_attr(zone, attr, val)
+      return nil if !ZONE_ATTRIBUTES.include?(attr)
+
+      # No sanity checking. callers must be careful
+      @SETTINGS[zone][attr].delete(val)
+    end
+
+    def in_zone_attr?(zone, attr, val)
+      @SETTINGS[zone][attr].include?(val)
+    end
+
+    def write_zone_masquerade(zone)
+      return nil if !zone_attr_modified?(zone, :masquerade)
+
+      if get_zone_attr(zone, :masquerade)
+        @fwd_api.add_masquerade(zone)
+      else
+        @fwd_api.remove_masquerade(zone)
+      end
+
+      del_zone_modified(zone, :masquerade)
+    end
+
+    def write_zone_interfaces(zone)
+      return nil if !zone_attr_modified?(zone, :interfaces)
+
+      # These are the ones which should be enabled
+      good_interfaces = get_zone_attr(zone, :interfaces)
+      # These are the ones which are enabled
+      current_interfaces = @fwd_api.list_interfaces(zone)
+      # And these are the ones which should be dropped
+      to_drop = current_interfaces - good_interfaces
+      to_add = good_interfaces - current_interfaces
+      Builtins.y2debug("Interfaces: drop -> #{to_drop} add -> #{to_add}")
+      to_drop.each { |rmif| @fwd_api.remove_interface(zone, rmif) }
+      to_add.each { |gif| @fwd_api.add_interface(zone, gif) }
+      del_zone_modified(zone, :interfaces)
+    end
+
+    def write_zone_services(zone)
+      return nil if !zone_attr_modified?(zone, :services)
+
+      # These are the services which should be enabled
+      good_services = get_zone_attr(zone, :services)
+      # These are the ones which are enabled
+      current_services = @fwd_api.list_services(zone)
+      # And these are the ones which should be dropped
+      to_drop = current_services - good_services
+      to_add = good_services - current_services
+      Builtins.y2debug("Services: drop -> #{to_drop} add -> #{to_add}")
+      to_drop.each { |rms| @fwd_api.remove_service(zone, rms) }
+      to_add.each { |gs| @fwd_api.add_service(zone, gs) }
+      del_zone_modified(zone, :services)
+    end
+
+    def write_zone_ports(zone)
+      return nil if !zone_attr_modified?(zone, :ports)
+
+      # These are the ports which should be enabled
+      good_ports = get_zone_attr(zone, :ports)
+      # These are the ones which are enabled
+      current_ports = @fwd_api.list_ports(zone)
+      # And these are the ones which should be dropped
+      to_drop = current_ports - good_ports
+      to_add = good_ports - current_ports
+      Builtins.y2debug("Ports: drop -> #{to_drop} add -> #{to_add}")
+      to_drop.each { |rmp| @fwd_api.remove_port(zone, rmp) }
+      to_add.each { |gp| @fwd_api.add_port(zone, gp) }
+      del_zone_modified(zone, :ports)
+    end
+
+    def write_zone_protocols(zone)
+      # These are the protocols which should be enabled
+      good_protocols = get_zone_attr(zone, :protocols)
+      # These are the ones which are enabled
+      current_protocols = @fwd_api.list_protocols(zone)
+      # And these are the ones which should be dropped
+      to_drop = current_protocols - good_protocols
+      to_add = good_protocols - current_protocols
+      Builtins.y2debug("Protocols: drop -> #{to_drop} add -> #{to_add}")
+      to_drop.each { |rmp| @fwd_api.remove_protocol(zone, rmp) }
+      to_add.each { |gp| @fwd_api.add_protocol(zone, gp) }
+      del_zone_modified(zone, :protocols)
+    end
+
+    # Sanitize array of intermixed services and ports and return them as
+    # two separate arrays for further processing. Invalid entries will be
+    # discarded.
+    # @param allowed_services [Array<String>] list of services and ports
+    # @param protocol [String] Network Protocol
+    # @return [Array<String>][Array<String>] Array of services and Array of ports to add
+    def sanitize_services_and_ports(allowed_services, protocol)
+      services = []
+      ports = []
+      allowed_services.each do |s|
+        Builtins.y2debug("Examining %1", s)
+        # Is it a service?
+        if SuSEFirewallServices.GetSupportedServices().keys.include?(s)
+          if protocol == "tcp"
+            if !SuSEFirewallServices.GetNeededTCPPorts(s).empty?
+              Builtins.y2debug("Adding service %1", s)
+              services << s
+            end
+          elsif protocol == "udp"
+            if !SuSEFirewallServices.GetNeededUDPPorts(s).empty?
+              Builtins.y2debug("Adding service %1", s)
+              services << s
+            end
+          end
+        # Is it a port?
+        elsif s =~ /\d+((:|-)\d+)?/
+          Builtins.y2debug("Adding port %1", s)
+          ports << s
+        # Is it something else?
+        else
+          Builtins.y2error("Ignoring unknown service: %1", s)
+        end
+      end
+
+      # Return the two arrays
+      [services, ports]
+    end
+
+    # Delete services for given protocol from zone
+    # @param zone [String] Zone
+    # @param protocol [String] Network Protocol
+    # @return nil
+    # @note This does not play well with FirewallD. Services may have TCP and UDP
+    # @note ports and we can't simply remove part of them. So what we do here is
+    # @note to remove the services which have a no other protocol dependecies
+    # @note protocol.
+    # FIXME: take IP and other protocols into consideration
+    def delete_services_with_protocol_from_zone(protocol, zone)
+      get_zone_attr(zone, :services).each do |s|
+        Builtins.y2debug(
+          "Examinining service %2_%1 for removal",
+          protocol, s
+        )
+        if protocol == "udp" &&
+            SuSEFirewallServices.GetNeededTCPPorts(s).empty? &&
+            !SuSEFirewallServices.GetNeededUDPPorts(s).empty?
+          Builtins.y2debug("Removing service %1", s)
+          del_from_zone_attr(zone, :services, s)
+        elsif protocol == "tcp" &&
+            SuSEFirewallServices.GetNeededUDPPorts(s).empty? &&
+            !SuSEFirewallServices.GetNeededTCPPorts(s).empty?
+          del_from_zone_attr(zone, :services, s)
+          Builtins.y2debug("Removing service %1", s)
+        else
+          Builtins.y2debug("Not removing %1 because it has protocol dependencies", s)
+        end
+      end
+      nil
+    end
+
+    # Add services to zone
+    # @param services [Array<String>] list of services to add
+    # @param zone [String] Zone
+    # @return nil
+    def set_services_to_zone(services, zone)
+      return nil if services.empty?
+
+      # Add the new services! We do not assign since that will override
+      # services depending on other protocols!ugh!
+      services.each do |s|
+        next if in_zone_attr?(zone, :services, s)
+
+        Builtins.y2debug("Service %1 will be added to the %2 zone", s, zone)
+        add_to_zone_attr(zone, :services, s)
+        add_zone_modified(zone, :services)
+      end
+    end
+
+    # Delete ports for given protocol from zone
+    # @param protocol [String] Network Protocol
+    # @param zone [String] Zone
+    # @return nil
+    def delete_ports_with_protocol_from_zone(protocol, zone)
+      get_zone_attr(zone, :ports).each do |p|
+        port_proto = p.split("/")
+        del_from_zone_attr(zone, :ports, p) if port_proto[1] == protocol
+        add_zone_modified(zone, :ports)
+      end
+    end
+
+    # Add ports for given protocol to zone
+    # @param ports [Array<String>] list of ports to add
+    # @param zone [String] Zone
+    # @return nil
+    def set_ports_with_protocol_to_zone(ports, protocol, zone)
+      return nil if ports.empty?
+
+      ports.each do |p|
+        # Convert SF2 port range to FirewallD
+        p.sub!(":", "-")
+        port_proto = "#{p}/#{protocol}"
+        next if @SETTINGS[zone][:ports].include?(port_proto)
+
+        # Remove old services and set the new ones.
+        Builtins.y2debug(
+          "Port %1 will be added to the %2 zone",
+          port_proto, zone
+        )
+        add_to_zone_attr(zone, :ports, port_proto)
+        add_zone_modified(zone, :ports)
+      end
+    end
+
+    publish variable: :firewall_service, type: "string", private: true
+    publish variable: :FIREWALL_PACKAGE, type: "const string"
+    publish variable: :SETTINGS, type: "map <string, any>", private: true
+    publish variable: :known_firewall_zones, type: "list <string>", private: true
+    publish variable: :special_all_interface_zone, type: "string"
+    publish variable: :zone_names, type: "map <string, string>", private: true
+    publish variable: :needed_packages_installed, type: "boolean"
+    publish variable: :check_and_install_package, type: "boolean", private: true
+    publish function: :GetStartService, type: "boolean ()"
+    publish function: :SetStartService, type: "void (boolean)"
+    publish function: :GetEnableService, type: "boolean ()"
+    publish function: :SetEnableService, type: "void (boolean)"
+    publish function: :StartServices, type: "boolean ()"
+    publish function: :StopServices, type: "boolean ()"
+    publish function: :EnableServices, type: "boolean ()"
+    publish function: :DisableServices, type: "boolean ()"
+    publish function: :IsEnabled, type: "boolean ()"
+    publish function: :IsStarted, type: "boolean ()"
+    publish function: :GetKnownFirewallZones, type: "list <string> ()"
+    publish function: :Read, type: "boolean ()"
+    publish function: :ActivateConfiguration, type: "boolean ()"
+    publish function: :WriteConfiguration, type: "boolean ()"
+    publish function: :WriteOnly, type: "boolean ()"
+    publish function: :Write, type: "boolean ()"
+    publish function: :Export, type: "map <string, any> ()"
+    publish function: :Import, type: "void (map <string, any>)"
+    publish function: :GetAllKnownInterfaces, type: "list <map <string, string>> ()"
+    publish function: :GetZoneOfInterface, type: "string (string)"
+    publish function: :IsInterfaceInZone, type: "boolean (string, string)"
+    publish function: :GetZonesOfInterfaces, type: "list <string> (list <string>)"
+    publish function: :GetZoneFullName, type: "string (string)"
+    publish function: :IsAnyNetworkInterfaceSupported, type: "boolean ()"
+    publish function: :GetInterfacesInZone, type: "list <string> (string)"
+    publish function: :GetInterfacesInZoneSupportingAnyFeature, type: "list <string> (string)"
+    publish function: :IsServiceSupportedInZone, type: "boolean (string, string)"
+    publish function: :GetServices, type: "map <string, map <string, boolean>> (list <string>)"
+    publish function: :GetListOfKnownInterfaces, type: "list <string> ()"
+    publish function: :GetServicesInZones, type: "map <string, map <string, boolean>> (list <string>)"
+    publish function: :SetAcceptExpertRules, type: "boolean (string, string)"
+    publish function: :IsKnownZone, type: "boolean (string)", private: true
+    publish function: :SetModified, type: "void ()"
+    publish function: :ResetModified, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
+    publish function: :GetZonesOfInterfacesWithAnyFeatureSupported, type: "list <string> (list <string>)"
+    publish function: :SetServices, type: "boolean (list <string>, list <string>, boolean)"
+    publish function: :SetServicesForZones, type: "boolean (list <string>, list <string>, boolean)"
+    publish function: :SuSEFirewallIsInstalled, type: "boolean ()"
+    publish function: :SetInstallPackagesIfMissing, type: "void (boolean)"
+    publish function: :SaveAndRestartService, type: "boolean ()"
+    publish function: :GetProtectFromInternalZone, type: "boolean ()"
+    publish function: :GetMasquerade, type: "boolean (string)"
+    publish function: :SetMasquerade, type: "void (boolean, string)"
+    publish function: :GetSpecialInterfacesInZone, type: "list <string> (string)"
+    publish function: :RemoveSpecialInterfaceFromZone, type: "void (string, string)"
+    publish function: :AddSpecialInterfaceIntoZone, type: "void (string, string)"
+    publish function: :RemoveInterfaceFromZone, type: "void (string, string)"
+    publish function: :AddInterfaceIntoZone, type: "void (string, string)"
+    publish function: :GetLoggingSettings, type: "string (string)"
+    publish function: :SetLoggingSettings, type: "void (string, string)"
+    publish function: :GetIgnoreLoggingBroadcast, type: "string (string)"
+    publish function: :SetIgnoreLoggingBroadcast, type: "void (string, string)"
+    publish variable: :supported_protocols, type: "list <string>", private: true
+    publish function: :IsSupportedProtocol, type: "boolean (string)", private: true
+    publish function: :GetAdditionalServices, type: "list <string> (string, string)"
+    publish function: :GetAllowedServicesForZoneProto, type: "list <string> (string, string)", private: true
+    publish function: :SetAdditionalServices, type: "void (string, string, list <string>)"
+    publish function: :RemoveAllowedPortsOrServices, type: "void (list <string>, string, string, boolean)", private: true
+    publish function: :AddAllowedPortsOrServices, type: "void (list <string>, string, string)", private: true
+    publish function: :IsOtherFirewallRunning, type: "boolean ()"
+    publish function: :ArePortsOrServicesAllowed, type: "boolean (list <string>, string, string, boolean)", private: true
+    publish function: :HaveService, type: "boolean (string, string, string)"
+    publish function: :AddService, type: "boolean (string, string, string)"
+    publish function: :RemoveService, type: "boolean (string, string, string)"
+    publish function: :AddXenSupport, type: "void ()"
+    publish function: :full_init_on_boot, type: "boolean (boolean)"
+  end
+end

--- a/library/network/src/lib/network/susefirewalldservices.rb
+++ b/library/network/src/lib/network/susefirewalldservices.rb
@@ -1,0 +1,186 @@
+# ***************************************************************************
+#
+# Copyright (c) 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+
+require "yast"
+require "network/susefirewallservices"
+
+module Yast
+  # Global Definition of Firewall Services
+  # Defined using TCP, UDP and RPC ports and IP protocols and Broadcast UDP
+  # ports. Results are cached, so repeating requests are answered faster.
+  class SuSEFirewalldServicesClass < SuSEFirewallServicesClass
+    include Yast::Logger
+
+    SERVICES_DIRECTORIES = ["/etc/firewalld/services", "/usr/lib/firewalld/services"].freeze
+
+    IGNORED_SERVICES = ["..", "."].freeze
+
+    def initialize
+      textdomain "base"
+
+      @services = nil
+
+      @known_services_features = {
+        "TCP"     => "tcp_ports",
+        "UDP"     => "udp_ports",
+        "IP"      => "ip_protocols",
+        "MODULES" => "modules"
+      }
+
+      @known_metadata = { "Name" => "name", "Description" => "description" }
+
+      # firewall needs restarting. Always false for firewalld
+      @sfws_modified = false
+    end
+
+    # Reads services that can be used in FirewallD
+    # @note Contrary to SF2 we do not read the full service details here
+    # @note since that would mean to issue 5-6 API calls for every service
+    # @note file which will take a lot of time for no particular reason.
+    # @note We will read the full service information if needed in the
+    # @note service_details method.
+    # @return [Boolean] if successful
+    # @api private
+    def ReadServicesDefinedByRPMPackages
+      log.info "Reading FirewallD services from #{SERVICES_DIRECTORIES.join(" and ")}"
+
+      @services ||= {}
+
+      return true unless SuSEFirewall.SuSEFirewallIsInstalled()
+
+      SuSEFirewall.api.services.each do |service_name|
+        # Init everything
+        @services[service_name] = {}
+        @known_services_features.merge(@known_metadata).each_value do |param|
+          # Set a good name for our service until we read its information
+          @services[service_name][param] = case param
+          when "description"
+            # We intentionally don't call the API here. We will use it as a
+            # flag to populate the full service details later on.
+            default_service_description(service_name)
+          when "name"
+            # We have to call the API here because there are callers which
+            # expect to at least provide a sensible service name without
+            # worrying for the full service details. This is going to be
+            # expensive though since the cost of calling --get-short grows
+            # linearly with the number of available services :-(
+            SuSEFirewall.api.service_short(service_name)
+          else
+            []
+          end
+        end
+      end
+    end
+
+    # Returns service definition.
+    # See @services for the format.
+    # If `silent` is not defined or set to `true`, function throws an exception
+    # SuSEFirewalServiceNotFound if service is not found on disk.
+    #
+    # @note Since we do not do full service population in ReadServicesDefinedByRPMPackages
+    # @note we have to do it here but only if the service hasn't been populated
+    # @note before. The way we determine if the service has been populated or not
+    # @note is to look at the "description" key.
+    #
+    # @param [String] service_name name that may include the "service:" prefix
+    # @param [String] silent whether to silently return nil
+    #                 when service is not found
+    # @api private
+    def service_details(service_name, silent = false)
+      service = all_services[service_name]
+      # Drop service: if needed
+      service_name = service_name.partition(":")[2] if service_name.include?("service:")
+      # If service description is the default one then we know that we haven't read the service
+      # information just yet. Lets do it now
+      populate_service(service_name) if all_services.fetch(service_name, {})["description"] ==
+        default_service_description(service_name)
+      if service.nil? && !silent
+        log.error "Uknown service '#{service_name}'"
+        log.info "Known services: #{all_services.keys}"
+
+        raise(
+          SuSEFirewalServiceNotFound,
+          format(_("Service with name '%{service_name}' does not exist"), service_name: service_name)
+        )
+      end
+
+      service
+    end
+
+    # Sets that configuration was modified
+    def SetModified
+      @sfws_modified = true
+
+      nil
+    end
+
+  private
+
+    # A good default description for all services. We will use that to
+    # determine if the service has been populated or not.
+    #
+    # @param service_name [String] The service name
+    # @return [String] Default description for service
+    def default_service_description(service_name)
+      format(_("The %{service_name} Service"), service_name: service_name.upcase)
+    end
+
+    # Populate service's internal data structures.
+    #
+    # @param service_name [String] The service name
+    def populate_service(service_name)
+      # This going to be too expensive (5 API calls per service) but this
+      # is really the slowpath since we rarely need to extract so much
+      # information from a service
+      SuSEFirewall.api.service_modules(service_name).split(" ").each do |x|
+        @services[service_name]["modules"] << x
+      end
+      SuSEFirewall.api.service_protocols(service_name).split(" ").each do |x|
+        @services[service_name]["protocols"] << x
+      end
+      SuSEFirewall.api.service_ports(service_name).split(" ").each do |x|
+        port_proto = x.split("/")
+        @services[service_name]["tcp_ports"] << port_proto[0] if port_proto[1] == "tcp"
+        @services[service_name]["udp_ports"] << port_proto[0] if port_proto[1] == "udp"
+      end
+      @services[service_name]["description"] = SuSEFirewall.api.service_description(service_name)
+
+      log.debug("Added service '#{service_name}' with info: #{@services[service_name]}")
+
+      true
+    end
+
+    publish function: :ReadServicesDefinedByRPMPackages, type: "boolean ()"
+    publish function: :GetSupportedServices, type: "map <string, string> ()"
+    publish function: :GetListOfServicesAddedByPackage, type: "list <string> ()"
+    publish function: :GetNeededTCPPorts, type: "list <string> (string)"
+    publish function: :GetNeededUDPPorts, type: "list <string> (string)"
+    publish function: :GetNeededRPCPorts, type: "list <string> (string)"
+    publish function: :GetNeededIPProtocols, type: "list <string> (string)"
+    publish function: :GetDescription, type: "string (string)"
+    publish function: :IsKnownService, type: "boolean (string)"
+    publish function: :GetNeededPortsAndProtocols, type: "map <string, list <string>> (string)"
+    publish function: :SetModified, type: "void ()"
+    publish function: :ResetModified, type: "void ()"
+    publish function: :GetModified, type: "boolean ()"
+  end
+end

--- a/library/network/src/lib/network/susefirewallservices.rb
+++ b/library/network/src/lib/network/susefirewallservices.rb
@@ -1,0 +1,241 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+
+require "yast"
+
+module Yast
+  # Service not found exception
+  class SuSEFirewalServiceNotFound < StandardError
+    def initialize(message)
+      super message
+    end
+  end
+
+  # Global Definition of Firewall Services
+  # Manages services for SuSEFirewall2 and FirewallD
+  class SuSEFirewallServicesClass < Module
+    include Yast::Logger
+
+    # this is how services defined by package are distinguished
+    DEFINED_BY_PKG_PREFIX = "service:".freeze
+
+    DEFAULT_SERVICE = {
+      "tcp_ports"       => [],
+      "udp_ports"       => [],
+      "rpc_ports"       => [],
+      "ip_protocols"    => [],
+      "broadcast_ports" => [],
+      "name"            => "",
+      "description"     => ""
+    }.freeze
+
+    def initialize
+      textdomain "base"
+    end
+
+    # Function returns the map of supported (known) services.
+    #
+    # @return [Hash{String => String}] supported services
+    #
+    # **Structure:**
+    #
+    #     { service_id => localized_service_name }
+    #     {
+    #         "service:dns-server" => "DNS Server",
+    #         "service:vnc" => "Remote Administration",
+    #     }
+    def GetSupportedServices
+      supported_services = {}
+      all_services.each do |service_id, service_definition|
+        # TRANSLATORS: Name of unknown service. %1 is a requested service id like nfs-server
+        supported_services[service_id] = service_definition["name"] || Builtins.sformat(_("Unknown service '%1'"), service_id)
+      end
+      supported_services
+    end
+
+    # Function returns if the service_id is a known (defined) service
+    #
+    # @param [String] service_id (including the "service:" prefix)
+    # @return  [Boolean] if is known (defined)
+    def IsKnownService(service_id)
+      !service_details(service_id, true).nil?
+    end
+
+    # Returns list of service-ids defined by packages.
+    # (including the "service:" prefix)
+    #
+    # @return [Array<String>] service ids
+    def GetListOfServicesAddedByPackage
+      all_services.keys
+    end
+
+    # Function returns needed TCP ports for service
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [Array<String>] of needed TCP ports
+    def GetNeededTCPPorts(service)
+      service_details(service)["tcp_ports"] || []
+    end
+
+    # Function returns needed UDP ports for service
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [Array<String>] of needed UDP ports
+    def GetNeededUDPPorts(service)
+      service_details(service)["udp_ports"] || []
+    end
+
+    # Function returns needed RPC ports for service
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [Array<String>] of needed RPC ports
+    def GetNeededRPCPorts(service)
+      service_details(service)["rpc_ports"] || []
+    end
+
+    # Function returns needed IP protocols for service
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [Array<String>] of needed IP protocols
+    def GetNeededIPProtocols(service)
+      service_details(service)["ip_protocols"] || []
+    end
+
+    # Function returns description of a firewall service
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [String] service description
+    def GetDescription(service)
+      service_details(service)["description"] || []
+    end
+
+    # Function returns needed ports and protocols for service.
+    # Service needs to be known (installed in the system).
+    # Function throws an exception SuSEFirewalServiceNotFound
+    # if service is not known (undefined).
+    #
+    # @param [String] service (including the "service:" prefix)
+    # @return  [Hash{String => Array<String>}] of needed ports and protocols
+    #
+    # @example
+    #   GetNeededPortsAndProtocols ("service:aaa") -> {
+    #           "tcp_ports"      => [ "122", "ftp-data" ],
+    #           "udp_ports"      => [ "427" ],
+    #           "rpc_ports"      => [ "portmap", "ypbind" ],
+    #           "ip_protocols"   => [],
+    #           "broadcast_ports"=> [ "427" ],
+    #   }
+    def GetNeededPortsAndProtocols(service)
+      DEFAULT_SERVICE.merge(service_details(service))
+    end
+
+    # Returns all known services loaded from disk on-the-fly
+    # @api private
+    def all_services
+      ReadServicesDefinedByRPMPackages() if @services.nil?
+      @services
+    end
+
+    # Sets that configuration was not modified
+    def ResetModified
+      @sfws_modified = false
+
+      nil
+    end
+
+    # Returns whether configuration was modified
+    #
+    # @return [Boolean] modified
+    def GetModified
+      @sfws_modified
+    end
+
+    # Returns whether the service ID is defined by package.
+    # Returns 'false' if it isn't.
+    #
+    # @param [String] service
+    # @return  [Boolean] whether service is defined by package
+    #
+    # @example
+    #   ServiceDefinedByPackage ("http-server") -> false
+    #   ServiceDefinedByPackage ("service:http-server") -> true
+    def ServiceDefinedByPackage(service)
+      service.start_with? DEFINED_BY_PKG_PREFIX
+    end
+
+    # Creates a file name from service name defined by package.
+    # Service MUST be defined by package, otherwise it returns 'nil'.
+    #
+    # @param [String] service name (e.g., 'service:abc')
+    # @return [String] file name (e.g., 'abc')
+    #
+    # @example
+    #   GetFilenameFromServiceDefinedByPackage ("service:abc") -> "abc"
+    #   GetFilenameFromServiceDefinedByPackage ("abc") -> nil
+    def GetFilenameFromServiceDefinedByPackage(service)
+      if !ServiceDefinedByPackage(service)
+        log.error "Service #{service} is not defined by package"
+        return nil
+      end
+
+      service[/\A#{DEFINED_BY_PKG_PREFIX}(.*)/, 1]
+    end
+
+    # Returns SCR Agent definition.
+    #
+    # @return [Yast::Term] with agent definition
+    # @param filefullpath [String] full filename path (to read by this agent)
+    # @api private
+    def GetMetadataAgent(filefullpath)
+      term(
+        :IniAgent,
+        filefullpath,
+        "options"  => [
+          "global_values",
+          "flat",
+          "read_only",
+          "ignore_case_regexps"
+        ],
+        "comments" => [
+          # jail followed by anything but jail (immediately)
+          "^[ \t]*#[^#].*$",
+          # comments that are not commented key:value pairs (see "params")
+          # they always use two jails
+          "^[ \t]*##[ \t]*[^([a-zA-Z0-9_]+:.*)]$",
+          # comments with three jails and more
+          "^[ \t]*###.*$",
+          # jail alone
+          "^[ \t]*#[ \t]*$",
+          # (empty space)
+          "^[ \t]*$",
+          # sysconfig entries
+          "^[ \t]*[a-zA-Z0-9_]+.*"
+        ],
+        "params"   => [
+          # commented key:value pairs
+          # e.g.: ## Name: service name
+          { "match" => ["^##[ \t]*([a-zA-Z0-9_]+):[ \t]*(.*)[ \t]*$", "%s: %s"] }
+        ]
+      )
+    end
+  end
+end

--- a/library/network/src/modules/SuSEFirewall.rb
+++ b/library/network/src/modules/SuSEFirewall.rb
@@ -1,0 +1,32 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+#
+# File:        modules/SuSEFirewall.rb
+# Authors:     Markos Chandras <mchandras@suse.de>, Karol Mroz <kmroz@suse.de>
+#
+# $Id$
+#
+# Module for handling SuSEfirewall2 or FirewallD
+require "yast"
+require "network/susefirewalld"
+
+Yast::SuSEFirewall = Yast::SuSEFirewalldClass.new

--- a/library/network/src/modules/SuSEFirewallProposal.rb
+++ b/library/network/src/modules/SuSEFirewallProposal.rb
@@ -1,0 +1,779 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2012 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+# File:  modules/SuSEFirewallProposal.ycp
+# Package:  SuSEFirewall configuration
+# Summary:  Functional interface for SuSEFirewall installation proposal
+# Authors:  Lukas Ocilka <locilka@suse.cz>
+#
+# $Id$
+#
+# This module provides a functional API for Installation proposal of SuSEfirewall2
+require "yast"
+
+module Yast
+  class SuSEFirewallProposalClass < Module
+    include Yast::Logger
+
+    def main
+      textdomain "base"
+
+      Yast.import "SuSEFirewall"
+      Yast.import "ProductFeatures"
+      Yast.import "Linuxrc"
+      Yast.import "Package"
+      Yast.import "SuSEFirewallServices"
+
+      # <!-- SuSEFirewall LOCAL VARIABLES //-->
+
+      # proposal was changed by user
+      @proposal_changed_by_user = false
+
+      # proposal was initialized yet
+      @proposal_initialized = false
+
+      # known interfaces
+      @known_interfaces = []
+
+      # warnings for this "turn"
+      @warnings_now = []
+
+      @vnc_fallback_ports = ["5801", "5901"]
+
+      # bnc #427708, yet another name of service
+      @vnc_service = "service:xorg-x11-server"
+
+      @ssh_service = "service:sshd"
+    end
+
+    # <!-- SuSEFirewall LOCAL VARIABLES //-->
+
+    # <!-- SuSEFirewall LOCAL FUNCTIONS //-->
+
+    # Local function adds another warning string into warnings for user
+    #
+    # @param [String] warning
+    def AddWarning(warning)
+      @warnings_now = Builtins.add(@warnings_now, warning)
+
+      nil
+    end
+
+    # Local function clears all warnings for user from memory
+    def ClearWarnings
+      @warnings_now = []
+
+      nil
+    end
+
+    # Function returns list of warnings for user
+    #
+    # @return  [Array<String>] of warnings
+    def GetWarnings
+      deep_copy(@warnings_now)
+    end
+
+    # Local function sets currently known interfaces.
+    #
+    # @param [Array<String>] interfaces list of known interfaces
+    def SetKnownInterfaces(interfaces)
+      interfaces = deep_copy(interfaces)
+      @known_interfaces = deep_copy(interfaces)
+
+      nil
+    end
+
+    # Local function returns list [string] of known interfaces.
+    # They must have been set using SetKnownInterfaces(list [string] interfaces)
+    # function.
+    #
+    # @return  [Array<String>] of known interfaces
+    def GetKnownInterfaces
+      deep_copy(@known_interfaces)
+    end
+
+    # Function returns if interface is a dial-up type.
+    #
+    # @return  [Boolean] if is dial-up interface
+    def IsDialUpInterface(interface)
+      all_interfaces = SuSEFirewall.GetAllKnownInterfaces
+
+      interface_type = nil
+      Builtins.foreach(all_interfaces) do |one|
+        next if Ops.get(one, "id") != interface
+
+        # this is THE interface
+        interface_type = Ops.get(one, "type")
+      end
+
+      interface_type == "dialup"
+    end
+
+    # Local function adds list of interfaces into zone.
+    #
+    # @param [Array<String>] interfaces
+    # @param [String] zone
+    def SetInterfacesToZone(interfaces, zone)
+      interfaces = deep_copy(interfaces)
+      Builtins.foreach(interfaces) do |interface|
+        SuSEFirewall.AddInterfaceIntoZone(interface, zone)
+      end
+
+      nil
+    end
+
+    # Local function for updating user-changed proposal.
+    def UpdateProposal
+      last_known_interfaces = GetKnownInterfaces()
+      currently_known_interfaces = SuSEFirewall.GetListOfKnownInterfaces
+
+      had_dialup_interfaces = false
+      Builtins.foreach(last_known_interfaces) do |this_interface|
+        if IsDialUpInterface(this_interface)
+          had_dialup_interfaces = true
+          raise Break
+        end
+      end
+
+      Builtins.foreach(currently_known_interfaces) do |interface|
+        # already known but not assigned
+        next if Builtins.contains(last_known_interfaces, interface)
+        # already configured in some zone
+        next if !SuSEFirewall.GetZoneOfInterface(interface).nil?
+
+        # any dial-up interfaces presented and the new one isn't dial-up
+        if had_dialup_interfaces && !IsDialUpInterface(interface)
+          AddWarning(
+            Builtins.sformat(
+              # TRANSLATORS: Warning in installation proposal, %1 is a device name (eth0, sl0, ...)
+              _(
+                "New network device '%1' found; added as an internal firewall interface"
+              ),
+              interface
+            )
+          )
+          SetInterfacesToZone([interface], "INT")
+        else
+          AddWarning(
+            Builtins.sformat(
+              # TRANSLATORS: Warning in installation proposal, %1 is a device name (eth0, sl0, ...)
+              _(
+                "New network device '%1' found; added as an external firewall interface"
+              ),
+              interface
+            )
+          )
+          SetInterfacesToZone([interface], "EXT")
+        end
+      end
+
+      SetKnownInterfaces(currently_known_interfaces)
+
+      nil
+    end
+
+    # Returns whether service is enabled in zones.
+    #
+    # @param [String] service
+    # @param [Array<String>] zones
+    # @return [Boolean] if enabled
+    def ServiceEnabled(service, zones)
+      zones = deep_copy(zones)
+      if service.nil? || service == ""
+        Builtins.y2error("Ups, service: %1?", service)
+        return false
+      end
+
+      if zones.nil? || zones == []
+        Builtins.y2error("Ups, zones: %1?", zones)
+        return false
+      end
+
+      serenabled = true
+
+      serstat = SuSEFirewall.GetServices([service])
+      Builtins.foreach(zones) do |one_zone|
+        if Ops.get(serstat, [service, one_zone]) == false
+          Builtins.y2milestone(
+            "Service %1 is not enabled in %2",
+            service,
+            one_zone
+          )
+          serenabled = false
+          raise Break
+        end
+      end
+
+      serenabled
+    end
+
+    # Enables ports in zones.
+    #
+    # @param [Array<String>] fallback_ports fallback TCP ports
+    # @param [Array<String>] zones
+    def EnableFallbackPorts(fallback_ports, zones)
+      known_zones = SuSEFirewall.GetKnownFirewallZones()
+      unknown_zones = zones - known_zones
+      raise "Unknown firewall zones #{unknown_zones}" unless unknown_zones.empty?
+
+      log.info "Enabling fallback ports: #{fallback_ports} in zones: #{zones}"
+      zones.each do |one_zone|
+        fallback_ports.each do |one_port|
+          SuSEFirewall.AddService(one_port, "TCP", one_zone)
+        end
+      end
+
+      nil
+    end
+
+    # Function opens service for network interfaces given as the third parameter.
+    # Fallback ports are used if the given service is uknown.
+    # If interfaces are not assigned to any firewall zone, all zones will be used.
+    #
+    # @see OpenServiceOnNonDialUpInterfaces for more info.
+    #
+    # @param [String] service e.g., "service:http-server"
+    # @param [Array<String>] fallback_ports e.g., ["80"]
+    # @param [Array<String>] interfaces e.g., ["eth3"]
+    def OpenServiceInInterfaces(service, fallback_ports, interfaces)
+      fallback_ports = deep_copy(fallback_ports)
+      interfaces = deep_copy(interfaces)
+      zones = SuSEFirewall.GetZonesOfInterfaces(interfaces)
+
+      # Interfaces might not be assigned to any zone yet, use all zones
+      zones = SuSEFirewall.GetKnownFirewallZones() if zones.empty?
+
+      if SuSEFirewallServices.IsKnownService(service)
+        log.info "Opening service #{service} on interfaces #{interfaces} (zones #{zones})"
+        SuSEFirewall.SetServicesForZones([service], zones, true)
+      else
+        log.warn "Unknown service #{service}, enabling fallback ports"
+        EnableFallbackPorts(fallback_ports, zones)
+      end
+
+      nil
+    end
+
+    # Checks whether the given service or (TCP) ports are open at least in
+    # one FW zone.
+    #
+    # @param [String] service e.g., "service:http-server"
+    # @param [Array<String>] fallback_ports e.g., ["80"]
+    def IsServiceOrPortsOpen(service, fallback_ports)
+      fallback_ports = deep_copy(fallback_ports)
+      ret = false
+
+      Builtins.foreach(SuSEFirewall.GetKnownFirewallZones) do |zone|
+        # either service is supported
+        if SuSEFirewall.IsServiceSupportedInZone(service, zone)
+          ret = true
+          # or check for ports
+        else
+          all_ports = true
+
+          # all ports have to be open
+          Builtins.foreach(fallback_ports) do |port|
+            if !SuSEFirewall.HaveService(port, "TCP", zone)
+              all_ports = false
+              raise Break
+            end
+          end
+
+          ret = true if all_ports
+        end
+        raise Break if ret == true
+      end
+
+      ret
+    end
+
+    # Function opens up the service on all non-dial-up network interfaces.
+    # If there are no network interfaces known and the 'any' feature is supported,
+    # function opens the service for the zone supporting that feature. If there
+    # are only dial-up interfaces, function opens the service for them.
+    #
+    # @param [String] service such as "service:koo" or "serice:boo"
+    # @param [Array<String>] fallback_ports list of ports used as a fallback if the given service doesn't exist
+    def OpenServiceOnNonDialUpInterfaces(service, fallback_ports)
+      fallback_ports = deep_copy(fallback_ports)
+      non_dial_up_interfaces = SuSEFirewall.GetAllNonDialUpInterfaces
+      dial_up_interfaces = SuSEFirewall.GetAllDialUpInterfaces
+
+      # Opening the service for non-dial-up interfaces
+      if Ops.greater_than(Builtins.size(non_dial_up_interfaces), 0)
+        OpenServiceInInterfaces(service, fallback_ports, non_dial_up_interfaces)
+        # Only dial-up network interfaces, there mustn't be any non-dial-up one
+      elsif Ops.greater_than(Builtins.size(dial_up_interfaces), 0)
+        OpenServiceInInterfaces(service, fallback_ports, dial_up_interfaces)
+        # No network interfaces are known
+      elsif Builtins.size(@known_interfaces) == 0
+        if SuSEFirewall.IsAnyNetworkInterfaceSupported == true
+          Builtins.y2warning(
+            "WARNING: Opening %1 for the External zone without any known interface!",
+            Builtins.toupper(service)
+          )
+          OpenServiceInInterfaces(
+            service,
+            fallback_ports,
+            [SuSEFirewall.special_all_interface_string]
+          )
+        end
+      end
+
+      nil
+    end
+
+    # Local function returns whether the Xen kernel is installed
+    #
+    # @return [Boolean] whether xen-capable kernel is installed.
+    def IsXenInstalled
+      # bug #154133
+      return true if Package.Installed("kernel-xen")
+      return true if Package.Installed("kernel-xenpae")
+
+      false
+    end
+
+    # Local function for proposing firewall configuration.
+    def ProposeFunctions
+      known_interfaces = SuSEFirewall.GetAllKnownInterfaces
+
+      dial_up_interfaces = []
+      non_dup_interfaces = []
+      Builtins.foreach(known_interfaces) do |interface|
+        if Ops.get(interface, "type") == "dial_up"
+          dial_up_interfaces = Builtins.add(
+            dial_up_interfaces,
+            Ops.get(interface, "id", "")
+          )
+        else
+          non_dup_interfaces = Builtins.add(
+            non_dup_interfaces,
+            Ops.get(interface, "id", "")
+          )
+        end
+      end
+
+      Builtins.y2milestone(
+        "Proposal based on configuration: Dial-up interfaces: %1, Other: %2",
+        dial_up_interfaces,
+        non_dup_interfaces
+      )
+
+      # has any network interface
+      if Builtins.size(non_dup_interfaces) == 0 ||
+          Builtins.size(dial_up_interfaces) == 0
+        SuSEFirewall.SetEnableService(
+          ProductFeatures.GetBooleanFeature("globals", "enable_firewall")
+        )
+        SuSEFirewall.SetStartService(
+          ProductFeatures.GetBooleanFeature("globals", "enable_firewall")
+        )
+      end
+
+      # has non-dial-up and also dial-up interfaces
+      if Ops.greater_than(Builtins.size(non_dup_interfaces), 0) &&
+          Ops.greater_than(Builtins.size(dial_up_interfaces), 0)
+        SetInterfacesToZone(non_dup_interfaces, "INT")
+        SetInterfacesToZone(dial_up_interfaces, "EXT")
+        SuSEFirewall.SetServicesForZones([@ssh_service], ["INT", "EXT"], true) if ProductFeatures.GetBooleanFeature("globals", "firewall_enable_ssh")
+
+        # has non-dial-up and doesn't have dial-up interfaces
+      elsif Ops.greater_than(Builtins.size(non_dup_interfaces), 0) &&
+          Builtins.size(dial_up_interfaces) == 0
+        SetInterfacesToZone(non_dup_interfaces, "EXT")
+        SuSEFirewall.SetServicesForZones([@ssh_service], ["EXT"], true) if ProductFeatures.GetBooleanFeature("globals", "firewall_enable_ssh")
+
+        # doesn't have non-dial-up and has dial-up interfaces
+      elsif Builtins.size(non_dup_interfaces) == 0 &&
+          Ops.greater_than(Builtins.size(dial_up_interfaces), 0)
+        SetInterfacesToZone(dial_up_interfaces, "EXT")
+        SuSEFirewall.SetServicesForZones([@ssh_service], ["EXT"], true) if ProductFeatures.GetBooleanFeature("globals", "firewall_enable_ssh")
+      end
+
+      # Dial-up interfaces are considered to be internal,
+      # Non-dial-up are considered to be external.
+      # If there are only Non-dial-up interfaces, they are all considered as external.
+      #
+      # VNC Installation proposes to open VNC Access up on the Non-dial-up interfaces only.
+      # SSH Installation is the same case...
+      if Linuxrc.vnc
+        Builtins.y2milestone(
+          "This is an installation over VNC, opening VNC on all non-dial-up interfaces..."
+        )
+        # Try the service first, then ports
+        # bnc #398855
+        OpenServiceOnNonDialUpInterfaces(@vnc_service, @vnc_fallback_ports)
+      end
+      if Linuxrc.usessh
+        Builtins.y2milestone(
+          "This is an installation over SSH, opening SSH on all non-dial-up interfaces..."
+        )
+        # Try the service first, then ports
+        # bnc #398855
+        OpenServiceOnNonDialUpInterfaces(@ssh_service, ["ssh"])
+      end
+
+      # Firewall support for XEN domain0
+      if IsXenInstalled()
+        Builtins.y2milestone(
+          "Adding Xen support into the firewall configuration"
+        )
+        SuSEFirewall.AddXenSupport
+      end
+
+      propose_iscsi if Linuxrc.useiscsi
+
+      SetKnownInterfaces(SuSEFirewall.GetListOfKnownInterfaces)
+
+      nil
+    end
+
+    # <!-- SuSEFirewall LOCAL FUNCTIONS //-->
+
+    # <!-- SuSEFirewall GLOBAL FUNCTIONS //-->
+
+    # Function sets that proposal was changed by user
+    #
+    # @param changed [true, false] if changed by user
+    def SetChangedByUser(changed)
+      Builtins.y2milestone("Proposal was changed by user")
+      @proposal_changed_by_user = changed
+
+      nil
+    end
+
+    # Local function returns if proposal was changed by user
+    #
+    # @return  [Boolean] if proposal was changed by user
+    def GetChangedByUser
+      @proposal_changed_by_user
+    end
+
+    # Function sets that proposal was initialized
+    #
+    # @param initialized [true, false] if initialized
+    def SetProposalInitialized(initialized)
+      @proposal_initialized = initialized
+
+      nil
+    end
+
+    # Local function returns if proposal was initialized already
+    #
+    # @return  [Boolean] if proposal was initialized
+    def GetProposalInitialized
+      @proposal_initialized
+    end
+
+    # Function fills up default configuration into internal values
+    #
+    # @return [void]
+    def Reset
+      SuSEFirewall.ResetReadFlag
+      SuSEFirewall.Read
+
+      nil
+    end
+
+    # Function proposes the SuSEfirewall2 configuration
+    #
+    # @return [void]
+    def Propose
+      # No proposal when SuSEfirewall2 is not installed
+      if !SuSEFirewall.SuSEFirewallIsInstalled
+        SuSEFirewall.SetEnableService(false)
+        SuSEFirewall.SetStartService(false)
+        return nil
+      end
+
+      # Not changed by user - Propose from scratch
+      if !GetChangedByUser()
+        Builtins.y2milestone("Calling firewall configuration proposal")
+        Reset()
+        ProposeFunctions()
+        # Changed - don't break user's configuration
+      else
+        Builtins.y2milestone("Calling firewall configuration update proposal")
+        UpdateProposal()
+      end
+
+      nil
+    end
+
+    # Function returns the proposal summary
+    #
+    # @return [Hash{String => String}] proposal
+    #
+    # **Structure:**
+    #
+    #     map $[
+    #       "output" : "HTML Proposal Summary",
+    #       "warning" : "HTML Warning Summary",
+    #      ]
+    def ProposalSummary
+      # output: $[ "output" : "HTML Proposal", "warning" : "HTML Warning" ];
+      output = ""
+      warning = ""
+
+      # SuSEfirewall2 package needn't be installed
+      if !SuSEFirewall.SuSEFirewallIsInstalled
+        # TRANSLATORS: Proposal informative text
+        output = "<ul>" +
+          _(
+            "The SuSEfirewall2 package is not installed. The firewall will be disabled."
+          ) + "</ul>"
+
+        return { "output" => output, "warning" => warning }
+      end
+
+      # SuSEfirewall2 is installed...
+
+      firewall_is_enabled = SuSEFirewall.GetEnableService == true
+
+      output = Ops.add(output, "<ul>\n")
+      output = Ops.add(
+        Ops.add(
+          Ops.add(output, "<li>"),
+          if firewall_is_enabled
+            # TRANSLATORS: Proposal informative text "Firewall is enabled (disable)" with link around
+            # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+            _(
+              "Firewall is enabled (<a href=\"firewall--disable_firewall_in_proposal\">disable</a>)"
+            )
+          else
+            # TRANSLATORS: Proposal informative text "Firewall is disabled (enable)" with link around
+            # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+            _(
+              "Firewall is disabled (<a href=\"firewall--enable_firewall_in_proposal\">enable</a>)"
+            )
+          end
+        ),
+        "</li>\n"
+      )
+
+      if firewall_is_enabled
+        # Any enabled SSH means SSH-is-enabled
+        is_ssh_enabled = false
+
+        # Any known interfaces
+        if Ops.greater_than(Builtins.size(@known_interfaces), 0)
+          Builtins.y2milestone("Interfaces: %1", @known_interfaces)
+
+          # all known interfaces for testing
+          used_zones = SuSEFirewall.GetZonesOfInterfacesWithAnyFeatureSupported(
+            @known_interfaces
+          )
+          Builtins.y2milestone("Zones used by firewall: %1", used_zones)
+
+          Builtins.foreach(used_zones) do |zone|
+            if SuSEFirewall.IsServiceSupportedInZone(@ssh_service, zone) ||
+                SuSEFirewall.HaveService("ssh", "TCP", zone)
+              is_ssh_enabled = true
+            end
+          end
+
+          output = Ops.add(
+            Ops.add(
+              Ops.add(output, "<li>"),
+              if is_ssh_enabled
+                # TRANSLATORS: Network proposal informative text with link around
+                # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+                _(
+                  "SSH port is open (<a href=\"firewall--disable_ssh_in_proposal\">close</a>)"
+                )
+              else
+                # TRANSLATORS: Network proposal informative text with link around
+                # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+                _(
+                  "SSH port is blocked (<a href=\"firewall--enable_ssh_in_proposal\">open</a>)"
+                )
+              end
+            ),
+            "</li>\n"
+          )
+
+          # No known interfaces, but 'any' is supported
+          # and ssh is enabled there
+        elsif SuSEFirewall.IsAnyNetworkInterfaceSupported &&
+            SuSEFirewall.IsServiceSupportedInZone(
+              @ssh_service,
+              SuSEFirewall.special_all_interface_zone
+            )
+          is_ssh_enabled = true
+          # TRANSLATORS: Network proposal informative text with link around
+          # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+          output = Ops.add(
+            Ops.add(
+              Ops.add(output, "<li>"),
+              _(
+                "SSH port is open (<a href=\"firewall--disable_ssh_in_proposal\">close</a>), but\nthere are no network interfaces configured"
+              )
+            ),
+            "</li>"
+          )
+        end
+        Builtins.y2milestone(
+          "SSH is " + (is_ssh_enabled ? "" : "not ") + "enabled"
+        )
+
+        if Linuxrc.usessh
+          if !is_ssh_enabled
+            # TRANSLATORS: This is a warning message. Installation over SSH without SSH allowed on firewall
+            AddWarning(
+              _(
+                "You are installing a system over SSH, but you have not opened the SSH port on the firewall."
+              )
+            )
+          end
+        end
+
+        # when the firewall is enabled and we are installing the system over VNC
+        if Linuxrc.vnc
+          # Any enabled VNC means VNC-is-enabled
+          is_vnc_enabled = false
+          if Ops.greater_than(Builtins.size(@known_interfaces), 0)
+            Builtins.foreach(
+              SuSEFirewall.GetZonesOfInterfacesWithAnyFeatureSupported(
+                @known_interfaces
+              )
+            ) do |zone|
+              if SuSEFirewall.IsServiceSupportedInZone(@vnc_service, zone) == true
+                is_vnc_enabled = true
+                # checking also fallback ports
+              else
+                set_vnc_enabled_to = true
+                Builtins.foreach(@vnc_fallback_ports) do |one_port|
+                  if SuSEFirewall.HaveService(one_port, "TCP", zone) != true
+                    set_vnc_enabled_to = false
+                    raise Break
+                  end
+                  is_vnc_enabled = true if set_vnc_enabled_to == true
+                end
+              end
+            end
+          end
+          Builtins.y2milestone(
+            "VNC port is " + (is_vnc_enabled ? "open" : "blocked") + " in the firewall"
+          )
+
+          output = Ops.add(
+            Ops.add(
+              Ops.add(output, "<li>"),
+              if is_vnc_enabled
+                # TRANSLATORS: Network proposal informative text "Remote Administration (VNC) is enabled" with link around
+                # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+                _(
+                  "Remote Administration (VNC) ports are open (<a href=\"firewall--disable_vnc_in_proposal\">close</a>)"
+                )
+              else
+                # TRANSLATORS: Network proposal informative text "Remote Administration (VNC) is disabled" with link around
+                # IMPORTANT: Please, do not change the HTML link <a href="...">...</a>, only visible text
+                _(
+                  "Remote Administration (VNC) ports are blocked (<a href=\"firewall--enable_vnc_in_proposal\">open</a>)"
+                )
+              end
+            ),
+            "</li>\n"
+          )
+
+          if !is_vnc_enabled
+            # TRANSLATORS: This is a warning message. Installation over VNC without VNC allowed on firewall
+            AddWarning(
+              _(
+                "You are installing a system using remote administration (VNC), but you have not opened the VNC ports on the firewall."
+              )
+            )
+          end
+        end
+
+        if Linuxrc.useiscsi
+          is_iscsi_enabled = IsServiceOrPortsOpen(
+            @iscsi_target_service,
+            @iscsi_target_fallback_ports
+          )
+
+          output = Ops.add(
+            Ops.add(
+              Ops.add(output, "<li>"),
+              if is_iscsi_enabled
+                # TRANSLATORS: Network proposal informative text
+                _("iSCSI Target ports are open")
+              else
+                # TRANSLATORS: Network proposal informative text
+                _("iSCSI Target ports are blocked")
+              end
+            ),
+            "</li>\n"
+          )
+
+          if !is_iscsi_enabled
+            # TRANSLATORS: This is a warning message. Installation to iSCSI without iSCSI allowed on firewall
+            AddWarning(
+              _(
+                "You are installing a system using iSCSI Target, but you have not opened the needed ports on the firewall."
+              )
+            )
+          end
+        end
+
+        warnings_strings = GetWarnings()
+        if Ops.greater_than(Builtins.size(warnings_strings), 0)
+          ClearWarnings()
+          Builtins.foreach(warnings_strings) do |single_warning|
+            warning = Ops.add(
+              Ops.add(Ops.add(warning, "<li>"), single_warning),
+              "</li>\n"
+            )
+          end
+          warning = Ops.add(Ops.add("<ul>\n", warning), "</ul>\n")
+        end
+      end
+
+      output = Ops.add(output, "</ul>\n")
+
+      { "output" => output, "warning" => warning }
+    end
+
+    # Proposes firewall settings for iSCSI
+    def propose_iscsi
+      log.info "iSCSI has been used during installation, proposing FW full_init_on_boot"
+
+      # bsc#916376: ports need to be open already during boot
+      SuSEFirewall.full_init_on_boot(true)
+
+      nil
+    end
+
+    publish function: :OpenServiceOnNonDialUpInterfaces, type: "void (string, list <string>)"
+    publish function: :SetChangedByUser, type: "void (boolean)"
+    publish function: :GetChangedByUser, type: "boolean ()"
+    publish function: :SetProposalInitialized, type: "void (boolean)"
+    publish function: :GetProposalInitialized, type: "boolean ()"
+    publish function: :Reset, type: "void ()"
+    publish function: :Propose, type: "void ()"
+    publish function: :ProposalSummary, type: "map <string, string> ()"
+    publish function: :propose_iscsi, type: "void ()"
+  end
+
+  SuSEFirewallProposal = SuSEFirewallProposalClass.new
+  SuSEFirewallProposal.main
+end

--- a/library/network/src/modules/SuSEFirewallServices.rb
+++ b/library/network/src/modules/SuSEFirewallServices.rb
@@ -1,0 +1,34 @@
+# ***************************************************************************
+#
+# Copyright (c) 2002 - 2016 Novell, Inc.
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public License as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, contact Novell, Inc.
+#
+# To contact Novell about this file by physical or electronic mail,
+# you may find current contact information at www.novell.com
+#
+# ***************************************************************************
+#
+# File:  modules/SuSEFirewallServices.rb
+# Package:  Firewall Services, Ports Aliases.
+# Summary:  Definition of Supported Firewall Services and Port Aliases.
+# Authors:  Markos Chandras <mchandras@suse.de>
+#
+# Global Definition of Firewall Services
+# Manages services for SuSEFirewall2 and FirewallD
+
+require "yast"
+require "network/susefirewalldservices"
+
+Yast::SuSEFirewallServices = Yast::SuSEFirewalldServicesClass.new

--- a/library/network/src/scrconf/sysconfig_SuSEfirewall2.scr
+++ b/library/network/src/scrconf/sysconfig_SuSEfirewall2.scr
@@ -1,0 +1,52 @@
+/**
+ * File:        cfg_firewall2.scr
+ * Summary:     Agent for reading/writing /etc/sysconfig/SuSEfirewall2
+ * Author:      Lukas Ocilka <lukas.ocilka@suse.cz>
+ * Access:      read / write
+ *
+ * Example:
+ *   Dir(.sysconfig.SuSEfirewall2)
+ *   (["FW_ROUTE", ...])
+ **
+ *   Read(.sysconfig.SuSEfirewall2.FW_ROUTE)
+ *   ("yes")
+ **
+ *   Write(.sysconfig.SuSEfirewall2.FW_ROUTE, "no")
+ *   (true)
+ **
+ *   // Don't forget to write nil to sync the settings!
+ *   Write(.sysconfig.SuSEfirewall2, nil)
+ *
+ * $Id$
+ *
+ * Read/Sets the values defined in /etc/sysconfig/SuSEfirewall2
+ * in an easy manner.
+ */
+.sysconfig.SuSEfirewall2
+
+`ag_ini(
+    `IniAgent (
+	"/etc/sysconfig/SuSEfirewall2",
+	$[
+	    // do not join_multiline, "\n" are replaced with " " later
+	    "options" : [ "line_can_continue", "global_values", "comments_last", "flat", ],
+	    "comments": [ "^[ \t]*#.*$", "#.*", "^[ \t]*$", ],
+	    "params" : [
+		// single quotes
+		$[
+		    "match" : [ "^[ \t]*([a-zA-Z0-9_]+)=\"([^\"]*)\"", "%s=\"%s\"" ],
+		    "multiline" : [ "^[ \t]*([^=]+)[ \t]*=[ \t]*\"([^\"]*)", "([^\"]*)\"" ],
+		],
+		// double (common) quotes
+		$[
+		    "match" : [ "^[ \t]*([a-zA-Z0-9_]+)='([^']*)'", "%s='%s'" ],
+		    "multiline" : [ "^[ \t]*([^=]+)[ \t]*=[ \t]*'([^']*)", "([^']*)'" ],
+		],
+		// without any quotes
+		$[
+		    "match" : [ "^[ \t]*([a-zA-Z0-9_]+)=([^ \t\"']*)[ \t]*$", "%s=\"%s\"" ],
+		],
+	    ],
+	]
+    )
+)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  1 15:16:20 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Revert the drop of SuSEFirewall2 as there are still some packages
+  which need to be adapted (bsc#1177160)
+- 4.3.34
+
+-------------------------------------------------------------------
 Tue Sep 29 09:46:21 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Drop SuSEFirewall2 code completely (fate#323460)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.33
+Version:        4.3.34
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
We announced the drop of support long time ago but there are still some modules that need to be adopted. In particular [yast-vpn](https://github.com/yast/yast-vpn/pull/6)

Maybe we could reopen the pull request and merge as it is... but the module looks like unmaintained and not used at all so I would propose to drop it.

Until then, just bring back the SuSEFirewall module.