### PR TITLE
Added "maintenance" to Yast2::Systemd::UnitProperties::ACTIVE_STATES

### DIFF
--- a/library/systemd/src/lib/yast2/systemd/unit_properties.rb
+++ b/library/systemd/src/lib/yast2/systemd/unit_properties.rb
@@ -12,6 +12,10 @@ module Yast2
       #
       # systemctl.c:check_unit_active uses (active, reloading)
       # For bsc#884756 we also consider "activating" to be active.
+      #
+      # "maintenance" means that the unit will automatically return
+      # to be "active" after a while. (`systemctl clean` was invoked)
+      #
       # (The remaining states are "deactivating", "inactive", "failed".)
       #
       # Yes, depending on systemd states that are NOT covered by their
@@ -20,7 +24,7 @@ module Yast2
       # (depending on hardware and software installed, VM or not)
       # is a 1 to 15 second delay (bsc#1045658).
       # That is why we try hard to avoid many systemctl calls.
-      ACTIVE_STATES = ["active", "activating", "reloading"].freeze
+      ACTIVE_STATES = ["active", "activating", "maintenance", "reloading"].freeze
 
       # @param systemd_unit [Yast2::Systemd::Unit]
       # @param property_text [String,nil] if provided, use it instead of calling `systemctl show`

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep  6 07:42:09 UTC 2021 - Martin Vidner <mvidner@suse.com>
+
+- Mark systemd unit/service state "maintenance" as active
+  (bsc#1190163)
+- 4.4.17
+
+-------------------------------------------------------------------
 Thu Jul 15 11:04:50 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not escape "$" in URL paths (bsc#1187581).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.16
+Version:        4.4.17
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- https://trello.com/c/8GYaBEp6/2606-2-new-systemd-states
- https://bugzilla.suse.com/show_bug.cgi?id=1190163

Related YaST PRs:
- https://github.com/yast/yast-services-manager/pull/214 (master)
- https://github.com/yast/yast-services-manager/pull/215 (check_systemd_states branch)

The relevant systemd commit is
https://github.com/systemd/systemd/pull/12176/commits/380dc8b0a25f544269fdff7d9fd0e488fb374031

Also, in src/core/unit.c, for the UNIT_MAINTENANCE state, unit_start returns -EAGAIN while unit_stop has no special case.

Therefore we treat "maintenance" as basically "active".