### PR TITLE
Fix bug introduced while adding auto wrapping

### DIFF
--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -442,7 +442,7 @@ module Yast
           CommandLine.Print(message_string)
         else
           timeout = (@timeout_messages.to_s.to_i > 0) ? @timeout_messages : 0
-          Yast2::Print.show(message_string, timeout: timeout)
+          Yast2::Popup.show(message_string, timeout: timeout)
         end
       end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 12 13:46:19 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Fixed bug introduced while adding auto wrapping (bsc#1179893)
+- 4.3.55
+
+-------------------------------------------------------------------
 Wed Feb 10 15:56:52 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Use Auto Wrapping of long lines for Yast2::Popup and Yast::Report

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.54
+Version:        4.3.55
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
#1122 introduced a bug in the Report module. See [here](https://github.com/yast/yast-yast2/pull/1122/files#diff-71d0b42ff18d870f2a798fdcfa236622d29ff278fb75e9a1a1d643e72d929d1cR445).

This should fix that bug.