### PR TITLE
Keep the libzypp target open to verify other packages (bsc#1180858)

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1681,7 +1681,6 @@ module Yast
         # libzypp needs the target for verifying the GPG signatures of the downloaded packages
         Pkg.TargetInitialize("/") if Stage.initial
         downloader.download(tmp.path)
-        Pkg.TargetFinish() if Stage.initial
 
         extract(tmp.path, dir)
         # the RPM package file is not needed after extracting it's content,

--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1678,7 +1678,8 @@ module Yast
       downloader = ::Packages::PackageDownloader.new(repo_id, package)
 
       Tempfile.open("downloaded-package-") do |tmp|
-        # libzypp needs the target for verifying the GPG signatures of the downloaded packages
+        # libzypp needs the target for verifying the GPG signatures of the downloaded packages,
+        # keep the target initialized, it might be needed later for verifying other packages
         Pkg.TargetInitialize("/") if Stage.initial
         downloader.download(tmp.path)
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 13 16:03:51 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Keep the libzypp target open to verify other packages
+  (bsc#1180858, related to the previous fix bsc#1179773)
+- 4.2.90
+
+-------------------------------------------------------------------
 Mon Jan 11 13:20:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Ensure the libzypp target is initialized when downloading

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.89
+Version:        4.2.90
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- This is a fix up for the previous PR #1127 
- The previous fix caused a regression in SP3, let's fix it also in SP2 (where it will be released as a maintenance update)
- https://bugzilla.suse.com/show_bug.cgi?id=1180858