### PR TITLE
Fix issue location

### DIFF
--- a/library/general/src/lib/y2issues/issue.rb
+++ b/library/general/src/lib/y2issues/issue.rb
@@ -38,7 +38,7 @@ module Y2Issues
   class Issue
     include Yast::I18n
 
-    # @return [String,nil] Where the error is located.
+    # @return [Location,nil] Where the error is located.
     attr_reader :location
     # @return [String] Error message
     attr_reader :message
@@ -46,13 +46,13 @@ module Y2Issues
     attr_reader :severity
 
     # @param message [String] User-oriented message describing the problem
-    # @param location [URI,String,nil] Where the error is located. Use a URI or
+    # @param location [String,nil] Where the error is located. Use a URI or
     #   a string to represent the error location. Use 'nil' if it
     #   does not exist an specific location.
     # @param severity [Symbol] warning (:warn) or fatal (:fatal)
     def initialize(message, location: nil, severity: :warn)
       @message = message
-      @location = Location.parse(location) if location
+      @location = location.is_a?(String) ? Location.parse(location) : location
       @severity = severity
     end
 

--- a/library/general/test/y2issues/issue_test.rb
+++ b/library/general/test/y2issues/issue_test.rb
@@ -25,7 +25,9 @@ describe Y2Issues::Issue do
   describe "#new" do
     subject(:issue) do
       described_class.new(
-        "Something went wrong", location: "file:/etc/hosts", severity: :fatal
+        "Something went wrong",
+        location: Y2Issues::Location.parse("file:/etc/hosts"),
+        severity: :fatal
       )
     end
 
@@ -33,6 +35,19 @@ describe Y2Issues::Issue do
       expect(issue.message).to eq("Something went wrong")
       expect(issue.location).to eq(Y2Issues::Location.parse("file:/etc/hosts"))
       expect(issue.severity).to eq(:fatal)
+    end
+
+    context "when location is given as a string" do
+      subject(:issue) do
+        described_class.new(
+          "Something went wrong",
+          location: "file:/etc/hosts"
+        )
+      end
+
+      it "parses the given location" do
+        expect(issue.location).to eq(Y2Issues::Location.parse("file:/etc/hosts"))
+      end
     end
 
     context "when a severity is not given" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Apr 22 06:35:11 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- The location given to the Y2Issue::Issue constructor can be a
+  string or a location object.
+
+-------------------------------------------------------------------
 Fri Apr 16 12:03:50 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a mechanism to report issues to the user (related to


### PR DESCRIPTION
Fixes the `Y2Issue::Issue` constructor to accept the location as a string or as a `Location` object. We do not need to release the fix now, so it can wait to the next version.