### PR TITLE
Updated manual page (bsc#1184681)

### DIFF
--- a/doc/yast2.8
+++ b/doc/yast2.8
@@ -26,7 +26,7 @@ YaST \- "Yet another Setup Tool", the installation and configuration tool
 .\"
 .SH DESCRIPTION
 .B YaST
-can be used to configure the system. It can configure a common hardware
+can be used to configure the system. It can configure common hardware
 (sound cards, printers), network connections (network cards), network
 clients and services (like NFS, FTP), as well as general system options
 (language, partitioning, software, bootloader).

--- a/doc/yast2.8
+++ b/doc/yast2.8
@@ -1,14 +1,16 @@
 .\" Michal Svec <msvec@suse.cz>
 .\"
 .\" Process this file with
-.\" groff -man -Tascii foo.1
+.\"   groff -man -Tutf8 yast2.8
+.\" or run
+.\"   man -l yast2.8
+.\" to display the man page without installing it
 .\"
-.\"
-.TH YAST2 8 "January 2003" "yast2" "System configuration"
+.TH YAST 8 "April 2021" "yast" "System configuration"
 .\"
 .\"
 .SH NAME
-YaST2 \- universal configuration utility
+YaST \- "Yet another Setup Tool", the installation and configuration tool
 .\"
 .\"
 .SH SYNOPSIS
@@ -19,43 +21,33 @@ YaST2 \- universal configuration utility
 .B ] [
 .I module specific options
 .B ]
-.br
-.B yast2 --install
-.I <package>
-.B [
-.I <package>
-.B [
-.I ...
-.B ] ]
 .\"
 .\"
 .SH DESCRIPTION
-.B YaST2
-is used to configure the system. It can configure a common hardware
-(sound cards, printers, keyboards, mice), network connections (network
-cards, ISDN cards, modems, DSL connections), network clients and services
-(NFS, NIS), as well as a general system options (language, partitioning,
-software, bootloader).
-
-.br
-.B YaST2
-comes with three frontends:
-.B GTK
-,
-.B QT
-and
-.B ncurses.
-All frontends are functionally equivalent.
-The correct frontend is selected automatically based on the available
-components and the current environment (the DISPLAY variable).
-
-.br
+.B YaST
+can be used to configure the system. It can configure a common hardware
+(sound cards, printers), network connections (network cards), network
+clients and services (like NFS, FTP), as well as a general system options
+(language, partitioning, software, bootloader).
+.\"
+.P
+.B YaST
+comes with
+.B Qt
+(graphical) and
+.B ncurses
+(text mode) frontends located in libyui-qt and libyui-ncurses packages. Both frontends are
+functionally equivalent. The correct frontend is selected automatically based
+on the available components and the current environment (the DISPLAY variable).
+.\"
+.P
 Use
 .B yast2
 alone to launch the
-.B YaST2 Control Center
+.B YaST Control Center
 from which you can select a particular configuration module or use
-.B yast2 <module>
+.B yast2
+.I module
 to launch the module directly.
 .\"
 .\"
@@ -63,57 +55,34 @@ to launch the module directly.
 .\"
 .TP
 .B --qt
-Run YaST in the QT graphical frontend
-.\"
-.TP
-.B --gtk
-Run YaST in the GTK graphical frontend
+Run YaST in the Qt graphical frontend if available, otherwise it uses the
+ncurses frontend
 .\"
 .TP
 .B --ncurses
-Run YaST in the ncurses text-mode frontend
+Run YaST in the ncurses text mode frontend
 .\"
 .TP
 .B -g, --geometry
-Default window size (QT frontend only).
+Default window size (Qt frontend only), e.g. \fB800x600
 .\"
 .TP
 .B -h, --help
-Print a usage and exit.
-.\"
-.TP
-.B -i, --install <package> [ <package> [ ... ] ]
-Install an RPM package. The
-.B package
-can be a single short package name (e.g. gvim)
-which will be installed with dependency checking, or the full
-path to an rpm package (e.g /tmp/gvim.rpm) which will be
-installed without dependency checking.
-.\"
-.\" #222757
-.TP
-.B --remove <package> [ <package> [ ... ] ]
-Remove an RPM package. The
-.B package
-can be short package names (e.g. gvim)
-which will be removed with dependency checking.
+Print usage and exit
 .\"
 .TP
 .B -l, --list
-List all available modules. To obtain usage info about
-a module, use "yast module help".
+List all available modules, to obtain usage info about
+a module use
+.B yast
+.I module
+.B help
+command.
 .\"
 .\"
-.SH MODULES WITH COMMAND LINE INTERFACE
+.SH COMMAND LINE INTERFACE
 .TP
-This is a list of YaST modules currently supporting command line interface:
-.P
-answering_machine, bootloader, ca_mgm, dhcp-server, dns, dns-server, fax,
-firewall, groups, host, http-server, idedma, inetd, irda, kerberos-client,
-keyboard, lan, language, ldap, mail, mouse, nfs, nfs_server, nis, nis_server,
-ntp-client, power-management, powertweak, printer, profile-manager, proxy,
-remote, routing, runlevel, samba-client, samba-server, security, sound,
-sysconfig, tftp-server, timezone, tv, users
+Some YaST modules support command line interface.
 .\"
 .P
 To obtain a list of basic commands for using a YaST module
@@ -143,7 +112,7 @@ module in a XML formatted file, use:
 .B yast2
 .I module
 .B xmlhelp
-.B xmlfile= \fI<filename>\fP
+.B xmlfile=\fI<filename>\fP
 .br
 .\"
 .P
@@ -171,12 +140,12 @@ commands of a YaST module, use
 .SH FILES
 .TP
 /var/log/YaST2/*
-Logs
+Log files, use the
+.B save_y2logs
+command for saving all files into a single archive
 .TP
 /etc/sysconfig/yast2, $HOME/.yast2/yast2
-Configures the preferred GUI.
-\" .SH BUGS
-\" Please report bugs at http://www.suse.de/feedback
+YaST configuration files
 .\"
 .\"
 .SH "EXIT STATUS"
@@ -199,8 +168,7 @@ Module specific error codes.
 .\"
 .SH AUTHOR
 .nf
-Michal Svec <msvec@suse.cz> - manual page
-Jakub Friedl <jfriedl@suse.cz> - manual page
+The YaST Team <yast-devel@opensuse.org>
 .fi
 .\"
 .\"

--- a/doc/yast2.8
+++ b/doc/yast2.8
@@ -28,7 +28,7 @@ YaST \- "Yet another Setup Tool", the installation and configuration tool
 .B YaST
 can be used to configure the system. It can configure a common hardware
 (sound cards, printers), network connections (network cards), network
-clients and services (like NFS, FTP), as well as a general system options
+clients and services (like NFS, FTP), as well as general system options
 (language, partitioning, software, bootloader).
 .\"
 .P

--- a/doc/yast2.8
+++ b/doc/yast2.8
@@ -1,10 +1,11 @@
-.\" Michal Svec <msvec@suse.cz>
 .\"
 .\" Process this file with
 .\"   groff -man -Tutf8 yast2.8
 .\" or run
 .\"   man -l yast2.8
 .\" to display the man page without installing it
+.\"
+.\" See https://www.gnu.org/software/groff/manual/html_node/man.html#man
 .\"
 .TH YAST 8 "April 2021" "yast" "System configuration"
 .\"

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Apr 14 12:09:49 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Updated manual page ("man yast2") (bsc#1184681)
+- 4.4.0
+
+-------------------------------------------------------------------
 Mon Apr 12 15:12:41 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a default value for file_path argument in ::new and ::load

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.60
+Version:        4.4.0
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1184681
- The man page was utterly outdated

### Changes

- Removed Gtk UI
- The `--install` and `--remove` options are obsolete (`zypper` should be preferred)
- Removed list of modules which support command line mode
- Some minor improvements and fixes

<details>
 <summary>Rendered Plain Text Version</summary>

```
YAST(8)                      System configuration                      YAST(8)



NAME
       YaST  -  "Yet  another  Setup Tool", the installation and configuration
       tool

SYNOPSIS
       yast2 [ options ] [ module ] [ module specific options ]

DESCRIPTION
       YaST can be used to configure the system. It  can  configure  a  common
       hardware  (sound cards, printers), network connections (network cards),
       network clients and services (like NFS, FTP), as well as a general sys-
       tem options (language, partitioning, software, bootloader).

       YaST  comes  with  Qt  (graphical)  and  ncurses  (text mode) frontends
       located in libyui-qt and libyui-ncurses packages.  Both  frontends  are
       functionally equivalent. The correct frontend is selected automatically
       based on the available components and the current environment (the DIS-
       PLAY variable).

       Use  yast2  alone  to launch the YaST Control Center from which you can
       select a particular configuration module or use yast2 module to  launch
       the module directly.

OPTIONS
       --qt   Run YaST in the Qt graphical frontend if available, otherwise it
              uses the ncurses frontend

       --ncurses
              Run YaST in the ncurses text mode frontend

       -g, --geometry
              Default window size (Qt frontend only), e.g. 800x600

       -h, --help
              Print usage and exit

       -l, --list
              List all available modules, to obtain usage info about a  module
              use yast module help command.

COMMAND LINE INTERFACE
       Some YaST modules support command line interface.

       To obtain a list of basic commands for using a YaST module with support
       for command line interface, use:
       yast2 module help

       To get more comprehensive information about the commands available  for
       a YaST module, use:
       yast2 module longhelp

       To  get information about the commands available for a YaST module in a
       XML formatted file, use:
       yast2 module xmlhelp xmlfile=<filename>

       To get information about a specific command of a YaST module, use:
       yast2 module command help

       To start an interactive console in which you can execute commands of  a
       YaST module, use
       yast2 module interactive

FILES
       /var/log/YaST2/*
              Log files, use the save_y2logs command for saving all files into
              a single archive

       /etc/sysconfig/yast2, $HOME/.yast2/yast2
              YaST configuration files

EXIT STATUS
       0      Successful program execution.

       1      Too few arguments.

       5      Error in arguments.

       16     Generic module error.

       > 16   Module specific error codes.

AUTHOR
       The YaST Team <yast-devel@opensuse.org>

SEE ALSO
       Documentation in /usr/share/doc/packages/yast2*.



yast                              April 2021                           YAST(8)
```

</details>
