### PR TITLE
[SLE-15-SP2] Do not escape $ in URI paths

### DIFF
--- a/library/types/src/modules/URLRecode.rb
+++ b/library/types/src/modules/URLRecode.rb
@@ -7,7 +7,7 @@ module Yast
   class URLRecodeClass < Module
     # these will be substituted to a regex character class
     USERNAME_PASSWORD_FRAGMENT_SAFE_CHARS = "-A-Za-z0-9_.!~*'()".freeze
-    PATH_SAFE_CHARS =                       "-A-Za-z0-9_.!~*'()/:".freeze
+    PATH_SAFE_CHARS =                       "-A-Za-z0-9_.!~*'()/:$".freeze
     QUERY_SAFE_CHARS =                      "-A-Za-z0-9_.!~*'()/:=&".freeze
 
     # Escape password, user name and fragment part of URL string

--- a/library/types/test/urlrecode_test.rb
+++ b/library/types/test/urlrecode_test.rb
@@ -8,7 +8,7 @@ describe Yast::URLRecode do
   subject { Yast::URLRecode }
 
   describe "#EscapePath" do
-    let(:test_path) { "/@\#$%^&/dir/\u010D\u00FD\u011B\u0161\u010D\u00FD\u00E1/file" }
+    let(:test_path) { "/@\#%^&/dir/\u010D\u00FD\u011B\u0161\u010D\u00FD\u00E1/file" }
     it "returns nil if the url is nil too" do
       expect(subject.EscapePath(nil)).to eq(nil)
     end
@@ -19,7 +19,7 @@ describe Yast::URLRecode do
 
     it "returns escaped path" do
       expect(subject.EscapePath(test_path)).to eq(
-        "/%40%23%24%25%5e%26/dir/%c4%8d%c3%bd%c4%9b%c5%a1%c4%8d%c3%bd%c3%a1/file"
+        "/%40%23%25%5e%26/dir/%c4%8d%c3%bd%c4%9b%c5%a1%c4%8d%c3%bd%c3%a1/file"
       )
     end
 
@@ -28,9 +28,14 @@ describe Yast::URLRecode do
     end
 
     it "returns escaped special characters" do
-      expect(subject.EscapePath(" !@\#$%^&*()/?+=:")).to eq(
-        "%20!%40%23%24%25%5e%26*()/%3f%2b%3d:"
+      expect(subject.EscapePath(" !@\#%^&*()/?+=:")).to eq(
+        "%20!%40%23%25%5e%26*()/%3f%2b%3d:"
       )
+    end
+
+    it "does not escape '$'" do
+      expect(subject.EscapePath("path/to/%SUSE%/$releasever"))
+        .to eq("path/to/%25SUSE%25/$releasever")
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 15 11:04:50 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not escape "$" in URL paths (bsc#1187581).
+- 4.2.95
+
+-------------------------------------------------------------------
 Tue Jun  8 08:26:13 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Ignore sysctl configuration files that do not have the .conf

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.2.94
+Version:        4.2.95
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
Fix [bsc#1187581](https://bugzilla.suse.com/show_bug.cgi?id=1187581) for SLE-15-SP2, not escaping "$" when producing the URI from it component parts. See https://github.com/yast/yast-yast2/pull/1183 for more information.