### PR TITLE
Propose hibernation

### DIFF
--- a/library/control/src/modules/ProductFeatures.rb
+++ b/library/control/src/modules/ProductFeatures.rb
@@ -72,7 +72,8 @@ module Yast
           "base_product_license_directory"  => "/usr/share/licenses/product/base/",
           "full_system_media_name"          => "",
           "full_system_download_url"        => "",
-          "save_y2logs"                     => true
+          "save_y2logs"                     => true,
+          "propose_hibernate"               => true
         },
         "partitioning"             => {
           "use_flexible_partitioning"    => false,

--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -57,6 +57,7 @@ module Yast
       Yast.import "Popup"
       Yast.import "Stage"
       Yast.import "FileUtils"
+      Yast.import "ProductFeatures"
 
       textdomain "base"
 
@@ -550,6 +551,19 @@ module Yast
         Popup.Message(_("Reboot your system\nto activate the new kernel.\n"))
       end
       @inform_about_kernel_change
+    end
+
+    # gets if YaST should propose hibernation aka Kernel resume parameter
+    # @return [Boolean] true if hibernation should be proposed
+    def propose_hibernation?
+      # Do not support s390. (jsc#SLE-6926)
+      return false unless Arch.i386 || Arch.x86_64
+      # Do not propose resume on virtuals (jsc#SLE-12280)
+      return false if Arch.is_kvm || Arch.is_xenU
+      # For some products it does not make sense to have hibernations (jsc#SLE-12280)
+      return false unless ProductFeatures.GetBooleanFeature("globals", "propose_hibernation")
+
+      true
     end
 
     publish function: :AddCmdLine, type: "void (string, string)"

--- a/library/system/test/kernel_test.rb
+++ b/library/system/test/kernel_test.rb
@@ -259,13 +259,13 @@ describe Yast::Kernel do
       context "on real hardware" do
         before do
           allow(Yast::Arch).to receive(:is_kvm).and_return(false)
-          allow(Yast::Arch).to receive(:is_domU).and_return(false)
+          allow(Yast::Arch).to receive(:is_xenU).and_return(false)
         end
 
         context "when product does not want hibernation proposal" do
           before do
             allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
-              .with("general", "propose_hibernation").and_return(false)
+              .with("globals", "propose_hibernation").and_return(false)
           end
 
           it "returns false" do
@@ -276,7 +276,7 @@ describe Yast::Kernel do
         context "when product wants hibernation proposal" do
           before do
             allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
-              .with("general", "propose_hibernation").and_return(true)
+              .with("globals", "propose_hibernation").and_return(true)
           end
 
           it "returns true" do

--- a/library/system/test/kernel_test.rb
+++ b/library/system/test/kernel_test.rb
@@ -229,4 +229,61 @@ describe Yast::Kernel do
       end
     end
   end
+
+  describe ".propose_hibernation?" do
+    context "on non-intel architectures" do
+      before do
+        allow(Yast::Arch).to receive(:architecture).and_return("s390_64")
+      end
+
+      it "returns false" do
+        expect(subject.propose_hibernation?).to eq false
+      end
+    end
+
+    context "on intel architecture" do
+      before do
+        allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
+      end
+
+      context "on virtual machine" do
+        before do
+          allow(Yast::Arch).to receive(:is_kvm).and_return(true)
+        end
+
+        it "returns false" do
+          expect(subject.propose_hibernation?).to eq false
+        end
+      end
+
+      context "on real hardware" do
+        before do
+          allow(Yast::Arch).to receive(:is_kvm).and_return(false)
+          allow(Yast::Arch).to receive(:is_domU).and_return(false)
+        end
+
+        context "when product does not want hibernation proposal" do
+          before do
+            allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+              .with("general", "propose_hibernation").and_return(false)
+          end
+
+          it "returns false" do
+            expect(subject.propose_hibernation?).to eq false
+          end
+        end
+
+        context "when product wants hibernation proposal" do
+          before do
+            allow(Yast::ProductFeatures).to receive(:GetBooleanFeature)
+              .with("general", "propose_hibernation").and_return(true)
+          end
+
+          it "returns true" do
+            expect(subject.propose_hibernation?).to eq true
+          end
+        end
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Nov 11 22:25:45 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- add methods to decide if hibernation should be proposed
+  (jsc#SLE-12280)
+- 4.3.41
+
+-------------------------------------------------------------------
 Fri Nov  6 22:40:12 UTC 2020 - José Iván López González <jlopez@suse.com>
 
 - Ensure #current_items always returns a list.

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.40
+Version:        4.3.41
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
add option to allow product to specify if it should propose hibernation or not.
trello https://trello.com/c/ULBrtwpz/2144-3-couldhave-hibernation-proposed-by-installer-bootloader
jira https://jira.suse.com/browse/SLE-12280
related PR: https://github.com/yast/yast-installation-control/pull/104