### PR TITLE
Revert hide dialog heading in text mode

### DIFF
--- a/library/wizard/src/modules/Wizard.rb
+++ b/library/wizard/src/modules/Wizard.rb
@@ -282,8 +282,12 @@ module Yast
             HSpacing(1),
             VBox(
               VSpacing(0.2),
-              # translators: dialog title to appear before any content is initialized
-              ReplacePoint(Id(:heading), dialog_heading(_("Initializing ..."))),
+              HBox(
+                # translators: dialog title to appear before any content is initialized
+                Heading(Id(:title), Opt(:hstretch), _("Initializing ...")),
+                HStretch(),
+                ReplacePoint(Id(:relnotes_rp), Empty())
+              ),
               VWeight(
                 1, # Layout trick: Lower layout priority with weight
                 HVCenter(Opt(:hvstretch), ReplacePoint(Id(:contents), Empty()))
@@ -329,8 +333,15 @@ module Yast
             70,
             VBox(
               VSpacing(0.2),
-              # translators: dialog title to appear before any content is initialized
-              ReplacePoint(Id(:heading), dialog_heading(_("YaST\nInitializing ...\n"))),
+              HBox(
+                # translators: dialog title to appear before any content is initialized
+                Heading(
+                  Id(:title),
+                  Opt(:hstretch),
+                  _("YaST\nInitializing ...\n")
+                ),
+                HStretch()
+              ),
               VWeight(
                 1, # Layout trick: Lower layout priority with weight
                 HVCenter(Opt(:hvstretch), ReplacePoint(Id(:contents), Empty()))
@@ -817,7 +828,7 @@ module Yast
 
         UI.ChangeWidget(Id(:back), :Enabled, has_back) if UI.WidgetExists(Id(:back))
         UI.ChangeWidget(Id(:abort), :Enabled, true) if UI.WidgetExists(Id(:abort))
-        UI.ReplaceWidget(Id(:heading), dialog_heading(title)) if UI.WidgetExists(Id(:heading))
+        UI.ChangeWidget(Id(:title), :Value, title) if UI.WidgetExists(Id(:title))
 
         UI.SetFocus(Id(:accept)) if set_focus && UI.WidgetExists(Id(:accept))
       end
@@ -1848,21 +1859,6 @@ module Yast
       UI.SetApplicationIcon(@icon_name)
       true
     end
-  end
-
-  # Returns the content for the heading of the dialog
-  #
-  # The heading is hidden when no title is given
-  #
-  # @param title [String, nil]
-  def dialog_heading(title)
-    return Empty() if title.nil? || title.empty?
-
-    HBox(
-      Heading(Id(:title), Opt(:hstretch), title),
-      HStretch(),
-      ReplacePoint(Id(:relnotes_rp), Empty())
-    )
   end
 
   Wizard = WizardClass.new

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Oct  8 20:21:22 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Revert changes for hiding the heading of the dialog in text mode
+  (the heading has no height if the title is empty).
+- bsc#1176808
+- 4.3.37
+
+-------------------------------------------------------------------
 Thu Oct  8 19:35:48 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: SectionWithAttributes#new_from_hashes accepts

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.36
+Version:        4.3.37
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

In https://github.com/yast/yast-yast2/pull/1098, `Yast::Wizard` was adapted to hide its heading when the title is set to empty. But in *ncurses*, the wizard heading always includes the *Release Notes* button. Such button must be preserved even though the title is set to empty.

* https://trello.com/c/ASQzhjTK/2102-sles15-sp3-p1-1176808-build-421-openqa-test-fails-in-releasenotes
* https://bugzilla.suse.com/show_bug.cgi?id=1176808
* See also https://trello.com/c/dT7X5aC1/2045-1-menu-layout-rendering-improvements.

## Solution

The changes introduced by https://github.com/yast/yast-yast2/pull/1098 were reverted and the *Release Notes* button is shown again.

![VirtualBox_openSUSE Tumbleweed_08_10_2020_14_17_24](https://user-images.githubusercontent.com/1112304/95473145-b5c2c500-097b-11eb-97a1-41e945a2f434.png)

Note that hiding the heading is not needed at all in text mode because the heading has no height when its title is empty. With an empty title, the heading only occupies space if the *Release Notes* button is shown. For example, this is how Expert Partitioner will look without a title and with a menu bar.

* During installation with *Release Notes* button:

![VirtualBox_openSUSE Tumbleweed_08_10_2020_15_45_50](https://user-images.githubusercontent.com/1112304/95474684-52399700-097d-11eb-87c9-abaddfd5cf36.png)

* In a running system without *Release Notes* button:

![Screenshot from 2020-10-08 15-31-15](https://user-images.githubusercontent.com/1112304/95473134-b3f90180-097b-11eb-8a96-184be1f353eb.png)


## Testing

* Manually tested.