### PR TITLE
Determine whether a widget is present/displayed

### DIFF
--- a/library/cwm/src/lib/cwm/abstract_widget.rb
+++ b/library/cwm/src/lib/cwm/abstract_widget.rb
@@ -191,7 +191,7 @@ module CWM
     # Determines whether the widget is currently displayed in the UI
     #
     # @return [Boolean]
-    def widget_present?
+    def displayed?
       Yast::UI.WidgetExists(Id(widget_id))
     end
 

--- a/library/cwm/src/lib/cwm/abstract_widget.rb
+++ b/library/cwm/src/lib/cwm/abstract_widget.rb
@@ -188,6 +188,13 @@ module CWM
       Yast::UI.SetFocus(Id(widget_id))
     end
 
+    # Determines whether the widget is currently displayed in the UI
+    #
+    # @return [Boolean]
+    def widget_present?
+      Yast::UI.WidgetExists(Id(widget_id))
+    end
+
   protected
 
     # A helper to check if an event is invoked by this widget

--- a/library/cwm/src/lib/cwm/common_widgets.rb
+++ b/library/cwm/src/lib/cwm/common_widgets.rb
@@ -25,12 +25,18 @@ module CWM
   # A mix-in for widgets using the :Value property
   module ValueBasedWidget
     # Get widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     # @return [Object] a value according to specific widget type
     def value
       Yast::UI.QueryWidget(Id(widget_id), :Value)
     end
 
     # Set widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     # @param val [Object] a value according to specific widget type
     # @return [void]
     def value=(val)
@@ -196,11 +202,19 @@ module CWM
     include ItemsSelection
     abstract_method :label
 
+    # Get widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     # @return [String] ID of the selected item
     def value
       Yast::UI.QueryWidget(Id(widget_id), :CurrentItem)
     end
 
+    # Set widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     # @param val [String] ID of the selected item
     def value=(val)
       Yast::UI.ChangeWidget(Id(widget_id), :CurrentItem, val)
@@ -217,11 +231,19 @@ module CWM
     include ItemsSelection
     abstract_method :label
 
+    # Get widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     # @return [Array<String>] return IDs of selected items
     def value
       Yast::UI.QueryWidget(Id(widget_id), :SelectedItems)
     end
 
+    # Set widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     # @param val [Array<String>] IDs of newly selected items
     def value=(val)
       Yast::UI.ChangeWidget(Id(widget_id), :SelectedItems, val)
@@ -287,10 +309,19 @@ module CWM
     # @!method hspacing
     #   @return [Fixnum] margin at both sides of the options list
 
+    # Get widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
     def value
       Yast::UI.QueryWidget(Id(widget_id), :CurrentButton)
     end
 
+    # Set widget value
+    #
+    # Calling this method only make sense when the widget is displayed (see #displayed?).
+    #
+    # @param val [Object] a value according to specific widget type
     def value=(val)
       Yast::UI.ChangeWidget(Id(widget_id), :CurrentButton, val)
     end
@@ -390,7 +421,8 @@ module CWM
 
     # Updates the content
     #
-    # Depending on #keep_scroll?, the vertical scroll will be saved and restored.
+    # Depending on #keep_scroll?, the vertical scroll will be saved and restored. Calling this
+    # method only make sense when the widget is displayed (see #displayed?).
     #
     # @param val [String] the new content for the widget
     def value=(val)

--- a/library/cwm/test/abstract_widget_test.rb
+++ b/library/cwm/test/abstract_widget_test.rb
@@ -204,7 +204,7 @@ describe CWM::AbstractWidget do
     end
   end
 
-  describe "#widget_present?" do
+  describe "#displayed?" do
     subject { TPresent.new }
 
     class TPresent < CWM::AbstractWidget
@@ -224,7 +224,7 @@ describe CWM::AbstractWidget do
       let(:present?) { true }
 
       it "returns true" do
-        expect(subject.widget_present?).to eq(true)
+        expect(subject.displayed?).to eq(true)
       end
     end
 
@@ -232,7 +232,7 @@ describe CWM::AbstractWidget do
       let(:present?) { false }
 
       it "returns false" do
-        expect(subject.widget_present?).to eq(false)
+        expect(subject.displayed?).to eq(false)
       end
     end
   end

--- a/library/cwm/test/abstract_widget_test.rb
+++ b/library/cwm/test/abstract_widget_test.rb
@@ -203,4 +203,37 @@ describe CWM::AbstractWidget do
       TFocus.new.focus
     end
   end
+
+  describe "#widget_present?" do
+    subject { TPresent.new }
+
+    class TPresent < CWM::AbstractWidget
+      self.widget_type = :empty
+
+      def initialize
+        self.widget_id = "test"
+      end
+    end
+
+    before do
+      allow(Yast::UI).to receive(:WidgetExists).with(Id("test"))
+        .and_return(present?)
+    end
+
+    context "when the widget is displayed in the UI" do
+      let(:present?) { true }
+
+      it "returns true" do
+        expect(subject.widget_present?).to eq(true)
+      end
+    end
+
+    context "when the widget is not displayed in the UI" do
+      let(:present?) { false }
+
+      it "returns false" do
+        expect(subject.widget_present?).to eq(false)
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar 29 09:46:31 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add a AbstractWidget#widget_present? to determine whether
+  a widget is in the UI (bsc#1184115).
+- 4.3.60
+
+-------------------------------------------------------------------
 Tue Mar  9 08:23:44 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Use meaningful button labels when asking the user if would like

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Mar 29 09:46:31 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Add a AbstractWidget#widget_present? to determine whether
+- Add a AbstractWidget#displayed? to determine whether
   a widget is in the UI (bsc#1184115).
 - 4.3.60
 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.59
+Version:        4.3.60
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
This PR adds a method to determine whether a UI is actually present in the UI. We will use this code to fix [bsc#1184115](https://bugzilla.suse.com/show_bug.cgi?id=1184115), but it could be useful to fix other bugs as well.

[bsc#118411](https://bugzilla.suse.com/show_bug.cgi?id=1184115)
