### PR TITLE
Fix entries for ES and ca_ES

### DIFF
--- a/library/general/src/data/country.ycp
+++ b/library/general/src/data/country.ycp
@@ -57,7 +57,6 @@ return $[
     "EC" : _("Ecuador"),
     "EE" : _("Estonia"),
     "EG" : _("Egypt"),
-    "ES" : _("Catalonia"),
     "ES" : _("Spain"),
     "FI" : _("Finland"),
     "FO" : _("Faroe Islands"),

--- a/library/general/src/data/country_long.ycp
+++ b/library/general/src/data/country_long.ycp
@@ -53,7 +53,7 @@ return $[
     "bn_BD" : _("Bangladesh"),
     "br_FR" : _("France"),
     "bs_BA" : _("Bosnia and Herzegowina"),
-    "ca_ES" : _("Catalonia"),
+    "ca_ES" : _("Spain"),
     "cs_CZ" : _("Czech Republic"),
     "cy_GB" : _("Great Britain"),
     "da_DK" : _("Denmark"),


### PR DESCRIPTION
- Remove Catalonia (duplicate for ES)
- Update ca_ES to Spain following other Spanish languages (gl_ES, eu_ES)