### PR TITLE
Prevent Crash if Replacing Content of Nonexistent Replace Point

### DIFF
--- a/library/wizard/test/manual/progress_demo.rb
+++ b/library/wizard/test/manual/progress_demo.rb
@@ -46,7 +46,6 @@
 require "yast"
 
 module Yast
-
   class ProgressDemo < Client
     include Yast::Logger
 
@@ -196,7 +195,7 @@ module Yast
 
     # Event handler for the main dialog as well as for any open popups
     def handle_events
-      while true
+      loop do
         input = UI.UserInput
         log.info("Input: \"#{input}\"")
 

--- a/library/wizard/test/manual/progress_demo.rb
+++ b/library/wizard/test/manual/progress_demo.rb
@@ -1,0 +1,150 @@
+#!/usr/bin/env ruby
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+#
+# Manual demo and testing client for the Progress.rb module
+#
+# Start with
+#
+#   yast2 ./progress_demo
+#
+# and click though the application.
+#
+
+require "yast"
+
+module Yast
+
+  class ProgressDemo < Client
+    include Yast::Logger
+
+    def initialize
+      Yast.import "UI"
+
+      @popup_count = 0
+    end
+
+    def run
+      UI.OpenDialog(content)
+      handle_events
+      UI.CloseDialog
+    end
+
+    def content
+      MinSize(
+        Id(:main_dialog),
+        60, 20,
+        MarginBox(
+          2, 0.45,
+          VBox(
+            HVCenter(
+              Label("Hello, World!")
+            ),
+            main_buttons
+          )
+        )
+      )
+    end
+
+    def main_buttons
+      HBox(
+        HStretch(),
+        *common_buttons,
+        HSpacing(3),
+        PushButton(Id(:quit), "&Quit")
+      )
+    end
+
+    def common_buttons
+      [
+        PushButton(Id(:progress), "&Progress"),
+        PushButton(Id(:open_popup), "&Open Popup")
+      ]
+    end
+
+    def open_popup
+      @popup_count += 1
+      UI.OpenDialog(popup_content)
+    end
+
+    def popup?
+      UI.WidgetExists(:popup_dialog)
+    end
+
+    def close_popup
+      if popup?
+        UI.CloseDialog
+        @popup_count -= 1
+      else
+        log.warn("No popup dialog to close")
+      end
+    end
+
+    def popup_content
+      MarginBox(
+        Id(:popup_dialog),
+        2, 0.45,
+        VBox(
+          HVCenter(
+            Label("Popup dialog ##{@popup_count} that gets in the way")
+          ),
+          popup_buttons
+        )
+      )
+    end
+
+    def popup_buttons
+      HBox(
+        HStretch(),
+        *common_buttons,
+        PushButton(Id(:close_popup), "&Close Popup"),
+        HStretch()
+      )
+    end
+
+    # Event handler for the main dialog as well as for any open popups
+    def handle_events
+      while true
+        input = UI.UserInput
+        log.info("Input: \"#{input}\"")
+
+        case input
+        when :quit
+          break # leave event loop
+        when :open_popup
+          open_popup
+        when :close_popup
+          close_popup
+        when :cancel # :cancel is WM_CLOSE
+          if popup?
+            close_popup
+          else
+            break # leave event loop
+          end
+        end
+
+        input
+      end
+    end
+  end
+end
+
+Yast::ProgressDemo.new.run

--- a/library/wizard/test/manual/progress_demo.rb
+++ b/library/wizard/test/manual/progress_demo.rb
@@ -194,6 +194,8 @@ module Yast
     end
 
     # Event handler for the main dialog as well as for any open popups
+    #
+    # rubocop:disable Style/GuardClause
     def handle_events
       loop do
         input = UI.UserInput
@@ -223,6 +225,7 @@ module Yast
         input
       end
     end
+    # rubocop:enable Style/GuardClause
 
     # Open a dialog to ask the user which progress type to use and set the
     # internal @progress_type member variable accordingly.

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 14 16:06:50 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't crash with UI exception in Progress.rb if a popup is in the way
+  (bsc#1187676)
+- 4.3.64
+
+-------------------------------------------------------------------
 Tue Jun  8 08:26:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Ignore sysctl configuration files that do not have the .conf

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.63
+Version:        4.3.64
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
_**This is the fix for SLE-15-SP3. The merge to master will follow.**_

## Trello

https://trello.com/c/wC5C2kRW

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1187676

## Problem

Under some circumstances, updating progress in the _Progress_ module can lead to a crash with a UI error "No widget with ID ...".

## Probable Cause

Another pop-up dialog may be in the way, e.g. during some libzypp callbacks. That will then be the topmost dialog, and of course that dialog does not have the expected widget tree, i.e. not the ReplacePoint that the _Progress_ module wants to modify with `UI.ReplaceWidget()`.

## Fix

Be more defensive in that _Progress_ module: Check if the expected widget exists in the current dialog before trying to exchange its content.

## Test

There was no test environment for the _Progress_ module at all: The only way of testing it was with a live YaST module. But that makes it complicated to get into all cases; and, worse for this bug, there is no way to enforce a popup dialog being in the way.

So I added a new manual test client for this. It's not realistically possible to do that with auto-tests, so this needs some manual interaction and _watching_ what happens.

The new test client is started from the test directory:

```
cd yast-yast2/library/wizard/test/manual
yast2 ./progress_demo
```

or, for NCurses:

```
yast2 ./progress_demo --ncurses
```

It first asks which progress scenario to use:

![progress-demo-01-ask-type](https://user-images.githubusercontent.com/11538225/125653665-b05e4c9d-0890-48cd-845c-6917a75c4e8c.png)

Then it opens one of either:

![progress-demo-02-simple-main](https://user-images.githubusercontent.com/11538225/125653704-bc0209b5-b597-4654-88b4-b41911129d71.png)
_Simple progress_

![progress-demo-04-complex-main](https://user-images.githubusercontent.com/11538225/125653754-08bb109f-bc91-4339-9f3b-d87aaae0774d.png)
_Complex progress_

In either case, there are some buttons which directly correspond to the exported actions of the _Progress_ module, and you can open one or more pop-up dialogs that get in the way (which is the purpose of this test for this bug). That pop-up has the same buttons to test the _Progress_ module's behaviour.

![progress-demo-03-simple-popup](https://user-images.githubusercontent.com/11538225/125654504-d8653832-d812-4150-953b-4ed88250b2d3.png)
_With popup dialog in the way_

Clicking around on those buttons might not update the progress output correctly, but it should at least not crash with a UI exception and error dialog.