### PR TITLE
Added supported migration "openSUSE Leap 15.3" -> SLES

### DIFF
--- a/library/packages/src/lib/y2packager/product_upgrade.rb
+++ b/library/packages/src/lib/y2packager/product_upgrade.rb
@@ -41,7 +41,10 @@ module Y2Packager
       # this one is used when openSUSE is not available, e.g. booting SLE medium
       # (moreover the openSUSE medium should contain only one product so that
       # product should be used unconditionally)
-      ["openSUSE"]                                                        => "SLES"
+      ["openSUSE"]                                                        => "SLES",
+      # (installed) openSUSE Leap => (available) SLES,
+      # same as above, in 15.3+ the product has been renamed from "openSUSE" to "Leap"
+      ["Leap"]                                                            => "SLES"
     }.freeze
 
     # This maps uses a list of installed products as the key and the removed products as a value.

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Feb  4 09:16:10 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added supported migration "openSUSE Leap 15.3" -> SLES
+  (in 15.3 the product has been renamed from "openSUSE" to "Leap")
+  (bsc#1181773)
+- 4.3.52
+
+-------------------------------------------------------------------
 Wed Jan 27 09:22:50 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Do not propose hibernation when running over a virtualized setup

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.51
+Version:        4.3.52
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1181773
- In Leap 15.3 the product has been renamed from `openSUSE` to `Leap` :scream: 
- I'll keep also the old openSUSE migration (just in case :smiley:)
- Manually tested by Luboš (https://bugzilla.suse.com/show_bug.cgi?id=1181773#c2)