### PR TITLE
Make Yast2::Equatable#hash to be fine tuned easelly

### DIFF
--- a/library/general/src/lib/yast2/equatable.rb
+++ b/library/general/src/lib/yast2/equatable.rb
@@ -82,7 +82,7 @@ module Yast2
       end
     end
 
-    # Return a Hash containing all the attributes and values used for comparing
+    # Returns a Hash containing all the attributes and values used for comparing
     # the objects as well as a :class key with the object class as the value.
     #
     # @return [Hash<Symbol, Object]

--- a/library/general/src/lib/yast2/equatable.rb
+++ b/library/general/src/lib/yast2/equatable.rb
@@ -82,13 +82,21 @@ module Yast2
       end
     end
 
+    # Return a Hash containing all the attributes and values used for comparing
+    # the objects as well as a :class key with the object class as the value.
+    #
+    # @return [Hash<Symbol, Object]
+    def eql_hash
+      ([[:class, self.class]] + self.class.eql_attrs.map { |m| [m, send(m)] }).to_h
+    end
+
     # Hash key to identify objects
     #
     # Objects with the same values for their eql_attrs have the same hash
     #
     # @return [Integer]
     def hash
-      ([[:class, self.class]] + self.class.eql_attrs.map { |m| [m, send(m)] }).to_h.hash
+      eql_hash.hash
     end
 
     # Whether the objects have the same hash key

--- a/library/general/test/yast2/equatable_test.rb
+++ b/library/general/test/yast2/equatable_test.rb
@@ -144,4 +144,30 @@ describe Yast2::Equatable do
       end
     end
   end
+
+  describe "#eql_hash" do
+    class EquatableTest
+      include Yast2::Equatable
+
+      attr_reader :attr1, :attr2, :attr3
+
+      eql_attr :attr1, :attr2
+
+      def initialize(attr1, attr2, attr3)
+        @attr1 = attr1
+        @attr2 = attr2
+        @attr3 = attr3
+      end
+    end
+
+    subject { EquatableTest.new("a", 10, :foo) }
+
+    it "returns a Hash containing the :class key and the object class as the value" do
+      expect(subject.eql_hash).to include(class: subject.class)
+    end
+
+    it "returns a Hash with the comparing attributes and their values" do
+      expect(subject.eql_hash).to include(attr1: "a", attr2: 10)
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jun  2 17:30:50 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Improve Yast2::Equatable mixin making the #hash method to be fine
+  tuned easelly (related to bsc#11806082).
+- 4.4.7
+
+-------------------------------------------------------------------
 Tue Jun  1 11:48:18 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added some names to the list of parameters handled by CFA for the

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Added improvement already mentioned in:

https://github.com/yast/yast-yast2/pull/1165#discussion_r639537928

Which will be very useful for adopting it in yast2-netnetwork (see https://github.com/yast/yast-network/pull/1228)

