### PR TITLE
Revert current items

### DIFF
--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -61,7 +61,7 @@ module CWM
     #
     # @return [Array<Array(String,String)>]
     def current_items
-      Yast::UI.QueryWidget(Id(widget_id), :Items) || []
+      Yast::UI.QueryWidget(Id(widget_id), :Items)
     end
 
     # @return [WidgetHash]

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -57,13 +57,6 @@ module CWM
       []
     end
 
-    # List the current items offered in the widget
-    #
-    # @return [Array<Array(String,String)>]
-    def current_items
-      Yast::UI.QueryWidget(Id(widget_id), :Items)
-    end
-
     # @return [WidgetHash]
     def cwm_definition
       super.merge(
@@ -201,8 +194,7 @@ module CWM
     #
     # @param val [Object] Value to assign to the widget
     def value=(val)
-      change_items([[val, val]] + current_items) if editable? && !current_items.map(&:first).include?(val)
-
+      change_items([[val, val]] + items) if editable? && !items.map(&:first).include?(val)
       self.orig_value = val
     end
 

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -140,10 +140,6 @@ describe CWM::ComboBox do
     describe "when the widget is editable" do
       subject { MountPointSelector.new }
 
-      before do
-        allow(subject).to receive(:current_items).and_return(subject.items)
-      end
-
       it "adds the given value to the list of items" do
         expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
         subject.value = "/srv"

--- a/library/cwm/test/common_widgets_test.rb
+++ b/library/cwm/test/common_widgets_test.rb
@@ -140,29 +140,20 @@ describe CWM::ComboBox do
     describe "when the widget is editable" do
       subject { MountPointSelector.new }
 
-      context "and there is no current items" do
-        it "adds the given value" do
-          expect(subject).to receive(:change_items).with([["/srv", "/srv"]])
-          subject.value = "/srv"
-        end
+      before do
+        allow(subject).to receive(:current_items).and_return(subject.items)
       end
 
-      context "and there are current items" do
-        before do
-          allow(subject).to receive(:current_items).and_return(subject.items)
-        end
-
-        it "adds the given value to the current list of items" do
-          expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
-          subject.value = "/srv"
-        end
+      it "adds the given value to the list of items" do
+        expect(subject).to receive(:change_items).with([["/srv", "/srv"], ["/", "/ (root)"]])
+        subject.value = "/srv"
       end
     end
 
     describe "when the widget is not editable" do
       subject { SelectorWithoutOpt.new }
 
-      it "does not add the given value to the current list of items" do
+      it "does not add the given value to the list of items" do
         expect(subject).to_not receive(:change_items)
         subject.value = "/srv"
       end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 24 22:03:19 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- CWM ComboBox: reverted the addition of the current_items method
+  (bsc#1177137)
+- 4.3.42
+
+-------------------------------------------------------------------
 Wed Nov 11 22:25:45 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - add methods to decide if hibernation should be proposed

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.41
+Version:        4.3.42
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

A [bug](https://bugzilla.suse.com/show_bug.cgi?id=1178832) was reported recently as consequence of #1044 . The problem is that when the ComboBox is editable and the value is not present in the list of items, the list of items is modified using `change_items` with the original items, a list that could have been modified like it is in the [yast-network essid widget](https://github.com/yast/yast-network/blob/941f20ab040e60fccbaf52bf7cf5261c629adcd3/src/lib/y2network/widgets/wireless_essid.rb#L83).

So, it was proposed to check the current widget items instead of the items list but as @shundhammer  pointed in https://bugzilla.suse.com/show_bug.cgi?id=1178832#c21, we created and inconsistency as we were not converting the list of `Items` to an `Array<string, string>`.

## Solution 

Revert the addition of the current_items method and fix the bug reported modifying [yast2-network](https://github.com/yast/yast-network/pull/1123) directly.