### PR TITLE
[SLE-15-SP3] Discourage the use of old URL modules

### DIFF
--- a/library/types/src/modules/URL.rb
+++ b/library/types/src/modules/URL.rb
@@ -30,6 +30,13 @@
 require "yast"
 
 module Yast
+  # A module for dealing with URLs
+  #
+  # @note This is legacy code ported from the
+  # {https://news.opensuse.org/2007/08/29/yast-independence-of-ycp/ YCP} era. Its use is highly
+  # discouraged in favor of the {https://ruby-doc.org/stdlib-3.0.2/libdoc/uri/rdoc/URI.html URI}
+  # standard library or the new {Y2Packager::ZyppUrl} (available from SLE-15-SP3 on) when working
+  # with libzypp URLs.
   class URLClass < Module
     def main
       textdomain "base"

--- a/library/types/src/modules/URLRecode.rb
+++ b/library/types/src/modules/URLRecode.rb
@@ -4,6 +4,12 @@ require "yast"
 
 module Yast
   # A drop-in replacement of an earlier Perl implementation
+  #
+  # @note This is legacy code ported from the
+  # {https://news.opensuse.org/2007/08/29/yast-independence-of-ycp/ YCP} era. Its use is highly
+  # discouraged in favor of the {https://ruby-doc.org/stdlib-3.0.2/libdoc/uri/rdoc/URI.html URI}
+  # standard library or the new {Y2Packager::ZyppUrl} (available from SLE-15-SP3 on) when working
+  # with libzypp URLs.
   class URLRecodeClass < Module
     # these will be substituted to a regex character class
     USERNAME_PASSWORD_FRAGMENT_SAFE_CHARS = "-A-Za-z0-9_.!~*'()".freeze


### PR DESCRIPTION
As suggested during the review of https://trello.com/c/BnMnGsu9/ (internal link), point developers to the right tools for dealing with (libzypp)URLs.

It mentions not only the [URI](https://ruby-doc.org/stdlib-3.0.2/libdoc/uri/rdoc/URI.html) Ruby standard module, but also the _recently_ added [`Y2Packager::ZyppUrl`](https://github.com/yast/yast-yast2/blob/SLE-15-SP3/library/packages/src/lib/y2packager/zypp_url.rb) (see #1071), which allows dealing with libzypp URLs.