### PR TITLE
Extend issues

### DIFF
--- a/library/general/src/lib/y2issues/list.rb
+++ b/library/general/src/lib/y2issues/list.rb
@@ -25,7 +25,7 @@ module Y2Issues
     include Enumerable
     extend Forwardable
 
-    def_delegators :@items, :each, :empty?, :<<
+    def_delegators :@items, :each, :empty?, :<<, :size
 
     # Constructor
     #
@@ -46,6 +46,17 @@ module Y2Issues
     # @return [Array<Issue>] List of problems
     def to_a
       @items
+    end
+
+    # concats issues
+    # @param args [Array[List]] args to concat. see Array#concat
+    #
+    # @note also self is modified
+    # @return [List]
+    def concat(*args)
+      @items.concat(*args.map(&:to_a))
+
+      self
     end
   end
 end

--- a/library/general/test/y2issues/list_test.rb
+++ b/library/general/test/y2issues/list_test.rb
@@ -79,9 +79,10 @@ describe Y2Issues::List do
       issue2 = Y2Issues::Issue.new("Something went wrong2")
       issue3 = Y2Issues::Issue.new("Something went wrong3")
       expect(described_class.new([issue1]).concat(
-        described_class.new([issue2]), described_class.new([issue3])).to_a).to eq(
-          described_class.new([issue1, issue2, issue3]).to_a
-        )
+        described_class.new([issue2]), described_class.new([issue3])
+      ).to_a).to eq(
+        described_class.new([issue1, issue2, issue3]).to_a
+      )
     end
   end
 end

--- a/library/general/test/y2issues/list_test.rb
+++ b/library/general/test/y2issues/list_test.rb
@@ -72,4 +72,16 @@ describe Y2Issues::List do
 
     end
   end
+
+  describe "#concat" do
+    it "concats all passed Lists" do
+      issue1 = Y2Issues::Issue.new("Something went wrong", severity: :fatal)
+      issue2 = Y2Issues::Issue.new("Something went wrong2")
+      issue3 = Y2Issues::Issue.new("Something went wrong3")
+      expect(described_class.new([issue1]).concat(
+        described_class.new([issue2]), described_class.new([issue3])).to_a).to eq(
+          described_class.new([issue1, issue2, issue3]).to_a
+        )
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jun 21 20:51:57 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Y2Issue::List: Add method size and concat (related to
+  bsc#1181295).
+- 4.4.13
+
+-------------------------------------------------------------------
 Thu Jun 17 06:15:02 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - add riscv64 architecture helper (jsc#PM-2612)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Jun 21 20:51:57 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
-- Y2Issue::List: Add method size and concat (related to
+- Y2Issue::List: Add methods size and concat (related to
   bsc#1181295).
 - 4.4.13
 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.12
+Version:        4.4.13
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Reason: For Y2Issue::List it is needed sometimes to concat more sources of issues and for such case it is useful to be able to concat Lists. Size is common convenient method too check amount of issues.

Related to work on y2users.