### PR TITLE
adapt PopupClass to use autwrap

### DIFF
--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -91,7 +91,7 @@ module Yast
             VSpacing(0.2),
             richtext ? rt : Left(Label(Opt(:autoWrap), message)),
             VSpacing(0.2),
-            (!label.nil? && label != "") ? Label(Id(:label), Opt(:autoWrap), label) : Empty()
+            (!label.nil? && label != "") ? Label(Id(:label), label) : Empty()
           )
         ) # no headline
       else
@@ -100,7 +100,7 @@ module Yast
           VBox(
             richtext ? rt : VCenter(Label(Opt(:autoWrap), message)),
             VSpacing(0.2),
-            (!label.nil? && label != "") ? Label(Id(:label), Opt(:autoWrap), label) : Empty()
+            (!label.nil? && label != "") ? Label(Id(:label), label) : Empty()
           )
         )
       end

--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -89,18 +89,18 @@ module Yast
           VBox(
             Left(Heading(headline)),
             VSpacing(0.2),
-            richtext ? rt : Left(Label(message)),
+            richtext ? rt : Left(Label(Opt(:autoWrap), message)),
             VSpacing(0.2),
-            (!label.nil? && label != "") ? Label(Id(:label), label) : Empty()
+            (!label.nil? && label != "") ? Label(Id(:label), Opt(:autoWrap), label) : Empty()
           )
         ) # no headline
       else
         VBox(
           VSpacing(0.4),
           VBox(
-            richtext ? rt : VCenter(Label(message)),
+            richtext ? rt : VCenter(Label(Opt(:autoWrap), message)),
             VSpacing(0.2),
-            (!label.nil? && label != "") ? Label(Id(:label), label) : Empty()
+            (!label.nil? && label != "") ? Label(Id(:label), Opt(:autoWrap), label) : Empty()
           )
         )
       end
@@ -1542,7 +1542,7 @@ module Yast
           HSpacing(1),
           VBox(
             VSpacing(0.2),
-            Label(message),
+            Label(Opt(:autoWrap), message),
             HCenter(Label(Id(:remaining_time), Ops.add("", timeout_seconds))),
             ButtonBox(
               PushButton(Id(:timed_stop), Opt(:customButton), Label.StopButton),

--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -87,9 +87,9 @@ module Yast
         VBox(
           VSpacing(0.4),
           VBox(
-            Left(Heading(headline)),
+            Left(MarginBox(5, 5, Heading(headline))),
             VSpacing(0.2),
-            richtext ? rt : Left(Label(Opt(:autoWrap), message)),
+            richtext ? rt : Left(MinWidth(40, Label(Opt(:autoWrap), message))),
             VSpacing(0.2),
             (!label.nil? && label != "") ? Label(Id(:label), label) : Empty()
           )
@@ -98,7 +98,7 @@ module Yast
         VBox(
           VSpacing(0.4),
           VBox(
-            richtext ? rt : VCenter(Label(Opt(:autoWrap), message)),
+            richtext ? rt : VCenter(MinWidth(40, Label(Opt(:autoWrap), message))),
             VSpacing(0.2),
             (!label.nil? && label != "") ? Label(Id(:label), label) : Empty()
           )


### PR DESCRIPTION
trello: https://trello.com/c/uIRLC469/1952-3-use-autowrap

Notes:
Autowrap Does not work with any paragraphs. See:

without AutoWrap:
![no_autowrap3](https://user-images.githubusercontent.com/478871/101378577-8cf37900-38b3-11eb-9756-c254dd69ace9.png)
![no_autowrap2](https://user-images.githubusercontent.com/478871/101378580-8d8c0f80-38b3-11eb-8791-9e289c820d88.png)
![no_autowrap1](https://user-images.githubusercontent.com/478871/101378585-8e24a600-38b3-11eb-8677-3d06affab881.png)


with AutoWrap:
![autowrap3](https://user-images.githubusercontent.com/478871/101378613-9a106800-38b3-11eb-83a6-2b04fc42c67e.png)
![autowrap2](https://user-images.githubusercontent.com/478871/101378615-9aa8fe80-38b3-11eb-83df-53ef45df6cec.png)
![autowrap1](https://user-images.githubusercontent.com/478871/101378616-9aa8fe80-38b3-11eb-808a-2a69393f6604.png)
