### PR TITLE
Do not convert result to sym directly

### DIFF
--- a/library/control/src/modules/ProductControl.rb
+++ b/library/control/src/modules/ProductControl.rb
@@ -1348,7 +1348,7 @@ module Yast
           # This code will be triggered before the red pop window appears on the user's screen
           Hooks.run("installation_failure") if result == false
 
-          result = result.to_sym
+          result = Convert.to_symbol(result)
 
           Hooks.run("after_#{step_name}")
         else

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May  3 14:35:49 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when a client execution return false
+  (related to bsc#1185561, and bsc#1180954).
+- 4.4.3
+
+-------------------------------------------------------------------
 Tue Apr 27 10:51:35 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Add to yast2 mixin Yast2::SecretAttributes for hiding sensitive
@@ -42,7 +49,7 @@ Tue Mar  9 08:23:44 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Use meaningful button labels when asking the user if would like
   to continue when an installation client is missing
-  (related to bsc#1180594).
+  (related to bsc#1180954).
 - 4.3.59
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
The same than #1161, but for `master` branch.

It restores a conversion to symbol using `Convert.to_symbol` instead of Ruby `#to_sym` method.

Related to https://bugzilla.suse.com/show_bug.cgi?id=1185561