### PR TITLE
Add Equatable mixin

### DIFF
--- a/library/general/src/lib/yast2/equatable.rb
+++ b/library/general/src/lib/yast2/equatable.rb
@@ -1,0 +1,104 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Yast2
+  # Mixin for classes that require to define a custom comparison
+  #
+  # By default, the methods #==, #eql? and #equal? in Object subclasses return true if both objects
+  # are the same (point to the same object in memory). Actually #eql? should return true if both
+  # objects refer to the same hash key. But in practice, two objects have the same hash key if they
+  # are the very same object. There are some exceptions like String, which returns the same hash key
+  # if they have the same value.
+  #
+  # The #eql? and #hash methods must be related. That is, if two objects are #eql?, then they should
+  # have the same #hash. This is important, otherwise we could have unexpected results in certain
+  # operations like subtracting Arrays. When performing the difference of two Arrays, the method
+  # used for comparing the objects in the Array depends on the Array length (see source code of
+  # Array#difference). If both Arrays have more than SMALL_ARRAY_LEN (i.e., 16) elements, then
+  # the #hash method is used. Otherwise it uses #eql?. This is one of the reason why #eql? and #hash
+  # should be paired.
+  #
+  # @example
+  #   class Foo
+  #     include Equatable
+  #
+  #     attr_reader :attr1, :attr2
+  #
+  #     eql_attr :attr1
+  #
+  #     def initialize(attr1, attr2)
+  #       @attr1 = attr1
+  #       @attr2 = attr2
+  #     end
+  #   end
+  #
+  #   foo1 = Foo.new("a", "b")
+  #   foo2 = Foo.new("a", "c")
+  #
+  #   foo1 == foo2      #=> true
+  #   foo1.eql?(foo2)   #=> true
+  #   foo1.equal?(foo2) #=> false
+  module Equatable
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    # Class methods for defining the attributes to consider when comparing objects
+    module ClassMethods
+      # Inherited classes must remember the attributes for comparison from its parent class
+      def inherited(subclass)
+        subclass.eql_attr(*eql_attrs)
+      end
+
+      # Name of the attributes to consider when comparing objects
+      #
+      # @return [Array<Symbol>]
+      def eql_attrs
+        @eql_attrs || []
+      end
+
+      # Saves the name of the attributes to use when comparing objects
+      #
+      # @param names [Array<Symbol>]
+      def eql_attr(*names)
+        @eql_attrs ||= []
+        @eql_attrs += names
+      end
+    end
+
+    # Hash key to identify objects
+    #
+    # Objects with the same values for their eql_attrs have the same hash
+    #
+    # @return [Integer]
+    def hash
+      ([[:class, self.class]] + self.class.eql_attrs.map { |m| [m, send(m)] }).to_h.hash
+    end
+
+    # Whether the objects have the same hash key
+    #
+    # @param other [Object]
+    # @return [Boolean]
+    def eql?(other)
+      hash == other.hash
+    end
+
+    alias_method :==, :eql?
+  end
+end

--- a/library/general/test/yast2/equatable_test.rb
+++ b/library/general/test/yast2/equatable_test.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "yast2/equatable"
+
+describe Yast2::Equatable do
+  describe ".eql_attrs" do
+    class EquatableTest1
+      include Yast2::Equatable
+    end
+
+    context "when no attributes have been added for comparison" do
+      it "returns an empty list" do
+        expect(EquatableTest1.eql_attrs).to be_empty
+      end
+    end
+
+    context "when some attributes have been added for comparison" do
+      before do
+        EquatableTest1.eql_attr :foo, :bar
+      end
+
+      it "returns a list with the name of the attributes for comparison" do
+        expect(EquatableTest1.eql_attrs).to contain_exactly(:foo, :bar)
+      end
+    end
+  end
+
+  describe "#eql?" do
+    class EquatableTest
+      include Yast2::Equatable
+
+      attr_reader :attr1, :attr2, :attr3
+
+      eql_attr :attr1, :attr2
+
+      def initialize(attr1, attr2, attr3)
+        @attr1 = attr1
+        @attr2 = attr2
+        @attr3 = attr3
+      end
+    end
+
+    subject { EquatableTest.new("a", 10, :foo) }
+
+    context "when giving the same object" do
+      let(:other) { subject }
+
+      it "returns true" do
+        expect(subject.eql?(other)).to eq(true)
+      end
+    end
+
+    context "when giving an object of the same class" do
+      context "and the attributes for comparison are equal" do
+        let(:other) { EquatableTest.new("a", 10, :other) }
+
+        it "returns true" do
+          expect(subject.eql?(other)).to eq(true)
+        end
+      end
+
+      context "and any of the attributes for comparison is not equal" do
+        let(:other) { EquatableTest.new("b", 10, :other) }
+
+        it "returns false" do
+          expect(subject.eql?(other)).to eq(false)
+        end
+      end
+    end
+
+    context "when giving an object of another class" do
+      let(:other) { "Another class" }
+
+      it "returns false" do
+        expect(subject.eql?(other)).to eq(false)
+      end
+    end
+
+    context "with a subclass object" do
+      class EquatableTestDerived < EquatableTest; end
+
+      subject { EquatableTestDerived.new("a", 10, :foo) }
+
+      context "when comparing with a parent class object" do
+        let(:other) { EquatableTest.new("a", 10, :foo) }
+
+        it "returns false" do
+          expect(subject.eql?(other)).to eq(false)
+        end
+      end
+
+      context "when adding more attributes for comparison" do
+        class EquatableTestDerived
+          eql_attr :attr3
+        end
+
+        context "and any of the parent attributes for comparison is not equal" do
+          let(:other) { EquatableTestDerived.new("a", 11, :foo) }
+
+          it "returns false" do
+            expect(subject.eql?(other)).to eq(false)
+          end
+        end
+
+        context "and the parent attributes for comparison are equal" do
+          let(:other) { EquatableTestDerived.new("a", 10, attr3) }
+
+          context "but the new attributes for comparison are not equal" do
+            let(:attr3) { :bar }
+
+            it "returns false" do
+              expect(subject.eql?(other)).to eq(false)
+            end
+          end
+
+          context "and the new attributes for comparison are equal" do
+            let(:attr3) { :foo }
+
+            it "returns true" do
+              expect(subject.eql?(other)).to eq(true)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 25 07:19:14 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Add Yast2::Equatable mixin to avoid troubles with classes that
+  overloads the comparison methods (related to bsc#1186082).
+- 4.4.5
+
+-------------------------------------------------------------------
 Fri May  7 15:10:14 UTC 2021 - Stefan Schubert <schubi@suse.de>
 
 - Logging all available product information into directory

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Objects redefining `#eql?` method should redefine `#hash` method too. These two methods must be paired, otherwise some actions like subtracting arrays could generate unexpected results.

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1186082.

## Solution

Add a `Equatable` mixin for keep `#eql?` and `#hash` paired.
