### PR TITLE
Do not escape $ in URI path

### DIFF
--- a/library/types/src/modules/URLRecode.rb
+++ b/library/types/src/modules/URLRecode.rb
@@ -7,7 +7,7 @@ module Yast
   class URLRecodeClass < Module
     # these will be substituted to a regex character class
     USERNAME_PASSWORD_FRAGMENT_SAFE_CHARS = "-A-Za-z0-9_.!~*'()".freeze
-    PATH_SAFE_CHARS =                       "-A-Za-z0-9_.!~*'()/:".freeze
+    PATH_SAFE_CHARS =                       "-A-Za-z0-9_.!~*'()/:$".freeze
     QUERY_SAFE_CHARS =                      "-A-Za-z0-9_.!~*'()/:=&".freeze
 
     # Escape password, user name and fragment part of URL string

--- a/library/types/test/url_test.rb
+++ b/library/types/test/url_test.rb
@@ -236,7 +236,7 @@ describe Yast::URL do
                              "path"   => "/share$$share/path/on/the/share",
                              "scheme" => "smb",
                              "user"   => "username")).to eq(
-                               "smb://username:passwd@myserver.com/share%24%24share/path/on/the/share?workgroup=workgroup"
+                               "smb://username:passwd@myserver.com/share$$share/path/on/the/share?workgroup=workgroup"
                              )
       end
     end

--- a/library/types/test/urlrecode_test.rb
+++ b/library/types/test/urlrecode_test.rb
@@ -8,7 +8,7 @@ describe Yast::URLRecode do
   subject { Yast::URLRecode }
 
   describe "#EscapePath" do
-    let(:test_path) { "/@\#$%^&/dir/\u010D\u00FD\u011B\u0161\u010D\u00FD\u00E1/file" }
+    let(:test_path) { "/@\#%^&/dir/\u010D\u00FD\u011B\u0161\u010D\u00FD\u00E1/file" }
     it "returns nil if the url is nil too" do
       expect(subject.EscapePath(nil)).to eq(nil)
     end
@@ -19,7 +19,7 @@ describe Yast::URLRecode do
 
     it "returns escaped path" do
       expect(subject.EscapePath(test_path)).to eq(
-        "/%40%23%24%25%5e%26/dir/%c4%8d%c3%bd%c4%9b%c5%a1%c4%8d%c3%bd%c3%a1/file"
+        "/%40%23%25%5e%26/dir/%c4%8d%c3%bd%c4%9b%c5%a1%c4%8d%c3%bd%c3%a1/file"
       )
     end
 
@@ -28,9 +28,14 @@ describe Yast::URLRecode do
     end
 
     it "returns escaped special characters" do
-      expect(subject.EscapePath(" !@\#$%^&*()/?+=:")).to eq(
-        "%20!%40%23%24%25%5e%26*()/%3f%2b%3d:"
+      expect(subject.EscapePath(" !@\#%^&*()/?+=:")).to eq(
+        "%20!%40%23%25%5e%26*()/%3f%2b%3d:"
       )
+    end
+
+    it "does not escape '$'" do
+      expect(subject.EscapePath("path/to/%SUSE%/$releasever"))
+        .to eq("path/to/%25SUSE%25/$releasever")
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jul 15 11:04:50 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not escape "$" in URL paths (bsc#1187581).
+- 4.4.16
+
+-------------------------------------------------------------------
 Wed Jul 14 16:06:50 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Don't crash with UI exception in Progress.rb if a popup is in the way

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.15
+Version:        4.4.16
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Fix [bsc#1187581](https://bugzilla.suse.com/show_bug.cgi?id=1187581) for SLE-15-SP3, not escaping "$" when producing the URI from it component parts. See #1183 for more information.