### PR TITLE
Do not propose hibernation on virtual setups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     # just for easier debugging...
     - name: Inspect Installed Packages
@@ -42,7 +42,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Rubocop
       run: rake check:rubocop
@@ -54,7 +54,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Package Build
       run: yast-ci-ruby -o package
@@ -66,7 +66,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Yardoc
       run: yardoc
@@ -80,7 +80,7 @@ jobs:
     steps:
 
     - name: Git Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Perl Syntax
       run: yast-ci-ruby -o perl_syntax

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -343,6 +343,16 @@ module Yast
       @_is_laptop
     end
 
+    # Whether the system is running over a virtualized environment
+    #
+    # @return [Boolean]
+    def is_virtual
+      return @_is_virtual unless @_is_virtual.nil?
+
+      @_is_virtual = SCR.Read(path(".target.string"), "/proc/cpuinfo")
+        .to_s.match?("^flags.*hypervisor.*\n")
+    end
+
     # ************************************************************
     # UML stuff
 

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -17,6 +17,29 @@ describe Yast::Arch do
     load module_path
   end
 
+  describe ".is_virtual" do
+    before do
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast::Path.new(".target.string"), "/proc/cpuinfo").and_return(cpuinfo)
+    end
+
+    context "when running in a non virtualized environment" do
+      let(:cpuinfo) { "processor: 1\nflags: fpu vme de pse tsc msr pae mce\nmodel: 45" }
+
+      it "returns false" do
+        expect(Yast::Arch.is_virtual).to eq(false)
+      end
+    end
+
+    context "when running in a virtualized environment" do
+      let(:cpuinfo) { "processor: 1\nflags: fpu vme de hypervisor pse tsc msr pae mce\nmodel: 45" }
+
+      it "returns true" do
+        expect(Yast::Arch.is_virtual).to eq(true)
+      end
+    end
+  end
+
   describe ".is_xen" do
     around do |example|
       change_scr_root(File.join(GENERAL_DATA_PATH, "arch", scenario), &example)

--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -559,7 +559,7 @@ module Yast
       # Do not support s390. (jsc#SLE-6926)
       return false unless Arch.i386 || Arch.x86_64
       # Do not propose resume on virtuals (jsc#SLE-12280)
-      return false if Arch.is_kvm || Arch.is_xenU
+      return false if Arch.is_virtual
       # For some products it does not make sense to have hibernations (jsc#SLE-12280)
       return false unless ProductFeatures.GetBooleanFeature("globals", "propose_hibernation")
 

--- a/library/system/test/kernel_test.rb
+++ b/library/system/test/kernel_test.rb
@@ -248,7 +248,7 @@ describe Yast::Kernel do
 
       context "on virtual machine" do
         before do
-          allow(Yast::Arch).to receive(:is_kvm).and_return(true)
+          allow(Yast::Arch).to receive(:is_virtual).and_return(true)
         end
 
         it "returns false" do
@@ -258,8 +258,7 @@ describe Yast::Kernel do
 
       context "on real hardware" do
         before do
-          allow(Yast::Arch).to receive(:is_kvm).and_return(false)
-          allow(Yast::Arch).to receive(:is_xenU).and_return(false)
+          allow(Yast::Arch).to receive(:is_virtual).and_return(false)
         end
 
         context "when product does not want hibernation proposal" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 27 09:22:50 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Do not propose hibernation when running over a virtualized setup
+  (bsc#1180982).
+- 4.3.51
+
+-------------------------------------------------------------------
 Wed Jan 20 09:28:51 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed Resolvables class to uniqely identify the libzypp objects

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.50
+Version:        4.3.51
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
### Problem

The method `Kernel#propose_hibernation?` was returning *true* when the system is running over certain virtualized setups like *hyper-v*. This makes to *yast2-bootloader* to propose the `resume=` kernel parameter in such scenarios, , but it should not do it according to https://jira.suse.com/browse/SLE-12280.

* https://bugzilla.suse.com/show_bug.cgi?id=1180982
* https://trello.com/c/VkjmNIRr/2279-3-yast-bootloader-adds-the-resume-parameter-when-it-shouldnt


### Solution

Now `Kernel#propose_hibernation?` uses the new method `Arch#is_virtual?` to check whether the system is running on a virtualized setup, does not matter the specific virtualization technology. For now this is enough, but maybe in the future we might need a more fine grained detection. In that case, we could consider to use [*virt-what*](http://people.redhat.com/~rjones/virt-what/virt-what.txt) utility. For example, to check what is the specific virtualization technology in use (kvm, hyper-v, etc).
