### PR TITLE
Use the same command to list snapshots during installation

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -74,7 +74,7 @@ module Yast2
 
     FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --root=%{root} list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
     CREATE_SNAPSHOT_CMD = "/usr/bin/snapper --no-dbus --root=%{root} create --type %{snapshot_type} --description %{description}".freeze
-    LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list".freeze
+    LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list --disable-used-space".freeze
 
     # Predefined snapshot cleanup strategies (the user can define custom ones, too)
     CLEANUP_STRATEGY = { number: "number", timeline: "timeline" }.freeze
@@ -251,16 +251,8 @@ module Yast2
       def all
         raise SnapperNotConfigured unless configured?
 
-        cmd = LIST_SNAPSHOTS_CMD.dup
-        # Add additional options only when running in normal model. Otherwise,
-        # the snapper version in the chroot might not understand them (e.g.,
-        # when upgrading from SLE 12 to SLE 15).
-        cmd << " --disable-used-space" if Yast::Mode.normal
-
-        out = Yast::SCR.Execute(
-          Yast::Path.new(".target.bash_output"),
-          format(cmd, root: target_root.shellescape)
-        )
+        cmd = format(LIST_SNAPSHOTS_CMD, root: target_root.shellescape)
+        out = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), cmd)
         log.info("Retrieving snapshots list: #{cmd} returned: #{out}")
         return [] unless out["exit"].zero?
 

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -11,7 +11,6 @@ describe Yast2::FsSnapshot do
   FIND_CONFIG = "/usr/bin/snapper --no-dbus --root=/ list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
   FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
   LIST_SNAPSHOTS = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list --disable-used-space".freeze
-  LIST_SNAPSHOTS_INSTALLATION = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list".freeze
 
   let(:dummy_snapshot) { double("snapshot", number: 2) }
 
@@ -438,21 +437,6 @@ describe Yast2::FsSnapshot do
 
         it "should return an empty array" do
           expect(described_class.all).to eq([])
-        end
-      end
-
-      context "when not running in normal mode" do
-        let(:output) { "" }
-
-        before do
-          allow(Yast::Mode).to receive(:normal).and_return(false)
-        end
-
-        it "do not use additional snapper options" do
-          expect(Yast::SCR).to receive(:Execute)
-            .with(path(".target.bash_output"), LIST_SNAPSHOTS_INSTALLATION)
-            .and_return("stdout" => output, "exit" => 0)
-          described_class.all
         end
       end
     end


### PR DESCRIPTION
Simplify #1125. While merging the changes to SP2, I realized that it uses the snapper version which is shipped with the DVD, so it is compatible with the `--disable-used-space` option.