### PR TITLE
Filter sysctl files

### DIFF
--- a/library/general/src/lib/cfa/sysctl_config.rb
+++ b/library/general/src/lib/cfa/sysctl_config.rb
@@ -157,7 +157,9 @@ module CFA
       if Yast::FileUtils.IsFile(path)
         [path]
       elsif Yast::FileUtils.IsDirectory(path)
-        Yast::SCR.Read(Yast::Path.new(".target.dir"), path).map { |file| File.join(path, file) }
+        Yast::SCR.Read(Yast::Path.new(".target.dir"), path)
+          .select { |f| f.end_with?(".conf") }
+          .map { |f| File.join(path, f) }
       else
         log.debug("Ignoring not valid path: #{path}")
 

--- a/library/general/src/lib/cfa/sysctl_config.rb
+++ b/library/general/src/lib/cfa/sysctl_config.rb
@@ -158,7 +158,7 @@ module CFA
         [path]
       elsif Yast::FileUtils.IsDirectory(path)
         Yast::SCR.Read(Yast::Path.new(".target.dir"), path)
-          .select { |f| f.end_with?(".conf") }
+          .select { |f| f.end_with?(".conf") } # according to 'sysctl.conf' manpage, only .conf files are considered
           .map { |f| File.join(path, f) }
       else
         log.debug("Ignoring not valid path: #{path}")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -3,7 +3,7 @@ Tue Jun  8 08:26:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Ignore sysctl configuration files that do not have the .conf
   extension. The only exception are kernel files
-  (/boot/sysctl.conf-*). (bsc#1187018).
+  (/boot/sysctl.conf-*) (bsc#1187018).
 - 4.4.10
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun  8 08:26:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Ignore sysctl configuration files whose extension is not
+  .conf. The only exception are kernel files (/boot/sysctl.conf-*).
+- 4.4.10
+
+-------------------------------------------------------------------
 Thu Jun  3 15:40:30 UTC 2021 - José Iván López González <jlopez@suse.com>
 
 - AutoYaST: SectionWithAttributes allows to indicate whether an

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Tue Jun  8 08:26:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- Ignore sysctl configuration files whose extension is not
-  .conf. The only exception are kernel files (/boot/sysctl.conf-*).
+- Ignore sysctl configuration files that do not have the .conf
+  extension. The only exception are kernel files
+  (/boot/sysctl.conf-*). (bsc#1187018).
 - 4.4.10
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.9
+Version:        4.4.10
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Ignore sysctl files that do not use the `.conf` exception. The only exception right now are `/boot/sysctl.conf-*` files.

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1187018.