### PR TITLE
AutoYaST: Allow blank values in SectionWithAttributes

### DIFF
--- a/library/general/src/lib/installation/autoinst_profile/section_with_attributes.rb
+++ b/library/general/src/lib/installation/autoinst_profile/section_with_attributes.rb
@@ -124,10 +124,13 @@ module Installation
         # Description of the attributes in the section.
         #
         # To be defined by each subclass. Each entry contains a hash with:
-        #   * :name        : the mandatory key
-        #   * :xml_name    : an optional alternative key
-        #   * :allow_blank : whether blank values (i.e, "" or []) are allowed. If set to false, the
-        #                    the value of the attribute will be nil when a blank is detected.
+        #   * :name        : (mandatory) name of the attribute.
+        #   * :xml_name    : (optional) name of the attribute in the xml profile. This is useful
+        #                    when the attribute is required to be called different to the its xml
+        #                    name.
+        #   * :allow_blank : (optional, false by default) whether blank values (i.e, "" or []) are
+        #                    allowed. If set to false, then the value of the attribute will be nil
+        #                    when a blank is detected.
         #
         # @return [Array<Hash>]
         def attributes

--- a/library/general/src/lib/installation/autoinst_profile/section_with_attributes.rb
+++ b/library/general/src/lib/installation/autoinst_profile/section_with_attributes.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2020] SUSE LLC
+# Copyright (c) [2020-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -123,8 +123,11 @@ module Installation
       class << self
         # Description of the attributes in the section.
         #
-        # To be defined by each subclass. Each entry contains a hash with the
-        # mandatory key :name and an optional key :xml_name.
+        # To be defined by each subclass. Each entry contains a hash with:
+        #   * :name        : the mandatory key
+        #   * :xml_name    : an optional alternative key
+        #   * :allow_blank : whether blank values (i.e, "" or []) are allowed. If set to false, the
+        #                    the value of the attribute will be nil when a blank is detected.
         #
         # @return [Array<Hash>]
         def attributes
@@ -194,10 +197,11 @@ module Installation
       #     included.
       def to_hashes
         attributes.each_with_object({}) do |attrib, result|
-          value = attrib_value(attrib)
-          next if attrib_skip?(value)
-
           key = attrib_key(attrib)
+          value = attrib_value(attrib)
+
+          next if attrib_skip?(key, value)
+
           result[key] = value
         end
       end
@@ -258,10 +262,19 @@ module Installation
         self.class.attributes
       end
 
+      def attrib(key)
+        attributes.find { |a| a[:xml_name] == key.to_sym || a[:name] == key.to_sym }
+      end
+
       # Whether an attribute must be skipped during import/export.
       #
-      # @return [Boolean] true is the value is blank
-      def attrib_skip?(value)
+      # @return [Boolean] true is the attribute allows to skip and its value is blank
+      def attrib_skip?(key, value)
+        attrib = attrib(key)
+
+        return true unless attrib
+        return false if attrib[:allow_blank]
+
         value.nil? || value == [] || value == ""
       end
 
@@ -283,7 +296,7 @@ module Installation
       end
 
       def attrib_name(key)
-        attrib = attributes.detect { |a| a[:xml_name] == key.to_sym || a[:name] == key.to_sym }
+        attrib = attrib(key)
         return nil unless attrib
 
         attrib[:name]
@@ -301,7 +314,7 @@ module Installation
           # This method only reads scalar values
           next if value.is_a?(Array) || value.is_a?(Hash)
 
-          if attrib_skip?(value)
+          if attrib_skip?(key, value)
             log.debug "Ignored blank value (#{value}) for #{key}"
             next
           end

--- a/library/general/test/installation/autoinst_profile/section_with_attributes_test.rb
+++ b/library/general/test/installation/autoinst_profile/section_with_attributes_test.rb
@@ -150,7 +150,7 @@ describe Installation::AutoinstProfile::SectionWithAttributes do
       end
     end
 
-    context "when an attribute does not allows blank" do
+    context "when an attribute does not allow blank" do
       context "and the hash does not contain that key" do
         let(:hash) { { name: "" } }
 

--- a/library/general/test/installation/autoinst_profile/section_with_attributes_test.rb
+++ b/library/general/test/installation/autoinst_profile/section_with_attributes_test.rb
@@ -1,4 +1,4 @@
-# Copyright (c) [2020] SUSE LLC
+# Copyright (c) [2020-2021] SUSE LLC
 #
 # All Rights Reserved.
 #
@@ -82,7 +82,8 @@ describe Installation::AutoinstProfile::SectionWithAttributes do
     class << self
       def attributes
         [
-          { name: :name }
+          { name: :name, allow_blank: true },
+          { name: :other, allow_blank: false }
         ]
       end
     end
@@ -103,6 +104,94 @@ describe Installation::AutoinstProfile::SectionWithAttributes do
     it "returns an instance including the given data" do
       group = GroupSection.new_from_hashes(name: "users")
       expect(group.name).to eq("users")
+    end
+
+    context "when an attribute allows blank" do
+      context "and the hash does not contain that key" do
+        let(:hash) { { other: "" } }
+
+        it "assigns nil to the attribute" do
+          group = GroupSection.new_from_hashes(hash)
+
+          expect(group.name).to be_nil
+        end
+      end
+
+      context "and the hash contains that key" do
+        context "and the value for the key is nil" do
+          let(:hash) { { name: nil } }
+
+          it "assigns nil to the attribute" do
+            group = GroupSection.new_from_hashes(hash)
+
+            expect(group.name).to be_nil
+          end
+        end
+
+        context "and the value for the key is blank" do
+          let(:hash) { { name: "" } }
+
+          it "assigns blank to the attribute" do
+            group = GroupSection.new_from_hashes(hash)
+
+            expect(group.name).to eq("")
+          end
+        end
+
+        context "and the value for the key is not blank" do
+          let(:hash) { { name: "a name" } }
+
+          it "assigns the given value to the attribute" do
+            group = GroupSection.new_from_hashes(hash)
+
+            expect(group.name).to eq("a name")
+          end
+        end
+      end
+    end
+
+    context "when an attribute does not allows blank" do
+      context "and the hash does not contain that key" do
+        let(:hash) { { name: "" } }
+
+        it "assigns nil to the attribute" do
+          group = GroupSection.new_from_hashes(hash)
+
+          expect(group.other).to be_nil
+        end
+      end
+
+      context "and the hash contains that key" do
+        context "and the value for the key is nil" do
+          let(:hash) { { other: nil } }
+
+          it "assigns nil to the attribute" do
+            group = GroupSection.new_from_hashes(hash)
+
+            expect(group.other).to be_nil
+          end
+        end
+
+        context "and the value for the key is blank" do
+          let(:hash) { { other: "" } }
+
+          it "assigns nil to the attribute" do
+            group = GroupSection.new_from_hashes(hash)
+
+            expect(group.other).to be_nil
+          end
+        end
+
+        context "and the value for the key is not blank" do
+          let(:hash) { { other: "a name" } }
+
+          it "assigns the given value to the attribute" do
+            group = GroupSection.new_from_hashes(hash)
+
+            expect(group.other).to eq("a name")
+          end
+        end
+      end
     end
 
     context "when nil is given" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jun  3 15:40:30 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- AutoYaST: SectionWithAttributes allows to indicate whether an
+  attribute accepts blank values (related to jsc#PM-2620).
+- 4.4.9
+
+-------------------------------------------------------------------
 Thu Jun  3 09:04:29 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - revert disable of hibernation based on product and virtual

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.8
+Version:        4.4.9
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

Sometimes, an AutoYaST profile might contain blank values for some properties, for example:

~~~xml
<users config:type="list">
  <user>
    <username>tux</username>
    <password_settings>
      <expire/>
      <mx>120</max>
      <inact>5</inact>
    </password_settings>
  </user>
</user>
~~~

In the example above, *expire* is empty, which means that the account has no expiration. By default, the *SectionWithAttributes* class converts the empty values to *nil*, so there is no way to distinguish when a properly was set as blank or it was missing in the profile. Such a differentiation is important in some cases like the *expire* option, because in case of blank, an empty string should be written in the /etc/shadow file for the *Expiration Date* field in order to make the account to never expire. And in case of nil (missing in the profile), nothing should be explicitly written in the file, giving the default value set by commands like *useradd*.


## Solution

Now on, the attributes definition in *SectionWithAttributes* allows to indicate for each attribute whether blank values are allowed or not.
