### PR TITLE
[RFC] Software management API proposal

### DIFF
--- a/library/packages/src/lib/y2packager/backend.rb
+++ b/library/packages/src/lib/y2packager/backend.rb
@@ -1,0 +1,48 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Packager
+  # Implements support for a software management system
+  #
+  # To implement support for an additional backend, just inherit from this class
+  # and implement the corresponding methods (e.g., #probe, #repositories, #search, etc.).
+  class Backend
+    # Initializes the backend
+    def probe; end
+
+    # Returns the list of repositories
+    #
+    # @return [Array<Repository>]
+    def repositories
+      []
+    end
+
+    # Returns the resolvables according to the given conditions and properties
+    #
+    # @todo Return a ResolvablesCollection instance.
+    #
+    # @param conditions [Hash<Symbol,String>] Search conditions (e.g., { name: "SLES" }
+    # @param properties [Array<Symbol>] List of properties to include in the result.
+    #   The default list is defined by each backend.
+    # @return [Array<Resolvable>]
+    def search(*)
+      []
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/installation_package_map.rb
+++ b/library/packages/src/lib/y2packager/installation_package_map.rb
@@ -1,0 +1,83 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+Yast.import "Pkg"
+
+module Y2Packager
+  # Installation packages map
+  #
+  # This map contains the correspondence between products and the
+  # installation package for each product.
+  #
+  # The information is always read again. Reason is that that url can be invalid,
+  # but user fix it later. This way it cache invalid result. See bsc#1086840
+  # ProductReader instance cache it properly, but caching for installation life-time
+  # should be prevented.
+  #
+  # @return [Hash<String,String>] product name -> installation package name
+  class InstallationPackageMap
+    include Yast::Logger
+
+    def initialize
+      @packages_map = nil
+    end
+
+    def for(pkg_name)
+      packages_map[pkg_name]
+    end
+
+  private
+
+    def packages_map
+      return @packages_map if @packages_map
+
+      install_pkgs = Yast::Pkg.PkgQueryProvides("system-installation()")
+      log.info "Installation packages: #{install_pkgs.inspect}"
+
+      @packages_map = {}
+
+      install_pkgs.each do |list|
+        pkg_name = list.first
+        # There can be more instances of same package in different version.
+        # Prefer the selected or the available package, they should provide newer data
+        # than the installed one.
+        packages = Yast::Pkg.Resolvables({ name: pkg_name, kind: :package }, [:dependencies, :status])
+        package = packages.find { |p| p["status"] == :selected } ||
+          packages.find { |p| p["status"] == :available } ||
+          packages.first
+
+        dependencies = package["deps"]
+        install_provides = dependencies.find_all do |d|
+          d["provides"]&.match(/system-installation\(\)/)
+        end
+
+        # parse product name from provides. Format of provide is
+        # `system-installation() = <product_name>`
+        install_provides.each do |install_provide|
+          product_name = install_provide["provides"][/system-installation\(\)\s*=\s*(\S+)/, 1]
+          log.info "package #{pkg_name} install product #{product_name}"
+          @packages_map[product_name] = pkg_name
+        end
+      end
+
+      @packages_map
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/libzypp_backend.rb
+++ b/library/packages/src/lib/y2packager/libzypp_backend.rb
@@ -1,0 +1,84 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2packager/backend"
+require "y2packager/rpm_repo"
+require "y2packager/package"
+require "y2packager/product"
+
+module Y2Packager
+  # Backend implementation for libzypp
+  class LibzyppBackend < Backend
+    # Initialize the libzypp subsystem using the pkg-bindings
+    def probe
+      Yast.import "Pkg"
+      Yast.import "PackageLock"
+      Yast::Pkg.TargetInitialize("/")
+      Yast::Pkg.TargetLoad
+      Yast::Pkg.SourceRestore
+      Yast::Pkg.SourceLoad
+    end
+
+    # Reads the repositories from the system
+    #
+    # @return [Array<RpmRepo>]
+    def repositories
+      Yast::Pkg.SourceGetCurrent(false).map do |repo_id|
+        repo = Yast::Pkg.SourceGeneralData(repo_id)
+        raise NotFound if repo.nil?
+
+        RpmRepo.new(repo_id: repo_id, repo_alias: repo["alias"],
+          enabled: repo["enabled"], name: repo["name"],
+          autorefresh: repo["autorefresh"], url: repo["raw_url"],
+          product_dir: repo["product_dir"])
+      end
+    end
+
+    # @todo Allow passing multiple statuses
+    # @todo Use a set of default properties so you do not need to explictly pass them
+    def search(conditions:, properties:)
+      resolvables = Yast::Pkg.Resolvables(
+        conditions,
+        (properties + [:kind]).uniq
+      )
+
+      resolvables.map do |res|
+        meth = "hash_to_#{res["kind"]}"
+        next res unless respond_to?(meth, true)
+
+        send(meth, res)
+      end
+    end
+
+  private
+
+    def hash_to_product(hsh)
+      Y2Packager::Product.new(
+        name: hsh["name"], arch: hsh["arch"], version: hsh["version"]
+      )
+    end
+
+    def hash_to_package(hsh)
+      Y2Packager::Package.new(
+        hsh["name"], hsh["source"], hsh["version"]
+      )
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/libzypp_backend.rb
+++ b/library/packages/src/lib/y2packager/libzypp_backend.rb
@@ -22,6 +22,7 @@ require "y2packager/backend"
 require "y2packager/rpm_repo"
 require "y2packager/package"
 require "y2packager/product"
+require "y2packager/installation_package_map"
 
 module Y2Packager
   # Backend implementation for libzypp
@@ -54,9 +55,11 @@ module Y2Packager
     # @todo Allow passing multiple statuses
     # @todo Use a set of default properties so you do not need to explictly pass them
     def search(conditions:, properties:)
+      @packages_map = InstallationPackageMap.new
+
       resolvables = Yast::Pkg.Resolvables(
         conditions,
-        (properties + [:kind]).uniq
+        (properties + [:name, :kind]).uniq
       )
 
       resolvables.map do |res|
@@ -71,7 +74,8 @@ module Y2Packager
 
     def hash_to_product(hsh)
       Y2Packager::Product.new(
-        name: hsh["name"], arch: hsh["arch"], version: hsh["version"]
+        name: hsh["name"], arch: hsh["arch"], version: hsh["version"],
+        installation_package: @packages_map.for(hsh["name"])
       )
     end
 

--- a/library/packages/src/lib/y2packager/rpm_repo.rb
+++ b/library/packages/src/lib/y2packager/rpm_repo.rb
@@ -1,0 +1,29 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2packager/repository"
+
+module Y2Packager
+  # Represents an RPM packages repository
+  #
+  # @todo Move here the RPM specific logic from the Repository class
+  #   and rename Repository to Origin.
+  class RpmRepo < Repository
+  end
+end

--- a/library/packages/src/lib/y2packager/software_manager.rb
+++ b/library/packages/src/lib/y2packager/software_manager.rb
@@ -1,0 +1,91 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "y2packager/repository"
+require "y2packager/libzypp_backend"
+require "y2packager/software_search"
+
+module Y2Packager
+  # This class represents the software management subsystem
+  #
+  # It allows managing software repositories, installing/removing software, and so on.
+  #
+  # @example Initialize the software management subsystem
+  #   software = SoftwareManagement.new(LibzyppBackend.new)
+  #   software.probe
+  #
+  # @example Convenience method to initialize the software manager
+  #   SoftwareManager.probe
+  #   SoftwareManager.current #=> #<Y2Packager::SoftwareManager...>
+  #
+  class SoftwareManager
+    # @return [Array<Backend>] List of known backends
+    attr_reader :backends
+
+    class << self
+      # Returns a SoftwareManager instance and keeps the reference for the future
+      #
+      # @note At this time, it always initializes the system using the LibzyppBackend.
+      # @return [SoftwareManagement] A SoftwareManagement instance for the current system
+      def current
+        @current ||= new([LibzyppBackend.new])
+      end
+
+      def reset
+        @current = nil
+      end
+    end
+
+    # @param backends [Array<Backend>] List of backends to use
+    def initialize(backends)
+      @backends = backends
+    end
+
+    # Initialize the software subsystem
+    def probe
+      backends.each(&:probe)
+    end
+
+    # Commits the changes defined in the software proposal
+    #
+    # @param [SoftwareProposal]
+    def commit(_proposal)
+      # ask the backends to install the given packages/apps
+      raise NotImplementedError
+    end
+
+    # List of repositories from all the backends
+    #
+    # @return [Array<Repository>] Defined repositories from all backends
+    def repositories
+      backends.each_with_object([]) do |backend, all|
+        all.concat(backend.repositories)
+      end
+    end
+
+    # Returns a search object which includes all backends
+    #
+    # @todo Allow disabling any backend.
+    #
+    # @return [SoftwareSearch]
+    def search
+      SoftwareSearch.new(*backends)
+    end
+  end
+end

--- a/library/packages/src/lib/y2packager/software_search.rb
+++ b/library/packages/src/lib/y2packager/software_search.rb
@@ -1,0 +1,88 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Packager
+  # Query the software manager for resolvables (packages, products, applications,
+  # and so on).
+  #
+  # Should we have two different classes? One for the conditions/properties
+  # and the other one that represents the query itself. See Backend#search for
+  # an explanation.
+  #
+  # The SoftwareSearch contains additional information, like the list of backends.
+  #
+  # @example Search by name
+  #   query = SoftwareSearch.new(backend)
+  #
+  class SoftwareSearch
+    include Enumerable
+
+    # @return [Array<Backend>] Limit the search to these backends
+    attr_reader :backends
+
+    # @return [Array<Symbol>] Properties to include
+    attr_reader :properties
+
+    # @return [Hash<Symbol,String>] A hash describing the conditions (e.g., {
+    #   name: "yast2" })
+    attr_reader :conditions
+
+    # attributes required for identifying a resolvable
+    BASE_ATTRIBUTES = [:kind, :name, :version, :arch, :source].freeze
+
+    def initialize(*backends)
+      @backends = backends # limit the query to these backends
+      @properties = BASE_ATTRIBUTES.dup
+      @conditions = {}
+    end
+
+    def named(name)
+      with(name: name)
+      self
+    end
+
+    def including(*names)
+      @properties.concat(names)
+      self
+    end
+
+    def excluding(*names)
+      names.each { |a| @properties.delete(a) }
+      self
+    end
+
+    def with(conds = {})
+      @conditions.merge!(conds)
+      self
+    end
+
+    # @todo Rely on a ResolvablesCollection instead
+    def each(&block)
+      resolvables.each(&block)
+    end
+
+  private
+
+    def resolvables
+      backends.each_with_object([]) do |backend, all|
+        all.concat(backend.search(conditions: conditions, properties: properties))
+      end
+    end
+  end
+end

--- a/library/packages/test/y2packager/installation_package_map_test.rb
+++ b/library/packages/test/y2packager/installation_package_map_test.rb
@@ -1,0 +1,53 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2packager/installation_package_map"
+
+describe Y2Packager::InstallationPackageMap do
+  describe "#packages_map" do
+    before do
+      allow(Yast::Pkg).to receive(:PkgQueryProvides).with("system-installation()").and_return(
+        # the first is the old product which will be removed from the system
+        [["openSUSE-release", :CAND, :NONE], ["openSUSE-release", :CAND, :CAND]]
+      )
+      allow(Yast::Pkg).to receive(:Resolvables).with({ name: "openSUSE-release", kind: :package },
+        [:dependencies, :status]).and_return(
+          [
+            {
+              # emulate an older system with no "system-installation()" provides
+              "deps"   => [],
+              # put the removed product first so we can check it is skipped
+              "status" => :removed
+            },
+            {
+              # in reality there are many more dependencies, but they are irrelevant for this test
+              "deps"   => [{ "provides" => "system-installation() = openSUSE" }],
+              "status" => :selected
+            }
+          ]
+        )
+    end
+
+    it "prefers the data from the new available product instead of the old installed one" do
+      expect(subject.for("openSUSE")).to eq("openSUSE-release")
+      # expect(described_class.installation_package_mapping).to eq("openSUSE" => "openSUSE-release")
+    end
+  end
+end

--- a/library/packages/test/y2packager/libzypp_backend_test.rb
+++ b/library/packages/test/y2packager/libzypp_backend_test.rb
@@ -54,6 +54,15 @@ describe Y2Packager::LibzyppBackend do
   end
 
   describe "#search" do
+    let(:installation_package_map) do
+      instance_double(Y2Packager::InstallationPackageMap, for: "openSUSE-release")
+    end
+
+    before do
+      allow(Y2Packager::InstallationPackageMap).to receive(:new)
+        .and_return(installation_package_map)
+    end
+
     context "searching a package by name" do
       it "returns the package with the given name" do
         expect(Yast::Pkg).to receive(:Resolvables)
@@ -78,16 +87,16 @@ describe Y2Packager::LibzyppBackend do
           .with(
             { kind: :product, name: "openSUSE" }, [:name, :version, :kind]
           )
-          .and_return([
-                        { "name" => "openSUSE", "version" => "20211027-0", "kind" => :product }
-                      ])
-
+          .and_return(
+            [{ "name" => "openSUSE", "version" => "20211027-0", "kind" => :product }]
+          )
         prod = backend.search(
           conditions: { kind: :product, name: "openSUSE" }, properties: [:name, :version]
         ).first
         expect(prod).to be_a(Y2Packager::Product)
         expect(prod.name).to eq("openSUSE")
         expect(prod.version).to eq("20211027-0")
+        expect(prod.installation_package).to eq("openSUSE-release")
       end
     end
   end

--- a/library/packages/test/y2packager/libzypp_backend_test.rb
+++ b/library/packages/test/y2packager/libzypp_backend_test.rb
@@ -1,0 +1,94 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2packager/libzypp_backend"
+require "y2packager/software_search"
+
+Yast.import "Pkg"
+
+describe Y2Packager::LibzyppBackend do
+  subject(:backend) { described_class.new }
+
+  describe "#probe" do
+    it "initializes the packaging system" do
+      # TODO: this is not the most useful test
+      expect(Yast::Pkg).to receive(:SourceLoad)
+
+      backend.probe
+    end
+  end
+
+  describe "#repositories" do
+    before do
+      allow(Yast::Pkg).to receive(:SourceGetCurrent).with(false).and_return([0, 1])
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(0)
+        .and_return("name" => "SLES", "raw_url" => "file:///sles")
+      allow(Yast::Pkg).to receive(:SourceGeneralData).with(1)
+        .and_return("name" => "SLED", "raw_url" => "file:///sled")
+    end
+
+    it "returns the list of known repositories" do
+      repos = backend.repositories
+      expect(repos[0]).to be_a(Y2Packager::RpmRepo)
+      expect(repos[0].name).to eq("SLES")
+      expect(repos[1]).to be_a(Y2Packager::RpmRepo)
+      expect(repos[1].name).to eq("SLED")
+    end
+  end
+
+  describe "#search" do
+    context "searching a package by name" do
+      it "returns the package with the given name" do
+        expect(Yast::Pkg).to receive(:Resolvables)
+          .with({ kind: :package, name: "yast2" }, [:name, :version, :kind])
+          .and_return([
+                        { "name" => "yast2", "version" => "4.4.0", "source" => 1, "kind" => :package }
+                      ])
+
+        pkg = backend.search(
+          conditions: { kind: :package, name: "yast2" }, properties: [:name, :version]
+        ).first
+        expect(pkg).to be_a(Y2Packager::Package)
+        expect(pkg.name).to eq("yast2")
+        expect(pkg.version).to eq("4.4.0")
+        expect(pkg.repo_id).to eq(1)
+      end
+    end
+
+    context "searching a product by name" do
+      it "returns the product with the given name" do
+        expect(Yast::Pkg).to receive(:Resolvables)
+          .with(
+            { kind: :product, name: "openSUSE" }, [:name, :version, :kind]
+          )
+          .and_return([
+                        { "name" => "openSUSE", "version" => "20211027-0", "kind" => :product }
+                      ])
+
+        prod = backend.search(
+          conditions: { kind: :product, name: "openSUSE" }, properties: [:name, :version]
+        ).first
+        expect(prod).to be_a(Y2Packager::Product)
+        expect(prod.name).to eq("openSUSE")
+        expect(prod.version).to eq("20211027-0")
+      end
+    end
+  end
+end

--- a/library/packages/test/y2packager/software_manager_test.rb
+++ b/library/packages/test/y2packager/software_manager_test.rb
@@ -1,0 +1,64 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2packager/software_manager"
+
+describe Y2Packager::SoftwareManager do
+  subject(:software) do
+    described_class.new([backend])
+  end
+
+  let(:backend) do
+    instance_double(Y2Packager::LibzyppBackend, repositories: [repo])
+  end
+
+  let(:repo) do
+    instance_double(Y2Packager::Repository)
+  end
+
+  describe ".current" do
+    before { described_class.reset }
+
+    it "creates a SoftwareManagement instance" do
+      expect(described_class.current).to be_a(Y2Packager::SoftwareManager)
+    end
+
+    context "when called twice" do
+      it "returns the same instance" do
+        software0 = described_class.current
+        software1 = described_class.current
+        expect(software0).to be(software1)
+      end
+    end
+  end
+
+  describe "#repositories" do
+    it "returns repositories from all backends" do
+      expect(software.repositories).to eq([repo])
+    end
+  end
+
+  describe "#probe" do
+    it "calls the probe method of each backend" do
+      expect(backend).to receive(:probe)
+      software.probe
+    end
+  end
+end

--- a/library/packages/test/y2packager/software_search_test.rb
+++ b/library/packages/test/y2packager/software_search_test.rb
@@ -1,0 +1,76 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "y2packager/software_search"
+require "y2packager/backend"
+
+describe Y2Packager::SoftwareSearch do
+  subject(:search) { described_class.new(backend) }
+
+  let(:backend) do
+    instance_double(Y2Packager::Backend)
+  end
+
+  describe "#with" do
+    it "sets conditions" do
+      search.with(name: "yast2-packager")
+      expect(search.conditions).to eq(name: "yast2-packager")
+    end
+  end
+
+  describe "#named" do
+    it "sets a condition on the name" do
+      search.named("yast2")
+      expect(search.conditions).to eq(name: "yast2")
+    end
+  end
+
+  describe "#including" do
+    it "adds a property to the list of properties to include" do
+      expect(search.properties).to_not include(:description)
+      search.including(:description)
+      expect(search.properties).to include(:description)
+    end
+  end
+
+  describe "#excluding" do
+    it "adds a property to the list of properties to exclude" do
+      expect(search.properties).to include(:name)
+      search.excluding(:name)
+      expect(search.properties).to_not include(:name)
+    end
+  end
+
+  describe "#to_a" do
+    let(:package) { double("yast2") }
+
+    it "asks the backend an returns the result" do
+      search.with(name: "SLES")
+
+      expect(backend).to receive(:search)
+        .with(
+          conditions: { name: "SLES" },
+          properties: array_including(:kind, :name, :version, :arch, :source)
+        )
+        .and_return([package])
+      expect(search.to_a).to eq([package])
+    end
+  end
+end


### PR DESCRIPTION
This PR implements a tentative API for software management. It is still a WIP, but it serves as an indication of the direction we are following.

* The entry point to the API is the `SoftwareManager` class, which offers an API to initialize the software stack, query for "resolvables" (packages and products), etc.
* Potentially, it supports multiple backends. Support for libzypp is implemented as any other backend.
* Classes like `Package` or `Product` should be backend-agnostic (not implemented yet).
* It implements a rich query API (see `SoftwareSearch`), although it is far from being finished.

## An example

```ruby
require "y2packager/software_manager"
require "y2packager/libzypp_backend"

manager = Y2Packager::SoftwareManager.new
manager.probe # Initialize the software stack
query = manager.search.with(kind: :product)
query.each do |product|
  puts product.name
end

# you can extend the query later
query.with(name: "SLES")
query.first&.name #=> "SLES"
```

## Pending

* [ ] PackageSearch:
  * [ ] Load all the attributes, including custom ones. See the existing Y2Packager::Resolvable class.
  * [ ] Allow searching for multiple states.
  * [ ] Offer a better way to define conditions (?)
* [ ] Ad-hoc installation of packages/products
* [ ] Implement the `SoftwareProposal` class and the corresponding `SoftwareManager#commit` method.