### PR TITLE
Small reorganization in Y2Issues

### DIFF
--- a/library/general/src/lib/installation/autoinst_issues/missing_value.rb
+++ b/library/general/src/lib/installation/autoinst_issues/missing_value.rb
@@ -32,7 +32,7 @@ module Installation
       # @param section     [String] Section where it was detected
       # @param attribute   [String] Name of the missing attribute
       # @param description [String] additional explanation; optional
-      # @param severity    [Symbol] :warn, :fatal = abort the installation ; optional
+      # @param severity    [Symbol] :warn, :error = abort the installation ; optional
       def initialize(section, attr, description = "", severity = :warn)
         textdomain "base"
 

--- a/library/general/src/lib/y2issues.rb
+++ b/library/general/src/lib/y2issues.rb
@@ -28,7 +28,7 @@
 #
 # @example Registering an error
 #   list = Y2Issues::List.new
-#   list << Y2Issues::Issue.new("Could not read network configuration", severity: :fatal)
+#   list << Y2Issues::Issue.new("Could not read network configuration", severity: :error)
 module Y2Issues
   # Reports the errors to the user
   #

--- a/library/general/src/lib/y2issues.rb
+++ b/library/general/src/lib/y2issues.rb
@@ -46,6 +46,7 @@ require "y2issues/list"
 require "y2issues/presenter"
 require "y2issues/location"
 require "y2issues/reporter"
+require "y2issues/autoinst_reporter"
 
 # Issues types
 require "y2issues/issue"

--- a/library/general/src/lib/y2issues/autoinst_reporter.rb
+++ b/library/general/src/lib/y2issues/autoinst_reporter.rb
@@ -31,6 +31,12 @@ module Y2Issues
   # possibility to abort. Thus, the return value of {#report} must be checked by the caller
   # to handle that situation.
   class AutoinstReporter < Reporter
+    # @see Reporter#initialize
+    def initialize(*args)
+      super(*args)
+      textdomain "base"
+    end
+
   private
 
     # Displays a pop-up containing the issues

--- a/library/general/src/lib/y2issues/autoinst_reporter.rb
+++ b/library/general/src/lib/y2issues/autoinst_reporter.rb
@@ -1,0 +1,62 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2issues/reporter"
+
+Yast.import "Label"
+Yast.import "HTML"
+
+module Y2Issues
+  # This class provides a mechanism to report YaST2 issues at the beginning of the AutoYaST
+  # installation process, before any real change has been done to the system
+  #
+  # In contrast to the base reporter (which only informs the user), this gives the user the
+  # possibility to abort. Thus, the return value of {#report} must be checked by the caller
+  # to handle that situation.
+  class AutoinstReporter < Reporter
+  private
+
+    # Displays a pop-up containing the issues
+    #
+    # It can behave in two different ways depending if the issues are only
+    # warnings or an error was found:
+    #
+    # * Ask the user if she/he wants to continue or abort the installation.
+    # * Display a message and only offer an 'Abort' button.
+    def show_issues
+      if level == :error
+        headline = :error
+        buttons = { abort: Yast::Label.AbortButton }
+        question = _("Please, correct these problems and try again.")
+        timeout = 0
+      else
+        headline = :warning
+        buttons = :yes_no
+        question = _("Do you want to continue?")
+        timeout = @timeout
+      end
+
+      content = presenter.to_html + Yast::HTML.Para(question)
+      Yast2::Popup.show(
+        content, richtext: true, headline: headline, buttons: buttons, timeout: timeout
+      )
+    end
+  end
+end

--- a/library/general/src/lib/y2issues/issue.rb
+++ b/library/general/src/lib/y2issues/issue.rb
@@ -27,7 +27,7 @@ module Y2Issues
   # specific information. See {InvalidValue} as an example.
   #
   # @example Create a new error
-  #   Issue.new("Could not read network configuration", severity: :fatal)
+  #   Issue.new("Could not read network configuration", severity: :error)
   #
   # @example Create an error from an specific location
   #   Issue.new(
@@ -42,25 +42,27 @@ module Y2Issues
     attr_reader :location
     # @return [String] Error message
     attr_reader :message
-    # @return [Symbol] Error severity (:warn, :fatal)
+    # @return [Symbol] Error severity (:warn, :error)
     attr_reader :severity
 
     # @param message [String] User-oriented message describing the problem
     # @param location [String,nil] Where the error is located. Use a URI or
     #   a string to represent the error location. Use 'nil' if it
     #   does not exist an specific location.
-    # @param severity [Symbol] warning (:warn) or fatal (:fatal)
+    # @param severity [Symbol] warning (:warn) or error (:error)
     def initialize(message, location: nil, severity: :warn)
       @message = message
       @location = location.is_a?(String) ? Location.parse(location) : location
       @severity = severity
     end
 
-    # Determines whether the error is fatal or not
+    # Determines whether the issue is an error
     #
     # @return [Boolean]
-    def fatal?
-      @severity == :fatal
+    def error?
+      @severity == :error
     end
+
+    alias_method :fatal?, :error?
   end
 end

--- a/library/general/src/lib/y2issues/list.rb
+++ b/library/general/src/lib/y2issues/list.rb
@@ -34,12 +34,14 @@ module Y2Issues
       @items = issues
     end
 
-    # Determine whether any of the problem on the list is fatal
+    # Determine whether any of the issues on the list is an error
     #
-    # @return [Boolean] true if any of them is a fatal problem
-    def fatal?
-      any?(&:fatal?)
+    # @return [Boolean]
+    def error?
+      any?(&:error?)
     end
+
+    alias_method :fatal?, :error?
 
     # Returns an array containing registered problems
     #

--- a/library/general/src/lib/y2issues/presenter.rb
+++ b/library/general/src/lib/y2issues/presenter.rb
@@ -48,10 +48,10 @@ module Y2Issues
     #
     # @return [String] HTML representing the list of issues
     def to_html
-      fatal, non_fatal = issues.partition(&:fatal?)
+      errors, warnings = issues.partition(&:error?)
       parts = []
-      parts << error_text(fatal) unless fatal.empty?
-      parts << warning_text(non_fatal) unless non_fatal.empty?
+      parts << error_text(errors) unless errors.empty?
+      parts << warning_text(warnings) unless warnings.empty?
 
       parts.join
     end

--- a/library/general/src/lib/y2issues/reporter.rb
+++ b/library/general/src/lib/y2issues/reporter.rb
@@ -37,7 +37,7 @@ module Y2Issues
     def initialize(issues, report_settings: Yast::Report.Export)
       textdomain "base"
       @presenter = Presenter.new(issues)
-      @level = issues.fatal? ? :error : :warn
+      @level = issues.error? ? :error : :warn
       @log, @show, @timeout = find_settings(report_settings, @level)
     end
 
@@ -55,7 +55,8 @@ module Y2Issues
 
     # Displays a pop-up containing the issues
     #
-    # It can behave in two different ways depending if a fatal issue was found:
+    # It can behave in two different ways depending if the issues are only
+    # warnings or an error was found:
     #
     # * Ask the user if she/he wants to continue or abort the installation.
     # * Display a message and only offer an 'Abort' button.

--- a/library/general/src/lib/y2issues/reporter.rb
+++ b/library/general/src/lib/y2issues/reporter.rb
@@ -20,7 +20,6 @@
 require "yast"
 require "y2issues"
 
-Yast.import "Label"
 Yast.import "Report"
 
 module Y2Issues
@@ -44,6 +43,8 @@ module Y2Issues
     # Reports the issues to the user
     #
     # Depending on the given report settings, it may display a pop-up, and/or log the error.
+    #
+    # @return [Symbol, nil] response of the user to the pop-up, nil if no pop-up was displayed
     def report
       log_issues if @log
       show_issues if @show
@@ -54,28 +55,10 @@ module Y2Issues
     attr_reader :level, :presenter
 
     # Displays a pop-up containing the issues
-    #
-    # It can behave in two different ways depending if the issues are only
-    # warnings or an error was found:
-    #
-    # * Ask the user if she/he wants to continue or abort the installation.
-    # * Display a message and only offer an 'Abort' button.
     def show_issues
-      if level == :error
-        headline = :error
-        buttons = { abort: Yast::Label.AbortButton }
-        question = _("Please, correct these problems and try again.")
-        timeout = 0
-      else
-        headline = :warning
-        buttons = :yes_no
-        question = _("Do you want to continue?")
-        timeout = @timeout
-      end
-
-      content = presenter.to_html + Yast::HTML.Para(question)
+      head = (level == :error) ? :error : :warning
       Yast2::Popup.show(
-        content, richtext: true, headline: headline, buttons: buttons, timeout: timeout
+        presenter.to_html, richtext: true, headline: head, buttons: :ok, timeout: @timeout
       )
     end
 

--- a/library/general/test/y2issues/autoinst_reporter_test.rb
+++ b/library/general/test/y2issues/autoinst_reporter_test.rb
@@ -21,7 +21,7 @@
 require_relative "../test_helper"
 require "y2issues"
 
-describe Y2Issues::Reporter do
+describe Y2Issues::AutoinstReporter do
   let(:reporter) { described_class.new(list, report_settings: report) }
   let(:list) { Y2Issues::List.new([issue]) }
   let(:issue) do
@@ -54,9 +54,10 @@ describe Y2Issues::Reporter do
     context "when there is an error" do
       let(:level) { :error }
 
-      it "displays issues as errors with the corresponding timeout" do
+      it "displays issues as errors with no timeout" do
         expect(Yast2::Popup).to receive(:show) .with(
-          /Important issues/, headline: :error, richtext: true, timeout: 15, buttons: :ok
+          /Important issues/, headline: :error, richtext: true, timeout: 0,
+          buttons: a_hash_including(abort: String)
         )
         reporter.report
       end
@@ -90,7 +91,8 @@ describe Y2Issues::Reporter do
 
       it "displays issues as warnings with the corresponding timeout" do
         expect(Yast2::Popup).to receive(:show) .with(
-          /Minor issues/, headline: :warning, richtext: true, timeout: 10, buttons: :ok
+          /Minor issues/, headline: :warning, richtext: true, timeout: 10,
+          buttons: :yes_no
         )
         reporter.report
       end

--- a/library/general/test/y2issues/issue_test.rb
+++ b/library/general/test/y2issues/issue_test.rb
@@ -27,14 +27,14 @@ describe Y2Issues::Issue do
       described_class.new(
         "Something went wrong",
         location: Y2Issues::Location.parse("file:/etc/hosts"),
-        severity: :fatal
+        severity: :error
       )
     end
 
     it "creates an issue" do
       expect(issue.message).to eq("Something went wrong")
       expect(issue.location).to eq(Y2Issues::Location.parse("file:/etc/hosts"))
-      expect(issue.severity).to eq(:fatal)
+      expect(issue.severity).to eq(:error)
     end
 
     context "when location is given as a string" do
@@ -59,20 +59,20 @@ describe Y2Issues::Issue do
     end
   end
 
-  describe "#fatal?" do
-    context "when severity is :fatal" do
-      subject(:issue) { described_class.new("Something went wrong", severity: :fatal) }
+  describe "#error?" do
+    context "when severity is :error" do
+      subject(:issue) { described_class.new("Something went wrong", severity: :error) }
 
       it "returns true" do
-        expect(issue.fatal?).to eq(true)
+        expect(issue.error?).to eq(true)
       end
     end
 
-    context "when severity is :fatal" do
+    context "when severity is :error" do
       subject(:issue) { described_class.new("Something went wrong", severity: :warn) }
 
       it "returns false" do
-        expect(issue.fatal?).to eq(false)
+        expect(issue.error?).to eq(false)
       end
     end
   end

--- a/library/general/test/y2issues/list_test.rb
+++ b/library/general/test/y2issues/list_test.rb
@@ -56,18 +56,18 @@ describe Y2Issues::List do
     end
   end
 
-  describe "#fatal?" do
-    context "when contains some fatal error" do
-      let(:issue) { Y2Issues::Issue.new("Something went wrong", severity: :fatal) }
+  describe "#error?" do
+    context "when contains some error" do
+      let(:issue) { Y2Issues::Issue.new("Something went wrong", severity: :error) }
 
       it "returns true" do
-        expect(list.fatal?).to eq(true)
+        expect(list.error?).to eq(true)
       end
     end
 
-    context "when does not contain any fatal error" do
+    context "when does not contain any error error" do
       it "returns false" do
-        expect(list.fatal?).to eq(false)
+        expect(list.error?).to eq(false)
       end
 
     end

--- a/library/general/test/y2issues/presenter_test.rb
+++ b/library/general/test/y2issues/presenter_test.rb
@@ -26,9 +26,9 @@ describe Y2Issues::Presenter do
   let(:list) { Y2Issues::List.new }
 
   describe "#to_html" do
-    context "when a fatal issue was found" do
+    context "when an error was found" do
       before do
-        list << Y2Issues::Issue.new("Something is invalid", severity: :fatal)
+        list << Y2Issues::Issue.new("Something is invalid", severity: :error)
       end
 
       it "includes issues messages" do
@@ -36,12 +36,12 @@ describe Y2Issues::Presenter do
         expect(presenter.to_html.to_s).to include "<li>#{issue.message}</li>"
       end
 
-      it "includes an introduction to fatal issues qlist" do
+      it "includes an introduction to the errors list" do
         expect(presenter.to_html.to_s).to include "Important issues"
       end
     end
 
-    context "when a non fatal issue was found" do
+    context "when a warning was found" do
       before do
         list << Y2Issues::Issue.new("Something is missing", severity: :warn)
       end
@@ -51,7 +51,7 @@ describe Y2Issues::Presenter do
         expect(presenter.to_html.to_s).to include "<li>#{issue.message}</li>"
       end
 
-      it "includes an introduction to non fatal issues list" do
+      it "includes an introduction to the warnings list" do
         expect(presenter.to_html.to_s).to include "<p>Minor issues"
       end
     end

--- a/library/general/test/y2issues/reporter_test.rb
+++ b/library/general/test/y2issues/reporter_test.rb
@@ -39,7 +39,7 @@ describe Y2Issues::Reporter do
   let(:errors_settings) do
     { "log" => true, "show" => true, "timeout" => 15 }
   end
-  let(:level) { :fatal }
+  let(:level) { :error }
 
   describe "#report" do
     before do
@@ -51,8 +51,8 @@ describe Y2Issues::Reporter do
       reporter.report
     end
 
-    context "when there is a fatal error" do
-      let(:level) { :fatal }
+    context "when there is an error" do
+      let(:level) { :error }
 
       it "displays issues as errors with no timeout" do
         expect(Yast2::Popup).to receive(:show) .with(

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,17 +1,17 @@
 -------------------------------------------------------------------
 Tue Jun 22 10:00:23 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
-- Y2Issue::Issue: renamed severity "fatal" to "error", to be more
+- Y2Issues::Issue: renamed severity "fatal" to "error", to be more
   consistent with other parts of (Auto)YaST
-- Changed behavior of Y2Issue::Reporter to be more generic (related
-  to jsc#PM-2620 and bsc#1166743)
-- Introduced Y2Issue::AutoinstReporter to retain the old behavior
+- Changed behavior of Y2Issues::Reporter to be more generic
+  (related to jsc#PM-2620 and bsc#1166743)
+- Introduced Y2Issues::AutoinstReporter to retain the old behavior
 - 4.4.14
 
 -------------------------------------------------------------------
 Mon Jun 21 20:51:57 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
-- Y2Issue::List: Add methods size and concat (related to
+- Y2Issues::List: Add methods size and concat (related to
   bsc#1181295).
 - 4.4.13
 
@@ -97,7 +97,7 @@ Tue Apr 27 10:51:35 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 -------------------------------------------------------------------
 Thu Apr 22 06:35:11 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
-- The location given to the Y2Issue::Issue constructor can be a
+- The location given to the Y2Issues::Issue constructor can be a
   string or a location object.
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Tue Jun 22 10:00:23 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Y2Issue::Issue: renamed severity "fatal" to "error", to be more
+  consistent with other parts of (Auto)YaST
+- Changed behavior of Y2Issue::Reporter to be more generic (related
+  to jsc#PM-2620 and bsc#1166743)
+- Introduced Y2Issue::AutoinstReporter to retain the old behavior
+- 4.4.14
+
+-------------------------------------------------------------------
 Mon Jun 21 20:51:57 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Y2Issue::List: Add methods size and concat (related to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.13
+Version:        4.4.14
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Problem

During the partial re-implementation of yast2-users, we found a couple of things to be improved in Y2Issues.

1) The Y2Issues severity levels were `:warn` and `:fatal`. But other parts of YaST use slightly different conventions for similar concepts[1]:
  - In the module `Report` there are functions line, `Message`,  `Warning` and `Error`.
  - In the `<report>` section of the AutoYaST profile, it's possible to define the behavior for the following categories: errors, warnings, messages, yesno_messages.

2) The current implementation of `Y2Issues::Reporter` was too focused in a single use case - showing errors found while processing the AutoYaST profile and offering the user the opportunity to abort installation.

## Solution

- Renamed `:fatal` to `:error`.
- Changed behavior of `Y2Issue::Reporter` to be more generic, just displaying the errors
- Introduced `Y2Issue::AutoinstReporter` to retain the old behavior

## Pending

- Adapt yast2-network to the new API
- Adapt yast2-users (the new y2users branch) to the new API
- Manual testing

## Notes

[1] The installation proposals follow a different convention, but I don't think it's expected to use Y2Issues in that context. Just for completeness, let's list here the warning levels accepted for a proposal:

  - `:notice`
  - `:warning` (default)
  - `:error`
  - `:blocker`
  - `:fatal`

A `:blocker` will prevent the user from continuing the installation. If any proposal contains a blocker warning, the Accept button in the proposal dialog will be disabled - the user needs to fix that blocker before continuing.

`:fatal` is like `:blocker` but also stops building the proposal.

An `:error` does not prevent continuing of the installation, but shows a popup that an user has to confirm to continue with the installation.
