### PR TITLE
[ProductControl] Ask if user would like to continue when client is missing

### DIFF
--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -1353,14 +1353,14 @@ module Yast
           Hooks.run("after_#{step_name}")
         else
           # Client not found. Ask the user if want to continue (related to bsc#1180954)
-          Builtins.y2error("Client '%1' not found", client_name)
+          log.error("Client '#{client_name}' not found")
 
           text = format(
             # TRANSLATORS: Message warning the user that a client is missing where %{client} is
             # replaced by the client name (e.g. "registration", "user")
             _(
               "Something went wrong and the expected '%{client}' dialog was not found.\n\n" \
-              "Would you like to continue anyway?"
+              "Would you like to skip dialog and continue anyway?"
             ),
             client: client_name
           )
@@ -1368,9 +1368,7 @@ module Yast
           continue = Yast2::Popup.show(text, buttons: :yes_no) == :yes
 
           if continue
-            Builtins.y2warning(
-              "Continuing the workflow after skipping the '%1' missing client", client_name
-            )
+            log.warning("Continuing after skipping the '#{client_name}' missing client")
             # If user decided to continue, uses the former_result (:next or :back)
             result = former_result
           else

--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -1353,6 +1353,8 @@ module Yast
           Hooks.run("after_#{step_name}")
         else
           # Client not found. Ask the user if want to continue (related to bsc#1180954)
+          Builtins.y2error("Client '%1' not found", client_name)
+
           text = format(
             # TRANSLATORS: Message warning the user that a client is missing where %{client} is
             # replaced by the client name (e.g. "registration", "user")
@@ -1365,8 +1367,16 @@ module Yast
 
           continue = Yast2::Popup.show(text, buttons: :yes_no) == :yes
 
-          # If user decided to continue, uses the former_result (:next or :back); :abort otherwise.
-          result = continue ? former_result : :abort
+          if continue
+            Builtins.y2warning(
+              "Continuing the workflow after skipping the '%1' missing client", client_name
+            )
+            # If user decided to continue, uses the former_result (:next or :back)
+            result = former_result
+          else
+            # :abort because user decided to not continue
+            result = :abort
+          end
         end
 
         Builtins.y2milestone("Calling %1 returned %2", argterm, result)

--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -29,6 +29,7 @@
 #
 require "yast"
 require "yast2/control_log_dir_rotator"
+require "yast2/popup"
 
 module Yast
   class ProductControlClass < Module
@@ -1336,16 +1337,37 @@ module Yast
           end
         end
 
-        Hooks.run("before_#{step_name}")
+        client_name = getClientName(step_name, step_execute)
 
-        result = WFM.CallFunction(getClientName(step_name, step_execute), args)
+        # Check if client exist before continuing
+        if WFM.ClientExists(client_name)
+          Hooks.run("before_#{step_name}")
 
-        # this code will be triggered before the red pop window appears on the user's screen
-        Hooks.run("installation_failure") if result == false
+          result = WFM.CallFunction(client_name, args)
 
-        result = Convert.to_symbol(result)
+          # This code will be triggered before the red pop window appears on the user's screen
+          Hooks.run("installation_failure") if result == false
 
-        Hooks.run("after_#{step_name}")
+          result = result.to_sym
+
+          Hooks.run("after_#{step_name}")
+        else
+          # Client not found. Ask the user if want to continue (related to bsc#1180954)
+          text = format(
+            # TRANSLATORS: Message warning the user that a client is missing where %{client} is
+            # replaced by the client name (e.g. "registration", "user")
+            _(
+              "Something went wrong and the expected '%{client}' dialog was not found.\n\n" \
+              "Would you like to continue anyway?"
+            ),
+            client: client_name
+          )
+
+          continue = Yast2::Popup.show(text, buttons: :yes_no) == :yes
+
+          # If user decided to continue, uses the former_result (:next or :back); :abort otherwise.
+          result = continue ? former_result : :abort
+        end
 
         Builtins.y2milestone("Calling %1 returned %2", argterm, result)
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  8 09:19:37 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Ask the user if would like to continue when an installation
+  client is missing (related to bsc#1180594).
+- 4.3.57
+
+-------------------------------------------------------------------
 Thu Mar  4 12:41:56 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix backward compatibility for focus parameter of

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.56
+Version:        4.3.57
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
### Problem

> Yast-firstboot executes the clients enabled in its control file. But it shows an exception error when a client is not available (e.g., because the package is not installed). — _**extracted from https://trello.com/c/xA1YyIdv/ (internal link) description**_

### Solution

**Do not crash**, by checking if the client exists and asking the user what to do (continue or not) when it does not.

* If user decides to continue, the workflow will continue to _:next_ or _:back_ client/step, depending on the previous result
* If not, the installation/firstboot workflow will be completely _:abort_

### Tests

Only tested manually, since adding unit tests for this complex part of the code if out of the scope of this PR.

### Screenshots

| Before | After |
|-|-|
| ![Screenshot_sle15sp3_2021-03-08_09:41:51](https://user-images.githubusercontent.com/1691872/110304053-0ace3a00-7ff3-11eb-9fc1-8a5f423f612f.png) | ![Screenshot_sle15sp3_2021-03-08_09:49:19](https://user-images.githubusercontent.com/1691872/110304504-96e06180-7ff3-11eb-99a9-1b3d4992692e.png) |



### Additional notes

After taking a look to the code, there are no doubts that [ProductControl.RunFrom](https://github.com/yast/yast-yast2/blob/4c985bb22eda5427a37b254609e9b9f822a43a1c/library/control/src/modules/ProductControl.rb#L1227-L1505) deserves a refactorization, getting rid of those _Builtins_ and extracting the logic to a specialized class. However, I conclude that postponing it for SP4 is a better idea.


---

Related links

* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1180954
* GitHub issues: https://github.com/yast/yast-firstboot/issues/116

