### PR TITLE
CFA: recognize more fields from login.defs

### DIFF
--- a/library/general/src/lib/cfa/login_defs.rb
+++ b/library/general/src/lib/cfa/login_defs.rb
@@ -46,23 +46,33 @@ module CFA
     # @return [Array<Symbol>] List of known login.defs attributes
     KNOWN_ATTRIBUTES = [
       :character_class,
+      :create_home,
       :encrypt_method,
       :fail_delay,
       :gid_max,
       :gid_min,
       :groupadd_cmd,
+      :home_mode,
       :pass_max_days,
       :pass_min_days,
       :pass_warn_age,
+      :sub_gid_min,
+      :sub_gid_max,
+      :sub_gid_count,
+      :sub_uid_min,
+      :sub_uid_max,
+      :sub_uid_count,
       :sys_gid_max,
       :sys_gid_min,
       :sys_uid_max,
       :sys_uid_min,
       :uid_max,
       :uid_min,
+      :umask,
       :useradd_cmd,
       :userdel_postcmd,
-      :userdel_precmd
+      :userdel_precmd,
+      :usergroups_enab
     ].freeze
 
     DEFAULT_PATH = "/etc/login.defs".freeze

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  1 11:48:18 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Added some names to the list of parameters handled by CFA for the
+  login.defs configuration (related to jsc#PM-2620).
+- 4.4.6
+
+-------------------------------------------------------------------
 Tue May 25 07:19:14 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - Add Yast2::Equatable mixin to avoid troubles with classes that

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
This is a pre-requisite for https://github.com/yast/yast-users/pull/284

This repository contains a CFA class to deal with login.defs. But it only handles a limited set of configuration parameters. This adds `umask` to that set, since it's needed in order to configure useradd (at some point, the `umask` configuration was part of `/etc/default/useradd` but now it's only present in login.defs).

Taking the opportunity, this PR also adds another parameters that influence the behavior of useradd.