### PR TITLE
Product Class: Checking if method product_package is availble before …

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -415,7 +415,7 @@ module Yast
       package = case source
       when ::Integer
         product = find_product(source)
-        return nil unless product&.product_package
+        return nil if !product.methods.include?(:product_package) || !product&.product_package
 
         product_package = product.product_package
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Oct  2 14:37:00 UTC 2020 - schubi <schubi@localhost>
+
+- Product Class: Checking if method product_package is availble
+  before using it (bsc#1175681). Needed while adding older add-on
+  repos.
+- 4.2.88
+
+-------------------------------------------------------------------
 Fri Jul 24 08:06:27 UTC 2020 - Jeff Kowalczyk <jkowalczyk@suse.com>
 
 - update is_wsl function to match wsl1 and wsl2 osrelease spellings

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.87
+Version:        4.2.88
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
…using it (bsc#1175681). Needed while adding older add-on repos.

The customer is using an really old repo via Add-On module. This repo does not have any product_package information in the product description.