### PR TITLE
Fix #current_items

### DIFF
--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -61,7 +61,7 @@ module CWM
     #
     # @return [Array<Array(String,String)>]
     def current_items
-      Yast::UI.QueryWidget(Id(widget_id), :Items)
+      Yast::UI.QueryWidget(Id(widget_id), :Items) || []
     end
 
     # @return [WidgetHash]

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -140,20 +140,29 @@ describe CWM::ComboBox do
     describe "when the widget is editable" do
       subject { MountPointSelector.new }
 
-      before do
-        allow(subject).to receive(:current_items).and_return(subject.items)
+      context "and there is no current items" do
+        it "adds the given value" do
+          expect(subject).to receive(:change_items).with([["/srv", "/srv"]])
+          subject.value = "/srv"
+        end
       end
 
-      it "adds the given value to the list of items" do
-        expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
-        subject.value = "/srv"
+      context "and there are current items" do
+        before do
+          allow(subject).to receive(:current_items).and_return(subject.items)
+        end
+
+        it "adds the given value to the current list of items" do
+          expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
+          subject.value = "/srv"
+        end
       end
     end
 
     describe "when the widget is not editable" do
       subject { SelectorWithoutOpt.new }
 
-      it "does not add the given value to the list of items" do
+      it "does not add the given value to the current list of items" do
         expect(subject).to_not receive(:change_items)
         subject.value = "/srv"
       end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov  6 22:40:12 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Ensure #current_items always returns a list.
+- Related to bsc#1177137.
+- 4.3.40
+
+-------------------------------------------------------------------
 Thu Nov  5 09:08:49 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - CWM ComboBox: query the current items offered by the widget when

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.39
+Version:        4.3.40
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Last changes in CWM (see https://github.com/yast/yast-yast2/pull/1113) can make unit tests to fail. The method `#current_items` returns nil in unit tests, so the test will fail when `ComboBox#value=` tries to map over nil.

See https://github.com/yast/yast-yast2/pull/1113#pullrequestreview-525536006.

## Solution

Ensure that `#current_items` always returns a list.
