### PR TITLE
[SLE-15-SP3] Do not convert result to sym directly

### DIFF
--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -1348,7 +1348,7 @@ module Yast
           # This code will be triggered before the red pop window appears on the user's screen
           Hooks.run("installation_failure") if result == false
 
-          result = result.to_sym
+          result = Convert.to_symbol(result)
 
           Hooks.run("after_#{step_name}")
         else

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -23,7 +23,7 @@ Tue Mar  9 08:23:44 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Use meaningful button labels when asking the user if would like
   to continue when an installation client is missing
-  (related to bsc#1180594).
+  (related to bsc#1180954).
 - 4.3.59
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May  3 14:35:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when a client execution return false
+  (related to bsc#1185561, and bsc#1180954).
+- 4.3.61
+
+-------------------------------------------------------------------
 Mon Apr 12 15:12:41 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add a default value for file_path argument in ::new and ::load

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.60
+Version:        4.3.61
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

A call to `Convert.to_symbol` was wrongly changed in https://github.com/yast/yast-yast2/pull/1143, which makes the installation crash with a `NoMethodError (undefined method ``to_sym' for false:FalseClass)` when the result from a client is `false`

* https://bugzilla.suse.com/show_bug.cgi?id=1185561
* https://trello.com/c/Kq990Qba/4698-tw-p3-1185561-ruby-error-in-installation-after-partitioning

## Solution

A kind of revert to previous code and keep using `result = Convert.to_symbol(result)` instead `result = result.to_sym`

## Additional note

The Bugzilla reference for version 4.3.59 has been fixed, switching from _bsc#1180**59**4_ to _bsc#1180**95**4_