### PR TITLE
bsc#1180142: do not use 'installation-helper' to create snapshots

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -253,6 +253,9 @@ module Yast2
         raise SnapperNotConfigured unless configured?
 
         cmd = LIST_SNAPSHOTS_CMD.dup
+        # Add additional options only when running in normal model. Otherwise,
+        # the snapper version in the chroot might not understand them (e.g.,
+        # when upgrading from SLE 12 to SLE 15).
         cmd << " --disable-used-space" if Yast::Mode.normal
 
         out = Yast::SCR.Execute(

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -74,7 +74,7 @@ module Yast2
 
     FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --root=%{root} list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
     CREATE_SNAPSHOT_CMD = "/usr/bin/snapper --no-dbus --root=%{root} create --type %{snapshot_type} --description %{description}".freeze
-    LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list --disable-used-space".freeze
+    LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list".freeze
     VALID_LINE_REGEX = /\A\s*\d+[-+*]?\s*\|\s*\w+/
 
     # Predefined snapshot cleanup strategies (the user can define custom ones, too)
@@ -252,9 +252,12 @@ module Yast2
       def all
         raise SnapperNotConfigured unless configured?
 
+        cmd = LIST_SNAPSHOTS_CMD.dup
+        cmd << " --disable-used-space" if Yast::Mode.normal
+
         out = Yast::SCR.Execute(
           Yast::Path.new(".target.bash_output"),
-          format(LIST_SNAPSHOTS_CMD, root: target_root.shellescape)
+          format(cmd, root: target_root.shellescape)
         )
         lines = out["stdout"].lines.grep(VALID_LINE_REGEX) # relevant lines from output.
         log.info("Retrieving snapshots list: #{LIST_SNAPSHOTS_CMD} returned: #{out}")

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -73,7 +73,7 @@ module Yast2
     Yast.import "Mode"
 
     FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --root=%{root} list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
-    CREATE_SNAPSHOT_CMD = "/usr/lib/snapper/installation-helper --step 5 --root-prefix=%{root} --snapshot-type %{snapshot_type} --description %{description}".freeze
+    CREATE_SNAPSHOT_CMD = "/usr/bin/snapper --no-dbus --root=%{root} create --type %{snapshot_type} --description %{description}".freeze
     LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list --disable-used-space".freeze
     VALID_LINE_REGEX = /\A\s*\d+[-+*]?\s*\|\s*\w+/
 
@@ -318,7 +318,7 @@ module Yast2
         out = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), cmd)
 
         if out["exit"] == 0
-          find(out["stdout"].to_i) # The CREATE_SNAPSHOT_CMD returns the number of the new snapshot.
+          all.last
         else
           log.error "Snapshot could not be created: #{cmd} returned: #{out}"
           raise SnapshotCreationFailed

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -376,6 +376,34 @@ module Yast2
 
       # Parses the snapshots list
       #
+      # The snapshots list is a table like the following one:
+      #
+      #   # | Type   | Pre # | Date                            | User | Cleanup | Description           | Userdata
+      # ----+--------+-------+---------------------------------+------+---------+-----------------------+--------------
+      #  0  | single |       |                                 | root |         | current               |
+      #  1* | single |       | Wed 20 Jan 2021 09:57:01 PM WET | root |         | first root filesystem |
+      #  2  | single |       | Wed 20 Jan 2021 10:09:46 PM WET | root | number  | after installation    | important=yes
+      #
+      # This method returns an array of hashes containing the information from
+      # the previous table:
+      #
+      # @example Parsing result ouput
+      #   [
+      #     {
+      #       "#"            => "0",
+      #       "Type"         => "single",
+      #       "Pre #"        => "",
+      #       "Date"         => "",
+      #       "User"         => "root",
+      #       "Cleanup"      => "",
+      #       "Description"  => "current",
+      #       "Userdata"     => ""},
+      #       # ...
+      #     }
+      #   ]
+      #
+      # Not that values are not processed.
+      #
       # @param content [String] Snapshots list content
       # @return Array<Hash> An array of hashes containing the data for each snapshot
       def parse_snapshots_list(content)

--- a/library/system/src/lib/yast2/fs_snapshot_store.rb
+++ b/library/system/src/lib/yast2/fs_snapshot_store.rb
@@ -28,6 +28,8 @@ module Yast2
   # Goal of this module is to provide easy to use api to store id of pre
   # snapshots, so post snapshots can be then easy to make.
   module FsSnapshotStore
+    class IOError < StandardError; end
+
     # Stores pre snapshot with given id and purpose
     # @param[String] purpose of snapshot like "upgrade"
     # @raise[RuntimeError] if writing to file failed
@@ -38,7 +40,7 @@ module Yast2
         snapshot_id.to_s
       )
 
-      raise "Failed to write Pre Snapshot id for #{purpose} to store. See logs." unless result
+      raise IOError, "Failed to write Pre Snapshot id for #{purpose} to store. See logs." unless result
     end
 
     # Loads id of pre snapshot for given purpose
@@ -52,7 +54,7 @@ module Yast2
       )
 
       if !content || content !~ /^\d+$/
-        raise "Failed to read Pre Snapshot id for #{purpose} from store. See logs."
+        raise IOError, "Failed to read Pre Snapshot id for #{purpose} from store. See logs."
       end
 
       content.to_i

--- a/library/system/test/fs_snapshot_store_test.rb
+++ b/library/system/test/fs_snapshot_store_test.rb
@@ -22,7 +22,7 @@ describe Yast2::FsSnapshotStore do
         "42"
       ).and_return(nil)
 
-      expect { described_class.save("test", 42) }.to raise_error(/Failed to write/)
+      expect { described_class.save("test", 42) }.to raise_error(Yast2::FsSnapshotStore::IOError)
     end
   end
 
@@ -42,7 +42,7 @@ describe Yast2::FsSnapshotStore do
         "/var/lib/YaST2/pre_snapshot_test.id"
       ).and_return(nil)
 
-      expect { described_class.load("test") }.to raise_error(/Failed to read/)
+      expect { described_class.load("test") }.to raise_error(Yast2::FsSnapshotStore::IOError)
     end
 
     it "raises exception if file content is not number" do
@@ -51,7 +51,7 @@ describe Yast2::FsSnapshotStore do
         "/var/lib/YaST2/pre_snapshot_test.id"
       ).and_return("blabla\n")
 
-      expect { described_class.load("test") }.to raise_error(/Failed to read/)
+      expect { described_class.load("test") }.to raise_error(Yast2::FsSnapshotStore::IOError)
     end
   end
 

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -11,6 +11,7 @@ describe Yast2::FsSnapshot do
   FIND_CONFIG = "/usr/bin/snapper --no-dbus --root=/ list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
   FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
   LIST_SNAPSHOTS = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list --disable-used-space".freeze
+  LIST_SNAPSHOTS_INSTALLATION = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list".freeze
 
   let(:dummy_snapshot) { double("snapshot", number: 2) }
 
@@ -437,6 +438,21 @@ describe Yast2::FsSnapshot do
 
         it "should return an empty array" do
           expect(described_class.all).to eq([])
+        end
+      end
+
+      context "when not running in normal mode" do
+        let(:output) { "" }
+
+        before do
+          allow(Yast::Mode).to receive(:normal).and_return(false)
+        end
+
+        it "do not use additional snapper options" do
+          expect(Yast::SCR).to receive(:Execute)
+            .with(path(".target.bash_output"), LIST_SNAPSHOTS_INSTALLATION)
+            .and_return("stdout" => output, "exit" => 0)
+          described_class.all
         end
       end
     end

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -12,7 +12,7 @@ describe Yast2::FsSnapshot do
   FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
   LIST_SNAPSHOTS = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list --disable-used-space".freeze
 
-  let(:dummy_snapshot) { double("snapshot") }
+  let(:dummy_snapshot) { double("snapshot", number: 2) }
 
   before do
     # reset configured cache
@@ -145,14 +145,15 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".create_single" do
-    CREATE_SINGLE_SNAPSHOT = "/usr/lib/snapper/installation-helper --step 5 "\
-      "--root-prefix=/ --snapshot-type single --description some-description".freeze
+    CREATE_SINGLE_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
+      "--root=/ create --type single --description some-description".freeze
     OPTION_CLEANUP_NUMBER = " --cleanup number".freeze
     OPTION_IMPORTANT = " --userdata \"important=yes\"".freeze
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
       allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:single).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:all).and_return([dummy_snapshot])
     end
 
     context "when snapper is configured" do
@@ -167,7 +168,7 @@ describe Yast2::FsSnapshot do
       end
 
       context "when snapshot creation fails" do
-        let(:output) { { "stdout" => "", "exit" => 1 } }
+        let(:output) { { "exit" => 1 } }
 
         it "logs the error and returns nil" do
           expect(logger).to receive(:error).with(/Snapshot could not be created/)
@@ -177,23 +178,19 @@ describe Yast2::FsSnapshot do
       end
 
       context "when snapshot creation is successful" do
-        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:output) { { "exit" => 0 } }
 
         it "returns the created snapshot" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description")
           expect(snapshot).to be(dummy_snapshot)
         end
       end
 
       context "when a cleanup strategy is set" do
-        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:output) { { "exit" => 0 } }
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
 
         it "creates a snapshot with that strategy" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description", cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -204,8 +201,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_IMPORTANT }
 
         it "creates a snapshot marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description", important: true)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -216,8 +211,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
 
         it "creates a snapshot with that strategy that is marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description", cleanup: :number, important: true)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -245,12 +238,13 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".create_pre" do
-    CREATE_PRE_SNAPSHOT = "/usr/lib/snapper/installation-helper --step 5 "\
-      "--root-prefix=/ --snapshot-type pre --description some-description".freeze
+    CREATE_PRE_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
+      "--root=/ create --type pre --description some-description".freeze
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
       allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:around).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:all).and_return([dummy_snapshot])
     end
 
     context "when snapper is configured" do
@@ -265,7 +259,7 @@ describe Yast2::FsSnapshot do
       end
 
       context "when snapshot creation fails" do
-        let(:output) { { "stdout" => "", "exit" => 1 } }
+        let(:output) { { "exit" => 1 } }
 
         it "logs the error and returns nil" do
           expect(logger).to receive(:error).with(/Snapshot could not be created/)
@@ -278,8 +272,6 @@ describe Yast2::FsSnapshot do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
 
         it "returns the created snapshot" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description")
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -290,8 +282,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
 
         it "creates a pre snapshot with that strategy" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description", cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -302,8 +292,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT }
 
         it "creates a pre snapshot marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description", important: true)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -314,8 +302,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
 
         it "creates a pre snapshot with that strategy that is marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description", important: true, cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -343,9 +329,9 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".create_post" do
-    CREATE_POST_SNAPSHOT = "/usr/lib/snapper/installation-helper --step 5 "\
-      "--root-prefix=/ --snapshot-type post --description some-description "\
-      "--pre-num 2".freeze
+    CREATE_POST_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
+      "--root=/ create --type post --description some-description "\
+      "--pre-num 1".freeze
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
@@ -356,16 +342,18 @@ describe Yast2::FsSnapshot do
       let(:configured) { true }
       let(:create_snapshot) { true }
 
-      let(:pre_snapshot) { double("snapshot", snapshot_type: :pre, number: 2) }
+      let(:pre_snapshot) { double("snapshot", snapshot_type: :pre, number: 1) }
       let(:snapshots) { [pre_snapshot] }
-      let(:output) { { "stdout" => "3", "exit" => 0 } }
+      let(:output) { { "exit" => 0 } }
 
       before do
         allow(Yast::SCR).to receive(:Execute)
           .with(path(".target.bash_output"), CREATE_POST_SNAPSHOT)
           .and_return(output)
         allow(Yast2::FsSnapshot).to receive(:all)
-          .and_return(snapshots)
+          .and_return([pre_snapshot])
+        allow(Yast2::FsSnapshot).to receive(:all)
+          .and_return([pre_snapshot, dummy_snapshot])
       end
 
       context "when previous snapshot exists" do
@@ -373,12 +361,8 @@ describe Yast2::FsSnapshot do
 
         context "when snapshot creation is successful" do
           it "returns the created snapshot" do
-            allow(Yast2::FsSnapshot).to receive(:find).with(pre_snapshot.number)
-              .and_return(pre_snapshot)
-            expect(Yast2::FsSnapshot).to receive(:find).with(3)
-              .and_return(dummy_snapshot)
             expect(described_class.create_post("some-description", pre_snapshot.number))
-              .to be(dummy_snapshot)
+              .to eq(dummy_snapshot)
           end
         end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Dec 21 10:27:21 UTC 2020 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not use the 'installation-helper' binary to create snapshots
+  during installation or offline upgrade (bsc#1180142).
+- Add a new exception to properly handle exceptions
+  when reading/writing snapshots numbers (related to bsc#1180142).
+- 4.1.80
+
+-------------------------------------------------------------------
 Tue Jul  7 09:48:04 CEST 2020 - schubi@suse.de
 
 - Command line interface: Do not start an UI while evaluating

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.79
+Version:        4.1.80
 
 Release:        0
 Summary:        YaST2 - Main Package


### PR DESCRIPTION
YaST uses an especial `installation-helper` binary to configure snapper and create snapshots during installation and offline upgrade. However, it does not work with LVM (at least not in all cases). This PR changes the `FsSnapshot` class to use the `snapper` binary (using the `--no-dbus` option) to create snapshots. The configuration phase is still done through `installation-helper`.

Additionally, it introduces a new kind of exception so errors when creating snapshots can be properly handled.

* Related to: https://github.com/yast/yast-update/pull/162 and https://github.com/yast/yast-installation/pull/901.