### PR TITLE
Fixed losing the product selection (bsc#1190228)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Sep 16 13:41:05 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed losing the current product and package selection during
+  installation, caused by unnecessary reloading of repositories
+  (bsc#1190228)
+- 4.4.20
+
+-------------------------------------------------------------------
 Wed Sep 15 15:30:00 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added infrastructure for installing missing UI extension plug-ins

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.19
+Version:        4.4.20
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## The Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1190228
- The products from addon modules are not selected to install, see the screenshot

![sp4_addons_not_selected](https://user-images.githubusercontent.com/907998/133750295-54e1a610-6fd0-4887-a042-a9fd9d9722db.png)

## Details

- It turned out that the products actually *are* selected after adding the repositories
- But the selection is lost when reaching the installation summary
- Further debugging revealed the the selection is lost after calling `Pkg.SourceStartCache` which (re)loads the repositories
- That's actually not needed during installation, that code is mainly intended for installed system
- In the past this was OK, maybe some libzypp behavior has been changed...

## The Fix

- The code which loads the repositories was fixed to avoid reloads when at least one repository is defined
  - During installation, where at least one repository is present, it will skip the repository load 
  - In installed system it will load the repositories unless they are already loaded

## Testing

- Tested manually in the latest SP4 build, all products are correctly selected to install

![sp4_addons_selected](https://user-images.githubusercontent.com/907998/133750645-939afef1-22a4-431c-93f5-34d67d9a2397.png)
