### PR TITLE
Support for nested items in CWM::Table

### DIFF
--- a/library/cwm/examples/object_api_table.rb
+++ b/library/cwm/examples/object_api_table.rb
@@ -31,6 +31,47 @@ class NiceTable < CWM::Table
   end
 end
 
+class NestedTable < CWM::Table
+  def header
+    [
+      "Device",
+      "Size",
+      "Type"
+    ]
+  end
+
+  def items
+    [
+      CWM::TableItem.new(:sda, ["/dev/sda", "931.5G", "Disk"], children: sda_items),
+      CWM::TableItem.new(:sdb, ["/dev/sdb", "900.0G", "Disk"]),
+      [:sdc, "/dev/sdc", "521.5G", "Disk"],
+      CWM::TableItem.new(:sdd, ["/dev/sdd", "0.89T", "Disk"], children: sdd_items, open: false)
+    ]
+  end
+
+private
+
+  def sda_items
+    [
+      [:sda1, "sda1",  "97.7G", "Ntfs Partition"],
+      [:sda2, "sda2",  "833.9G", "Ext4 Partition"]
+    ]
+  end
+
+  def sdd_items
+    [
+      CWM::TableItem.new(:sdd1, ["sdd1", "0.89T", "BtrFS Partition"], children: sdd1_items)
+    ]
+  end
+
+  def sdd1_items
+    [
+      CWM::TableItem.new(:home, ["@/home", "", "BtrFS Subvolume"]),
+      CWM::TableItem.new(:opt, ["@/opt", "", "BtrFS Subvolume"])
+    ]
+  end
+end
+
 module Yast
   class ExampleDialog
     include Yast::I18n
@@ -39,9 +80,11 @@ module Yast
       textdomain "example"
 
       table_widget = NiceTable.new
+      nested_table_widget = NestedTable.new
 
-      contents = HBox(
-        table_widget
+      contents = VBox(
+        table_widget,
+        nested_table_widget
       )
 
       Yast::Wizard.CreateDialog

--- a/library/cwm/examples/object_api_table.rb
+++ b/library/cwm/examples/object_api_table.rb
@@ -45,7 +45,7 @@ class NestedTable < CWM::Table
       CWM::TableItem.new(:sda, ["/dev/sda", "931.5G", "Disk"], children: sda_items),
       CWM::TableItem.new(:sdb, ["/dev/sdb", "900.0G", "Disk"]),
       [:sdc, "/dev/sdc", "521.5G", "Disk"],
-      CWM::TableItem.new(:sdd, ["/dev/sdd", "0.89T", "Disk"], children: sdd_items, open: false)
+      item(:sdd, ["/dev/sdd", "0.89T", "Disk"], children: sdd_items, open: false)
     ]
   end
 
@@ -66,8 +66,8 @@ private
 
   def sdd1_items
     [
-      CWM::TableItem.new(:home, ["@/home", "", "BtrFS Subvolume"]),
-      CWM::TableItem.new(:opt, ["@/opt", "", "BtrFS Subvolume"])
+      item(:home, ["@/home", "", "BtrFS Subvolume"]),
+      item(:opt, ["@/opt", "", "BtrFS Subvolume"])
     ]
   end
 end

--- a/library/cwm/src/lib/cwm/rspec.rb
+++ b/library/cwm/src/lib/cwm/rspec.rb
@@ -198,10 +198,10 @@ RSpec.shared_examples "CWM::Table" do
   end
 
   describe "#items" do
-    it "produces an array of arrays" do
+    it "produces a collection with arrays and/or TableItem objects" do
       expect(subject.items).to be_an Enumerable
       subject.items.each do |item|
-        expect(item).to be_a Array
+        expect(item).to be_a(Array).or be_a(CWM::TableItem)
       end
     end
   end

--- a/library/cwm/src/lib/cwm/table.rb
+++ b/library/cwm/src/lib/cwm/table.rb
@@ -2,6 +2,29 @@ require "abstract_method"
 require "cwm/custom_widget"
 
 module CWM
+  # An entry of a {Table}
+  class TableItem
+    # @return [String, Symbol]
+    attr_reader :id
+
+    # @return [Array]
+    attr_reader :values
+
+    # @see Table#items
+    # @return [Array<TableItem, Array>]
+    attr_reader :children
+
+    # @return [Boolean] whether children are initially expanded
+    attr_reader :open
+
+    def initialize(id, values, open: true, children: [])
+      @id = id
+      @values = values
+      @open = open
+      @children = children
+    end
+  end
+
   # Represents Table widget
   class Table < CustomWidget
     # @method header
@@ -19,10 +42,14 @@ module CWM
     #   end
     abstract_method :header
 
-    # gets initial two dimensional array of Table content
-    # one element in the first dimension contain as first element id and then
-    # rest is data in table, which can be e.g. terms. Then it have to be enclosed in
-    # `cell` term.
+    # Array with the table content
+    #
+    # Each element can be a {TableItem} or an Array
+    #
+    # If it's an array, the row contains no nested elements. The first element represents
+    # the id of the row and the rest is used as data for its cells. Those can be e.g. terms.
+    # Then it has to be enclosed in `cell` term.
+    #
     # @see for more complex example see examples directory
     # @note default value is empty array. It is useful when computation expensive content
     #   need to be set. In such case, it is better to keep empty items to quickly show table and
@@ -33,9 +60,11 @@ module CWM
     #   def items
     #     [
     #       [:first_user, "Joe", "Doe"],
-    #       [:best_user, "Chuck", "Norris"]
+    #       TableItem.new(:best_user, ["Chuck", "Norris"])
     #     ]
     #   end
+    #
+    # @return [Array<TableItem, Array>]
     def items
       []
     end
@@ -43,7 +72,7 @@ module CWM
     # change list on fly with argument. Useful when content of widget is changed.
     # @note items and change_items is consistent with ItemsSelection mixin, just format of
     #   items is different due to nature of Table content.
-    # @param items_list [Array<Array<Object>>] same format as {#items}
+    # @param items_list [Array] same format as {#items}
     def change_items(items_list)
       Yast::UI.ChangeWidget(Id(widget_id), :Items, format_items(items_list))
     end
@@ -122,14 +151,13 @@ module CWM
       items.map { |i| format_item(i) }
     end
 
+    # @see #format_items
     def format_item(item)
-      content = item.dup
+      return Item(Id(item.first), *item[1..-1]) if item.is_a?(Array)
 
-      content[0] = Id(content[0])
-
-      content[-2] = format_items(content[-2]) if content[-2].is_a?(Array)
-
-      Item(*content)
+      children = format_items(item.children)
+      open_tag = item.open ? :open : :closed
+      Item(Id(item.id), *item.values, children, open_tag)
     end
   end
 end

--- a/library/cwm/src/lib/cwm/table.rb
+++ b/library/cwm/src/lib/cwm/table.rb
@@ -119,9 +119,17 @@ module CWM
   private
 
     def format_items(items)
-      items.map do |item|
-        Item(Id(item.first), *item[1..-1])
-      end
+      items.map { |i| format_item(i) }
+    end
+
+    def format_item(item)
+      content = item.dup
+
+      content[0] = Id(content[0])
+
+      content[-2] = format_items(content[-2]) if content[-2].is_a?(Array)
+
+      Item(*content)
     end
   end
 end

--- a/library/cwm/src/lib/cwm/table.rb
+++ b/library/cwm/src/lib/cwm/table.rb
@@ -147,7 +147,7 @@ module CWM
     end
 
     # helper to create a {TableItem}
-    # @param args content of item
+    # @param args content of item, see {TableItem#initialize}
     # @note Not to be confused with the UI shortcut `Item`
     #
     # @example

--- a/library/cwm/src/lib/cwm/table.rb
+++ b/library/cwm/src/lib/cwm/table.rb
@@ -44,7 +44,8 @@ module CWM
 
     # Array with the table content
     #
-    # Each element can be a {TableItem} or an Array
+    # Each element can be a {TableItem} or an Array. The helper {#item} can be used to easily
+    # create {TableItem} objects.
     #
     # If it's an array, the row contains no nested elements. The first element represents
     # the id of the row and the rest is used as data for its cells. Those can be e.g. terms.
@@ -59,8 +60,15 @@ module CWM
     # @example for table with two columns
     #   def items
     #     [
-    #       [:first_user, "Joe", "Doe"],
-    #       TableItem.new(:best_user, ["Chuck", "Norris"])
+    #       item(:first_user, ["Joe", "Doe"], children: first_children),
+    #       [:best_user, "Chuck", "Norris"]
+    #     ]
+    #   end
+    #
+    #   def first_children
+    #     [
+    #       [:first_sub1, "SubJoe1", "Doe"],
+    #       [:first_sub2, "SubJoe2", "Doe"]
     #     ]
     #   end
     #
@@ -136,6 +144,16 @@ module CWM
     #   cell(icon("/tmp/cool_icon.png"), "Really cool!!!")
     def cell(*args)
       Yast::Term.new(:cell, *args)
+    end
+
+    # helper to create a {TableItem}
+    # @param args content of item
+    # @note Not to be confused with the UI shortcut `Item`
+    #
+    # @example
+    #   item(:joe, ["Joe", "Doe"], children: [[:joeson, "Joeson", "Doe"]], open: false)
+    def item(*args)
+      TableItem.new(*args)
     end
 
     # helper to say if table have multiselection

--- a/library/cwm/test/table_test.rb
+++ b/library/cwm/test/table_test.rb
@@ -15,7 +15,7 @@ describe CWM::Table do
     def items
       [
         [:one, "one", "eins"],
-        [:two, "two", "zwei"]
+        item(:two, ["two", "zwei"])
       ]
     end
   end


### PR DESCRIPTION
This replaces #1099.

Adds a new `TreeItem` class that can be used to specify nested items.

See https://trello.com/c/g0CpGq6T/1915-3-partitioner-nested-tables

This is how `examples/object_api_table.rb` looks like now, after adding a second table to it with nested elements:

![object_api_table](https://user-images.githubusercontent.com/3638289/96114692-3d618400-0ee6-11eb-9503-57e293a25e3b.png)
