### PR TITLE
bsc#1177405: AutoYaST crashes with an empty <raid_options> section

### DIFF
--- a/library/general/src/lib/installation/autoinst_profile/section_with_attributes.rb
+++ b/library/general/src/lib/installation/autoinst_profile/section_with_attributes.rb
@@ -147,7 +147,7 @@ module Installation
         # @return [SectionWithAttributes]
         def new_from_hashes(hash, parent = nil)
           result = new(parent)
-          result.init_from_hashes(hash)
+          result.init_from_hashes(hash) if hash.is_a?(Hash)
           result
         end
 
@@ -182,6 +182,8 @@ module Installation
       #
       # @param hash [Hash] see {.new_from_hashes}
       def init_from_hashes(hash)
+        return unless hash.is_a?(Hash)
+
         init_scalars_from_hash(hash)
       end
 

--- a/library/general/test/installation/autoinst_profile/section_with_attributes_test.rb
+++ b/library/general/test/installation/autoinst_profile/section_with_attributes_test.rb
@@ -111,6 +111,20 @@ describe Installation::AutoinstProfile::SectionWithAttributes do
     end
   end
 
+  describe ".new_from_hashes" do
+    it "returns an instance including the given data" do
+      group = GroupSection.new_from_hashes(name: "users")
+      expect(group.name).to eq("users")
+    end
+
+    context "when nil is given" do
+      it "returns a instance" do
+        group = GroupSection.new_from_hashes(nil)
+        expect(group.name).to be_nil
+      end
+    end
+  end
+
   describe "#section_path" do
     context "when the section does not have a parent" do
       subject { RootSection.new }

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct  7 13:23:28 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: do not crash when sections like 'raid_options' are
+  empty (bsc#1177405).
+- 4.3.35
+
+-------------------------------------------------------------------
 Thu Oct  1 15:16:20 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Revert the drop of SuSEFirewall2 as there are still some packages

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.34
+Version:        4.3.35
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Fixes [bsc#1177405](https://bugzilla.suse.com/show_bug.cgi?id=1177405). It does not try to import the information from a hash when it is not actually a hash.

```
<partition>
  <raid_options/>
</partition>
```

Is exported to: 

```ruby
{ raid_options: "" }
```

because there is not enough information to determine whether it is should be a string or a hash (the `raid_options` is supposed to be a hash).