### PR TITLE
Do not escape $ in URI paths

### DIFF
--- a/library/types/src/modules/URLRecode.rb
+++ b/library/types/src/modules/URLRecode.rb
@@ -9,7 +9,7 @@ module Yast
   class URLRecodeClass < Module
     # these will be substituted to a regex character class
     USERNAME_PASSWORD_FRAGMENT_SAFE_CHARS = "-A-Za-z0-9_.!~*'()".freeze
-    PATH_SAFE_CHARS =                       "-A-Za-z0-9_.!~*'()/:".freeze
+    PATH_SAFE_CHARS =                       "-A-Za-z0-9_.!~*'()/:$".freeze
     QUERY_SAFE_CHARS =                      "-A-Za-z0-9_.!~*'()/:=&".freeze
 
     # Escape password, user name and fragment part of URL string

--- a/library/types/test/urlrecode_test.rb
+++ b/library/types/test/urlrecode_test.rb
@@ -8,7 +8,7 @@ describe Yast::URLRecode do
   subject { Yast::URLRecode }
 
   describe "#EscapePath" do
-    let(:test_path) { "/@\#$%^&/dir/\u010D\u00FD\u011B\u0161\u010D\u00FD\u00E1/file" }
+    let(:test_path) { "/@\#%^&/dir/\u010D\u00FD\u011B\u0161\u010D\u00FD\u00E1/file" }
     it "returns nil if the url is nil too" do
       expect(subject.EscapePath(nil)).to eq(nil)
     end
@@ -19,7 +19,7 @@ describe Yast::URLRecode do
 
     it "returns escaped path" do
       expect(subject.EscapePath(test_path)).to eq(
-        "/%40%23%24%25%5e%26/dir/%c4%8d%c3%bd%c4%9b%c5%a1%c4%8d%c3%bd%c3%a1/file"
+        "/%40%23%25%5e%26/dir/%c4%8d%c3%bd%c4%9b%c5%a1%c4%8d%c3%bd%c3%a1/file"
       )
     end
 
@@ -28,9 +28,14 @@ describe Yast::URLRecode do
     end
 
     it "returns escaped special characters" do
-      expect(subject.EscapePath(" !@\#$%^&*()/?+=:")).to eq(
-        "%20!%40%23%24%25%5e%26*()/%3f%2b%3d:"
+      expect(subject.EscapePath(" !@\#%^&*()/?+=:")).to eq(
+        "%20!%40%23%25%5e%26*()/%3f%2b%3d:"
       )
+    end
+
+    it "does not escape '$'" do
+      expect(subject.EscapePath("path/to/%SUSE%/$releasever"))
+        .to eq("path/to/%25SUSE%25/$releasever")
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 15 11:04:50 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not escape "$" in URL paths (bsc#1187581).
+- 4.1.82
+
+-------------------------------------------------------------------
 Thu Apr 29 13:24:40 CEST 2021 - Jozef Pupava <jpupava@suse.com>
 
 - Add linuxrc option "reboot_timeout" to configure the timeout

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.1.81
+Version:        4.1.82
 
 Release:        0
 Summary:        YaST2 - Main Package


### PR DESCRIPTION
### Problem

When editing a repository using the "Edit Parts of the URL" mode, YaST does not handle the dollar sign properly (escaping it to "%24").

* Trello (internal link): https://trello.com/c/BnMnGsu9/
* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1187581

### Solution

Just include `$` into [`URLRecode.PATH_SAFE_CHARS`](https://github.com/yast/yast-yast2/blob/793a45380e65a642397b4e06bdf082b030702566/library/types/src/modules/URLRecode.rb#L12).

I evaluated (and discarded) the possibility to refactor [`URLRecode`](https://github.com/yast/yast-yast2/blob/793a45380e65a642397b4e06bdf082b030702566/library/types/src/modules/URLRecode.rb) for making it [RFC3986](https://datatracker.ietf.org/doc/html/rfc3986) compliant, but it does not pay off.

### Notes

#### Adding changes from SP1 on

Having a look at skelcds it could be checked that `$releasever` was used from openSUSE Leap 15.1 on. That's why the change is going to be included in SLE-15-SP1+ branches.


#### Revisiting URI parts

```
         foo://example.com:8042/over/there?name=ferret#nose
         \_/   \______________/\_________/ \_________/ \__/
          |           |            |            |        |
       scheme     authority       path        query   fragment
```

#### Allowed chars for the URI path according to  RFC3986

As the RFC states (see [Appendix A](https://datatracker.ietf.org/doc/html/rfc3986#appendix-A) for a quick view), an already percentage encoded (`%\h\h`) and `/a-zA-Z0-9-._~!$&'()*+,;=:@` are perfectly valid chars for the URI path. This can be expressed with below regexp

```
/%\h{2}|[\/a-zA-Z0-9-._~!$&'()*+,;=:@]/
```

However, refactoring `URLRecode` for being compliant with RFC3986 not only when escaping the `path` but when doing so for  `userinfo` and `query` is not as easy as it might appear at first sight. Furthermore, is not even necessary for the limited YaST URI handling so far.

### Tests

* Updated existing unit tests
* Added a concrete unit test to check that `$` is not being escaped by [`URLRecode.EscapePath`](https://github.com/yast/yast-yast2/blob/793a45380e65a642397b4e06bdf082b030702566/library/types/src/modules/URLRecode.rb#L22-L27)
* Tested manually using an openSUSE Leap 15.3
