### PR TITLE
CWM ComboBox: Query current items when extending the list with a new value.

### DIFF
--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -57,6 +57,13 @@ module CWM
       []
     end
 
+    # List the current items offered in the widget
+    #
+    # @return [Array<Array(String,String)>]
+    def current_items
+      Yast::UI.QueryWidget(Id(widget_id), :Items)
+    end
+
     # @return [WidgetHash]
     def cwm_definition
       super.merge(
@@ -194,7 +201,8 @@ module CWM
     #
     # @param val [Object] Value to assign to the widget
     def value=(val)
-      change_items([[val, val]] + items) if editable? && !items.map(&:first).include?(val)
+      change_items([[val, val]] + current_items) if editable? && !current_items.map(&:first).include?(val)
+
       self.orig_value = val
     end
 

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -140,6 +140,10 @@ describe CWM::ComboBox do
     describe "when the widget is editable" do
       subject { MountPointSelector.new }
 
+      before do
+        allow(subject).to receive(:current_items).and_return(subject.items)
+      end
+
       it "adds the given value to the list of items" do
         expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
         subject.value = "/srv"

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov  5 09:08:49 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- CWM ComboBox: query the current items offered by the widget when
+  the list of items is extended by a new value (bsc#1177137)
+- 4.3.39
+
+-------------------------------------------------------------------
 Tue Oct 20 13:11:41 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added support for nested items in CWM::Table (bsc#1176402)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.38
+Version:        4.3.39
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

When the user scan the available WiFI networks, the ComboBox is not populated with the results but only offers the orginal selection.

- https://bugzilla.suse.com/show_bug.cgi?id=1177137

## Solution

Query the list of items offered by the ComboBox in order to extend it with a new value.