### PR TITLE
[Product Control] Use meaningful button labels

### DIFF
--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -1365,7 +1365,8 @@ module Yast
             client: client_name
           )
 
-          continue = Yast2::Popup.show(text, buttons: :yes_no) == :yes
+          options = { yes: Label.ContinueButton, no: Label.AbortButton }
+          continue = Yast2::Popup.show(text, buttons: options) == :yes
 
           if continue
             log.warn("Continuing after skipping the '#{client_name}' missing client")

--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -1368,7 +1368,7 @@ module Yast
           continue = Yast2::Popup.show(text, buttons: :yes_no) == :yes
 
           if continue
-            log.warning("Continuing after skipping the '#{client_name}' missing client")
+            log.warn("Continuing after skipping the '#{client_name}' missing client")
             # If user decided to continue, uses the former_result (:next or :back)
             result = former_result
           else

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar  9 08:23:44 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Use meaningful button labels when asking the user if would like
+  to continue when an installation client is missing
+  (related to bsc#1180594).
+- 4.3.59
+
+-------------------------------------------------------------------
 Mon Mar  8 16:41:27 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - save_y2logs: Make modified content of log files just warning

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.58
+Version:        4.3.59
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Related to #1143, just change buttons labels from `Yes`/`No` to `Continue`/`Abort`.

![Screenshot_sle15sp3_2021-03-09_08:40:49](https://user-images.githubusercontent.com/1691872/110442866-3284d700-80b3-11eb-9f3e-2a18e0ae013b.png)


Also avoid a new crash by fixing a `log.warn` call :confused: 