### PR TITLE
handle save_y2logs when content modified when creating tarball

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  8 16:41:27 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- save_y2logs: Make modified content of log files just warning
+  instead of fatal (bsc#1182710 see comment 2)
+- 4.3.58
+
+-------------------------------------------------------------------
 Mon Mar  8 09:19:37 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Ask the user if would like to continue when an installation

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.57
+Version:        4.3.58
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only

--- a/scripts/save_y2logs
+++ b/scripts/save_y2logs
@@ -142,10 +142,13 @@ echo "Saving YaST logs to $TARGET" >&2
 
 [ -n "$COMPRESSION" ] && COMPRESSION="--$COMPRESSION"
 
-tar cf "$TARGET" $COMPRESSION --dereference -C / $LIST -C /var/log $LIST_VAR -C $TMPDIR $LIST_TMP
+tar cf "$TARGET" --warning=no-file-changed $COMPRESSION --dereference -C / $LIST -C /var/log $LIST_VAR -C $TMPDIR $LIST_TMP
 err=$?
 
 rm -rf $TMPDIR
+
+# tar returns 1 when content of tarball is older then current system. Happen when something still writting to logs or memsampler (bsc#1182710#c2)
+[ $err == 1 ] && echo "Warning: logs modified during save. Yast is probably running. Content of tarball can be older then current content." >&2 && err=0
 
 [ $err != 0 ] && echo "FATAL: Error creating archive $TARGET" >&2
 

--- a/scripts/save_y2logs
+++ b/scripts/save_y2logs
@@ -147,8 +147,8 @@ err=$?
 
 rm -rf $TMPDIR
 
-# tar returns 1 when content of tarball is older then current system. Happen when something still writting to logs or memsampler (bsc#1182710#c2)
-[ $err == 1 ] && echo "Warning: logs modified during save. Yast is probably running. Content of tarball can be older then current content." >&2 && err=0
+# tar returns 1 when content of tarball is older than the current system. Happen when something still writting to logs or memsampler (bsc#1182710#c2)
+[ $err == 1 ] && echo "Warning: logs modified during save. Yast is probably running. Content of tarball can be older than current content." >&2 && err=0
 
 [ $err != 0 ] && echo "FATAL: Error creating archive $TARGET" >&2
 


### PR DESCRIPTION
How it looks now ( easy to reproduce with Y2DEBUG=1 and slide show ):
![save_y2logs_modified](https://user-images.githubusercontent.com/478871/110352034-b5ffe300-8035-11eb-9d02-0e38b37280c3.png)
