### PR TITLE
Prevent Crash if Replacing Content of Nonexistent Replace Point [merge to master]

### DIFF
--- a/library/wizard/test/manual/progress_demo.rb
+++ b/library/wizard/test/manual/progress_demo.rb
@@ -1,0 +1,264 @@
+#!/usr/bin/env ruby
+
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+#---------------------------------------------------------------------------
+#
+# Manual demo and testing client for the Progress.rb module
+#
+# Start with
+#
+#   yast2 ./progress_demo
+#
+# and click though the application. Use the "Next Step", "Next Stage", "Next
+# Stage Step" buttons to trigger the progress update methods of the Progress
+# module directly.
+#
+# Use "Open Popup" to open a popup like in the libzypp callbacks (you can open
+# several of them) and "Close Popup" to close the toplevel layer of popups
+# again. Use the "Next XZ" buttons from there to check what happens if the
+# progress is updated while one of those popups is open: It shouldn't crash
+# with a UI error (bsc#1187676), though it may leave the progress somewhat
+# disturbed visually afterwards.
+#
+# Implementation details: This uses a normal UI dialog, not, as the Progress
+# module expects, a wizard dialog: It would completely exchange the content of
+# the wizard dialog, removing the buttons that we added for the purpose of this
+# test, which would make the test unusable.
+
+require "yast"
+
+module Yast
+  class ProgressDemo < Client
+    include Yast::Logger
+
+    attr_accessor :progress_type
+
+    def initialize
+      Yast.import "UI"
+      Yast.import "Progress"
+
+      @popup_count = 0
+      @progress_type = :simple
+    end
+
+    def run
+      UI.OpenDialog(content)
+      add_progress
+      handle_events
+      UI.CloseDialog
+    end
+
+    def content
+      MinSize(
+        Id(:main_dialog),
+        80, 20,
+        MarginBox(
+          2, 0.45,
+          HBox(
+            HVCenter(
+              # This emulates the inner part of a wizard dialog
+              # which we can't use to avoid our buttons being removed
+              ReplacePoint(Id(:contents), Empty())
+            ),
+            HSpacing(3),
+            main_buttons
+          )
+        )
+      )
+    end
+
+    def add_progress
+      case @progress_type
+      when :simple
+        simple_progress
+      when :complex, nil
+        complex_progress
+      end
+    end
+
+    def simple_progress
+      window_title = "" # unused
+      progress_title = "Some Progress..."
+      progress_len = 7
+      help_text = ""
+
+      Progress.Simple(
+        window_title,
+        progress_title,
+        progress_len,
+        help_text
+      )
+    end
+
+    def complex_progress
+      window_title = "" # unused
+      progress_title = "Complex Progress..."
+      help_text = ""
+
+      stages = ["Stage 1", "Stage 2", "Stage 3", "Stage 4"]
+      titles = ["Title 1", "Title 2", "Title 3", "Title 4"]
+      progress_len = 3 * stages.size
+
+      Progress.New(
+        window_title,
+        progress_title,
+        progress_len,
+        stages,
+        titles,
+        help_text
+      )
+      Progress.NextStage
+    end
+
+    def main_buttons
+      HSquash(
+        VBox(
+          VStretch(),
+          *common_buttons,
+          VStretch(),
+          PushButton(Id(:quit), Opt(:hstretch), "&Quit")
+        )
+      )
+    end
+
+    def common_buttons
+      # Opt(:hstretch) makes all buttons the same width if put in a vertical
+      # column (as used in the main dialog). It has no effect if they are put
+      # in a horizontal row (as used in the popup dialog).
+      opt = Opt(:hstretch)
+
+      [
+        PushButton(Id(:next_step), opt, "&Next Step"),
+        PushButton(Id(:next_stage), opt, "Next &Stage"),
+        PushButton(Id(:next_stage_step), opt, "Next Stage St&ep"),
+        PushButton(Id(:open_popup), opt, "&Open Popup")
+      ]
+    end
+
+    def open_popup
+      @popup_count += 1
+      UI.OpenDialog(popup_content)
+    end
+
+    def popup?
+      UI.WidgetExists(:popup_dialog)
+    end
+
+    def close_popup
+      if popup?
+        UI.CloseDialog
+        @popup_count -= 1
+      else
+        log.warn("No popup dialog to close")
+      end
+    end
+
+    def popup_content
+      MarginBox(
+        Id(:popup_dialog),
+        2, 0.45,
+        VBox(
+          HVCenter(
+            Label("Popup dialog ##{@popup_count} that gets in the way")
+          ),
+          popup_buttons
+        )
+      )
+    end
+
+    def popup_buttons
+      HBox(
+        HStretch(),
+        *common_buttons,
+        PushButton(Id(:close_popup), "&Close Popup"),
+        HStretch()
+      )
+    end
+
+    # Event handler for the main dialog as well as for any open popups
+    #
+    # rubocop:disable Style/GuardClause
+    def handle_events
+      loop do
+        input = UI.UserInput
+        log.info("Input: \"#{input}\"")
+
+        case input
+        when :quit
+          break # leave event loop
+        when :open_popup
+          open_popup
+        when :close_popup
+          close_popup
+        when :cancel # :cancel is WM_CLOSE
+          if popup?
+            close_popup
+          else
+            break # leave event loop
+          end
+        when :next_step
+          Progress.NextStep
+        when :next_stage
+          Progress.NextStage
+        when :next_stage_step
+          Progress.NextStageStep(1)
+        end
+
+        input
+      end
+    end
+    # rubocop:enable Style/GuardClause
+
+    # Open a dialog to ask the user which progress type to use and set the
+    # internal @progress_type member variable accordingly.
+    def select_progress_type
+      UI.OpenDialog(
+        MarginBox(
+          1, 0.45,
+          MinWidth(
+            20,
+            VBox(
+              SelectionBox(
+                Id(:progress_type),
+                "Progress &Type",
+                [
+                  Item(Id(:simple), "Simple", true),
+                  Item(Id(:complex), "Complex")
+                ]
+              ),
+              Right(PushButton("C&ontinue"))
+            )
+          )
+        )
+      )
+      UI.UserInput
+      # Query the widget as long as the dialog is still open
+      @progress_type = UI.QueryWidget(Id(:progress_type), :Value)
+      UI.CloseDialog
+      @progress_type
+    end
+  end
+end
+
+client = Yast::ProgressDemo.new
+# Comment the next line out to avoid the initial question
+client.select_progress_type
+client.run

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 14 16:06:50 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Don't crash with UI exception in Progress.rb if a popup is in the way
+  (bsc#1187676)
+- 4.4.15
+
+-------------------------------------------------------------------
 Wed Jun 23 13:24:04 UTC 2021 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Y2Issues::Issue: renamed severity "fatal" to "error", to be more

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.14
+Version:        4.4.15
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
_**This merges PR #1181 from SLE-15-SP3 to master.**_

## Trello

https://trello.com/c/wC5C2kRW

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1187676

## Problem

Under some circumstances, updating progress in the _Progress_ module can lead to a crash with a UI error "No widget with ID ...".

## Probable Cause

Another pop-up dialog may be in the way, e.g. during some libzypp callbacks. That will then be the topmost dialog, and of course that dialog does not have the expected widget tree, i.e. not the ReplacePoint that the _Progress_ module wants to modify with `UI.ReplaceWidget()`.

## Fix

Be more defensive in that _Progress_ module: Check if the expected widget exists in the current dialog before trying to exchange its content.

## Test

There was no test environment for the _Progress_ module at all: The only way of testing it was with a live YaST module. But that makes it complicated to get into all cases; and, worse for this bug, there is no way to enforce a popup dialog being in the way.

So I added a new manual test client for this. It's not realistically possible to do that with auto-tests, so this needs some manual interaction and _watching_ what happens.

The new test client is started from the test directory:

```
cd yast-yast2/library/wizard/test/manual
yast2 ./progress_demo
```

or, for NCurses:

```
yast2 ./progress_demo --ncurses
```

It first asks which progress scenario to use:

![progress-demo-01-ask-type](https://user-images.githubusercontent.com/11538225/125653665-b05e4c9d-0890-48cd-845c-6917a75c4e8c.png)

Then it opens one of either:

![progress-demo-02-simple-main](https://user-images.githubusercontent.com/11538225/125653704-bc0209b5-b597-4654-88b4-b41911129d71.png)
_Simple progress_

![progress-demo-04-complex-main](https://user-images.githubusercontent.com/11538225/125653754-08bb109f-bc91-4339-9f3b-d87aaae0774d.png)
_Complex progress_

In either case, there are some buttons which directly correspond to the exported actions of the _Progress_ module, and you can open one or more pop-up dialogs that get in the way (which is the purpose of this test for this bug). That pop-up has the same buttons to test the _Progress_ module's behaviour.

![progress-demo-03-simple-popup](https://user-images.githubusercontent.com/11538225/125654504-d8653832-d812-4150-953b-4ed88250b2d3.png)
_With popup dialog in the way_

Clicking around on those buttons might not update the progress output correctly, but it should at least not crash with a UI exception and error dialog.

