### PR TITLE
Ensure the libzypp target is initialized (bsc#1179773)

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1678,7 +1678,11 @@ module Yast
       downloader = ::Packages::PackageDownloader.new(repo_id, package)
 
       Tempfile.open("downloaded-package-") do |tmp|
+        # libzypp needs the target for verifying the GPG signatures of the downloaded packages
+        Pkg.TargetInitialize("/") if Stage.initial
         downloader.download(tmp.path)
+        Pkg.TargetFinish() if Stage.initial
+
         extract(tmp.path, dir)
         # the RPM package file is not needed after extracting it's content,
         # remove it explicitly now, do not wait for the garbage collector

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 11 13:20:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Ensure the libzypp target is initialized when downloading
+  the skelcd packages (to verify the GPG signatures) (bsc#1179773)
+- 4.2.89
+
+-------------------------------------------------------------------
 Mon Dec 14 13:42:24 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Log more details when several resolvables (instead of a single

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.88
+Version:        4.2.89
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Ensure the libzypp target is initialized when downloading the skelcd packages to verify the GPG signatures
- See https://bugzilla.suse.com/show_bug.cgi?id=1179773
- From the `y2log`:
  ```
  2021-01-11 06:17:00 <1> install(8866) [Ruby] modules/PackageCallbacks.rb:199 DoneProvide: 3,
  skelcd-control-SLES4SAP-15.2.2-3.3.2.x86_64 (SelfUpdate0): Signature verification failed [5-File
  does not exist or signature can't be checked]
  OOps. Target is not initialized!
  ```
- Libzypp needs the target for loading the known GPG keys
- I'm not sure whether the code can be used in installed system, I used `if Stage.initial` to apply this fix only in installation

![sles4sap_failed_verification](https://user-images.githubusercontent.com/907998/104200084-83b47980-5428-11eb-9dac-334a44d368d7.png)

## Testing

- Tested manually, after patching the installer the error popup is not displayed anymore.
