### PR TITLE
[master] Keep the libzypp target open to verify other packages

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -1692,10 +1692,10 @@ module Yast
       downloader = ::Packages::PackageDownloader.new(repo_id, package)
 
       Tempfile.open("downloaded-package-") do |tmp|
-        # libzypp needs the target for verifying the GPG signatures of the downloaded packages
+        # libzypp needs the target for verifying the GPG signatures of the downloaded packages,
+        # keep the target initialized, it might be needed later for verifying other packages
         Pkg.TargetInitialize("/") if Stage.initial
         downloader.download(tmp.path)
-        Pkg.TargetFinish() if Stage.initial
 
         extract(tmp.path, dir)
         # the RPM package file is not needed after extracting it's content,

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 13 16:03:51 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Keep the libzypp target open to verify other packages
+  (bsc#1180858, related to the previous fix bsc#1179773)
+- 4.3.49
+
+-------------------------------------------------------------------
 Mon Jan 11 16:40:37 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Ensure the libzypp target is initialized when downloading

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.48
+Version:        4.3.49
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Just merging #1129 from SP2 to `master`
- https://bugzilla.suse.com/show_bug.cgi?id=1180858