### PR TITLE
Small reorganization in Y2Issues

### DIFF
--- a/library/general/src/lib/installation/autoinst_issues/missing_value.rb
+++ b/library/general/src/lib/installation/autoinst_issues/missing_value.rb
@@ -32,7 +32,7 @@ module Installation
       # @param section     [String] Section where it was detected
       # @param attribute   [String] Name of the missing attribute
       # @param description [String] additional explanation; optional
-      # @param severity    [Symbol] :warn, :fatal = abort the installation ; optional
+      # @param severity    [Symbol] :warn, :error = abort the installation ; optional
       def initialize(section, attr, description = "", severity = :warn)
         textdomain "base"
 

--- a/library/general/src/lib/y2issues.rb
+++ b/library/general/src/lib/y2issues.rb
@@ -35,10 +35,13 @@ module Y2Issues
   # This is a helper method that offers an stable API on top of {Reporter}. Depending on
   # Yast::Report settings, it may show a pop-up with the found issues and log them.
   #
-  # @param [List] Issues list
+  # @param issues [List] Issues list
+  # @param warn [Symbol] what to do if the list of issues only contains warnings
+  # @param error [Symbol] what to do if the list of issues contains some error
+  # @return [Boolean] whether the process may continue, false means YaST is expected to abort
   # @see Y2Issues::Reporter
-  def self.report(issues)
-    Reporter.new(issues).report
+  def self.report(issues, warn: :ask, error: :abort)
+    Reporter.new(issues).report(warn: warn, error: error)
   end
 end
 

--- a/library/general/src/lib/y2issues.rb
+++ b/library/general/src/lib/y2issues.rb
@@ -28,7 +28,7 @@
 #
 # @example Registering an error
 #   list = Y2Issues::List.new
-#   list << Y2Issues::Issue.new("Could not read network configuration", severity: :fatal)
+#   list << Y2Issues::Issue.new("Could not read network configuration", severity: :error)
 module Y2Issues
   # Reports the errors to the user
   #

--- a/library/general/src/lib/y2issues/issue.rb
+++ b/library/general/src/lib/y2issues/issue.rb
@@ -27,7 +27,7 @@ module Y2Issues
   # specific information. See {InvalidValue} as an example.
   #
   # @example Create a new error
-  #   Issue.new("Could not read network configuration", severity: :fatal)
+  #   Issue.new("Could not read network configuration", severity: :error)
   #
   # @example Create an error from an specific location
   #   Issue.new(
@@ -42,25 +42,27 @@ module Y2Issues
     attr_reader :location
     # @return [String] Error message
     attr_reader :message
-    # @return [Symbol] Error severity (:warn, :fatal)
+    # @return [Symbol] Error severity (:warn, :error)
     attr_reader :severity
 
     # @param message [String] User-oriented message describing the problem
     # @param location [String,nil] Where the error is located. Use a URI or
     #   a string to represent the error location. Use 'nil' if it
     #   does not exist an specific location.
-    # @param severity [Symbol] warning (:warn) or fatal (:fatal)
+    # @param severity [Symbol] warning (:warn) or error (:error)
     def initialize(message, location: nil, severity: :warn)
       @message = message
       @location = location.is_a?(String) ? Location.parse(location) : location
       @severity = severity
     end
 
-    # Determines whether the error is fatal or not
+    # Determines whether the issue is an error
     #
     # @return [Boolean]
-    def fatal?
-      @severity == :fatal
+    def error?
+      @severity == :error
     end
+
+    alias_method :fatal?, :error?
   end
 end

--- a/library/general/src/lib/y2issues/list.rb
+++ b/library/general/src/lib/y2issues/list.rb
@@ -34,12 +34,14 @@ module Y2Issues
       @items = issues
     end
 
-    # Determine whether any of the problem on the list is fatal
+    # Determine whether any of the issues on the list is an error
     #
-    # @return [Boolean] true if any of them is a fatal problem
-    def fatal?
-      any?(&:fatal?)
+    # @return [Boolean]
+    def error?
+      any?(&:error?)
     end
+
+    alias_method :fatal?, :error?
 
     # Returns an array containing registered problems
     #

--- a/library/general/src/lib/y2issues/presenter.rb
+++ b/library/general/src/lib/y2issues/presenter.rb
@@ -48,10 +48,10 @@ module Y2Issues
     #
     # @return [String] HTML representing the list of issues
     def to_html
-      fatal, non_fatal = issues.partition(&:fatal?)
+      errors, warnings = issues.partition(&:error?)
       parts = []
-      parts << error_text(fatal) unless fatal.empty?
-      parts << warning_text(non_fatal) unless non_fatal.empty?
+      parts << error_text(errors) unless errors.empty?
+      parts << warning_text(warnings) unless warnings.empty?
 
       parts.join
     end

--- a/library/general/src/lib/y2issues/reporter.rb
+++ b/library/general/src/lib/y2issues/reporter.rb
@@ -37,7 +37,7 @@ module Y2Issues
     def initialize(issues, report_settings: Yast::Report.Export)
       textdomain "base"
       @presenter = Presenter.new(issues)
-      @level = issues.fatal? ? :error : :warn
+      @level = issues.error? ? :error : :warn
       @log, @show, @timeout = find_settings(report_settings, @level)
     end
 
@@ -55,7 +55,8 @@ module Y2Issues
 
     # Displays a pop-up containing the issues
     #
-    # It can behave in two different ways depending if a fatal issue was found:
+    # It can behave in two different ways depending if the issues are only
+    # warnings or an error was found:
     #
     # * Ask the user if she/he wants to continue or abort the installation.
     # * Display a message and only offer an 'Abort' button.

--- a/library/general/src/lib/y2issues/reporter.rb
+++ b/library/general/src/lib/y2issues/reporter.rb
@@ -22,6 +22,7 @@ require "y2issues"
 
 Yast.import "Label"
 Yast.import "Report"
+Yast.import "HTML"
 
 module Y2Issues
   # This class provides a mechanism to report YaST2 issues
@@ -44,39 +45,94 @@ module Y2Issues
     # Reports the issues to the user
     #
     # Depending on the given report settings, it may display a pop-up, and/or log the error.
-    def report
+    #
+    # In case of displaying the pop-up, the way to present the information and the possible return
+    # values are determined by the severity of the issues and the value of `warn` and `error`.
+    #
+    # If the value specified for the corresponding level is :abort, the pop-up contains the
+    # information and a single button to abort, the method returns false.
+    #
+    # If the value is :ask, the information is presented and the user is asked whether they want to
+    # continue or abort. The returned value depends on the answer.
+    #
+    # In the value is :continue (or any other symbol), the information is displayed with a button to
+    # simply close the pop-up and the method always returns true.
+    #
+    # @param warn [Symbol] what to do if the list of issues only contains warnings
+    # @param error [Symbol] what to do if the list of issues contains some error
+    # @return [Boolean] whether the process may continue, false means aborting
+    def report(warn: :ask, error: :abort)
       log_issues if @log
-      show_issues if @show
+      return true unless @show
+
+      show_issues(warn, error)
     end
 
   private
 
-    attr_reader :level, :presenter
+    # Severity of the set of issues
+    #
+    # @return [Symbol] :warn if all the issues are just warnings, :error if any
+    #   of the issues is an error
+    attr_reader :level
+
+    # @return [Presenter]
+    attr_reader :presenter
 
     # Displays a pop-up containing the issues
     #
-    # It can behave in two different ways depending if the issues are only
-    # warnings or an error was found:
-    #
-    # * Ask the user if she/he wants to continue or abort the installation.
-    # * Display a message and only offer an 'Abort' button.
-    def show_issues
-      if level == :error
-        headline = :error
-        buttons = { abort: Yast::Label.AbortButton }
-        question = _("Please, correct these problems and try again.")
-        timeout = 0
+    # @return [Boolean] see {#report}
+    def show_issues(warn, error)
+      action = (level == :error) ? error : warn
+      case action
+      when :abort
+        show_issues_abort
+      when :ask
+        show_issues_ask
       else
-        headline = :warning
-        buttons = :yes_no
-        question = _("Do you want to continue?")
-        timeout = @timeout
+        show_issues_continue
       end
+    end
 
-      content = presenter.to_html + Yast::HTML.Para(question)
-      Yast2::Popup.show(
-        content, richtext: true, headline: headline, buttons: buttons, timeout: timeout
-      )
+    # @see #show_issues
+    #
+    # @return [Boolean] see {#report}, always false in this case
+    def show_issues_abort
+      buttons = { abort: Yast::Label.AbortButton }
+      question = _("Please, correct these problems and try again.")
+      popup(question, buttons, with_timeout: false)
+
+      false
+    end
+
+    # @see #show_issues
+    #
+    # @return [Boolean] see {#report}
+    def show_issues_ask
+      popup(_("Do you want to continue?"), :yes_no) == :yes
+    end
+
+    # @see #show_issues
+    #
+    # @return [Boolean] see {#report}, always true in this case
+    def show_issues_continue
+      popup("", :ok)
+      true
+    end
+
+    # Displays pop-up with information about the issues
+    def popup(footer, btns, with_timeout: true)
+      text = presenter.to_html
+      text += Yast::HTML.Para(footer) if footer && !footer.empty?
+      time = with_timeout ? @timeout : 0
+      Yast2::Popup.show(text, richtext: true, headline: header, buttons: btns, timeout: time)
+    end
+
+    # @see #popup
+    def header
+      return :error if level == :error
+
+      :warning
     end
 
     # Writes the issues

--- a/library/general/test/y2issues/issue_test.rb
+++ b/library/general/test/y2issues/issue_test.rb
@@ -27,14 +27,14 @@ describe Y2Issues::Issue do
       described_class.new(
         "Something went wrong",
         location: Y2Issues::Location.parse("file:/etc/hosts"),
-        severity: :fatal
+        severity: :error
       )
     end
 
     it "creates an issue" do
       expect(issue.message).to eq("Something went wrong")
       expect(issue.location).to eq(Y2Issues::Location.parse("file:/etc/hosts"))
-      expect(issue.severity).to eq(:fatal)
+      expect(issue.severity).to eq(:error)
     end
 
     context "when location is given as a string" do
@@ -59,20 +59,20 @@ describe Y2Issues::Issue do
     end
   end
 
-  describe "#fatal?" do
-    context "when severity is :fatal" do
-      subject(:issue) { described_class.new("Something went wrong", severity: :fatal) }
+  describe "#error?" do
+    context "when severity is :error" do
+      subject(:issue) { described_class.new("Something went wrong", severity: :error) }
 
       it "returns true" do
-        expect(issue.fatal?).to eq(true)
+        expect(issue.error?).to eq(true)
       end
     end
 
-    context "when severity is :fatal" do
+    context "when severity is :error" do
       subject(:issue) { described_class.new("Something went wrong", severity: :warn) }
 
       it "returns false" do
-        expect(issue.fatal?).to eq(false)
+        expect(issue.error?).to eq(false)
       end
     end
   end

--- a/library/general/test/y2issues/list_test.rb
+++ b/library/general/test/y2issues/list_test.rb
@@ -56,18 +56,18 @@ describe Y2Issues::List do
     end
   end
 
-  describe "#fatal?" do
-    context "when contains some fatal error" do
-      let(:issue) { Y2Issues::Issue.new("Something went wrong", severity: :fatal) }
+  describe "#error?" do
+    context "when contains some error" do
+      let(:issue) { Y2Issues::Issue.new("Something went wrong", severity: :error) }
 
       it "returns true" do
-        expect(list.fatal?).to eq(true)
+        expect(list.error?).to eq(true)
       end
     end
 
-    context "when does not contain any fatal error" do
+    context "when does not contain any error error" do
       it "returns false" do
-        expect(list.fatal?).to eq(false)
+        expect(list.error?).to eq(false)
       end
 
     end

--- a/library/general/test/y2issues/presenter_test.rb
+++ b/library/general/test/y2issues/presenter_test.rb
@@ -26,9 +26,9 @@ describe Y2Issues::Presenter do
   let(:list) { Y2Issues::List.new }
 
   describe "#to_html" do
-    context "when a fatal issue was found" do
+    context "when an error was found" do
       before do
-        list << Y2Issues::Issue.new("Something is invalid", severity: :fatal)
+        list << Y2Issues::Issue.new("Something is invalid", severity: :error)
       end
 
       it "includes issues messages" do
@@ -36,12 +36,12 @@ describe Y2Issues::Presenter do
         expect(presenter.to_html.to_s).to include "<li>#{issue.message}</li>"
       end
 
-      it "includes an introduction to fatal issues qlist" do
+      it "includes an introduction to the errors list" do
         expect(presenter.to_html.to_s).to include "Important issues"
       end
     end
 
-    context "when a non fatal issue was found" do
+    context "when a warning was found" do
       before do
         list << Y2Issues::Issue.new("Something is missing", severity: :warn)
       end
@@ -51,7 +51,7 @@ describe Y2Issues::Presenter do
         expect(presenter.to_html.to_s).to include "<li>#{issue.message}</li>"
       end
 
-      it "includes an introduction to non fatal issues list" do
+      it "includes an introduction to the warnings list" do
         expect(presenter.to_html.to_s).to include "<p>Minor issues"
       end
     end

--- a/library/general/test/y2issues/reporter_test.rb
+++ b/library/general/test/y2issues/reporter_test.rb
@@ -39,7 +39,7 @@ describe Y2Issues::Reporter do
   let(:errors_settings) do
     { "log" => true, "show" => true, "timeout" => 15 }
   end
-  let(:level) { :fatal }
+  let(:level) { :error }
 
   describe "#report" do
     before do
@@ -51,8 +51,8 @@ describe Y2Issues::Reporter do
       reporter.report
     end
 
-    context "when there is a fatal error" do
-      let(:level) { :fatal }
+    context "when there is an error" do
+      let(:level) { :error }
 
       it "displays issues as errors with no timeout" do
         expect(Yast2::Popup).to receive(:show) .with(

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,16 @@
 -------------------------------------------------------------------
+Wed Jun 23 13:24:04 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Y2Issues::Issue: renamed severity "fatal" to "error", to be more
+  consistent with other parts of (Auto)YaST
+- Added options to configure the behavior of Y2Issues.report
+  (related to jsc#PM-2620 and bsc#1166743)
+- 4.4.14
+
+-------------------------------------------------------------------
 Mon Jun 21 20:51:57 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
-- Y2Issue::List: Add methods size and concat (related to
+- Y2Issues::List: Add methods size and concat (related to
   bsc#1181295).
 - 4.4.13
 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.13
+Version:        4.4.14
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Related pull requests

- This replaces #1177 
- Adapt yast2-users (Y2Users branch): https://github.com/yast/yast-users/pull/314
- Adapt yast2-network: https://github.com/yast/yast-network/pull/1240

## Problem

During the partial re-implementation of yast2-users, we found a couple of things to be improved in Y2Issues.

1) The Y2Issues severity levels were `:warn` and `:fatal`. But other parts of YaST use slightly different conventions for similar concepts[1]:
  - In the module `Report` there are functions line, `Message`,  `Warning` and `Error`.
  - In the `<report>` section of the AutoYaST profile, it's possible to define the behavior for the following categories: errors, warnings, messages, yesno_messages.

2) The current implementation of `Y2Issues.report` was too focused in a single use case - showing errors found while processing the AutoYaST profile and offering the user the opportunity to abort installation.

## Solution

- Renamed `:fatal` to `:error`.
- Extended `Y2Issue.report` with two new arguments that allow to specify what to do depending on the severity of the issues.

## Testing

- Adapted unit tests
- Manually tested with y2users with different usages of the reporter. See screenshots.

![reporter-ask](https://user-images.githubusercontent.com/3638289/123122633-7a532280-d446-11eb-8f32-830af1dc127f.png)

![reporter-continue](https://user-images.githubusercontent.com/3638289/123122699-85a64e00-d446-11eb-85f7-215a98b3cc40.png)


## Notes

[1] The installation proposals follow a different convention, but I don't think it's expected to use Y2Issues in that context. Just for completeness, let's list here the warning levels accepted for a proposal:

  - `:notice`
  - `:warning` (default)
  - `:error`
  - `:blocker`
  - `:fatal`

A `:blocker` will prevent the user from continuing the installation. If any proposal contains a blocker warning, the Accept button in the proposal dialog will be disabled - the user needs to fix that blocker before continuing.

`:fatal` is like `:blocker` but also stops building the proposal.

An `:error` does not prevent continuing of the installation, but shows a popup that an user has to confirm to continue with the installation.
