### PR TITLE
Force Creating the UI before Checking -pkg etc. UI Plug-ins

### DIFF
--- a/library/general/src/lib/ui/ui_extension_checker.rb
+++ b/library/general/src/lib/ui/ui_extension_checker.rb
@@ -30,11 +30,13 @@ module Yast
     # Constructor: Create a UI extension checker for the specified extension.
     #
     # @param ext_name [String] Short name of the UI extension ("pkg", "graph")
+    # @param force_ui [Boolean] Enforce creating a UI?
     #
-    def initialize(ext_name)
+    def initialize(ext_name, force_ui = true)
       textdomain "base"
       @ext_name = ext_name
       @ok = false
+      ensure_ui_created if force_ui
       @ui_plugin_info = UIPluginInfo.new
       ensure_ext_installed
     end
@@ -65,6 +67,16 @@ module Yast
         not_available_error
       end
       @ok
+    end
+
+    # Ensure that the UI is actually created: In CLI mode, that might be
+    # delayed because normally they should't create a UI at all.
+    #
+    def ensure_ui_created
+      # Just a UI call that doesn't do anything; this is already sufficient to
+      # load the UI main plug-in completely if it wasn't loaded yet.
+      # See also bsc#1192650
+      UI.WidgetExists(:foo)
     end
 
     # Check if the UI extension plug-in is installed.

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 15 17:33:48 UTC 2021 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Force creating the UI before checking -pkg etc. UI plug-ins
+  (bsc#1192650)
+- 4.4.22
+
+-------------------------------------------------------------------
 Fri Nov 12 12:32:19 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Adapt the code to the new product specification API

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.21
+Version:        4.4.22
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1192650


## Trello

https://trello.com/c/bM1EFCcS


## Problem

When clicking on a downloaded RPM in the desktop or in the web browser, there was a crash.


## Cause

This uses a MIME association between MIME type _application/x-rpm_ and a YaST .desktop file that ultimately calls `y2start sw_single <mypackage.rpm>`.

But because this adds arguments to the command line, it does not create a UI immediately (i.e. it does not load and execute a libyui plug-in); it delays that as long as possible because normally, YaST in CLI (command line interface) mode is not supposed to open any windows if it can be avoided at all.

In this case, however, it always opens a window anyway: That's the whole point of using the `sw_single` YaST module instead of a zypper command line like `zypper in <mypackage.rpm>`: It shows progress bars, and if any dependency problems are reported, the user can solve them with the Qt or NCurses UI.

Still, the new part that checks if the associated -pkg UI extension (`libyui-qt-pkg` or `libyui-ncurses-pkg`) is installed (and asks if it should install it if it's not) failed because it didn't even find the _main_ UI plug-in.


## Fix

This commit executes a simple UI operation that does nothing, but as a side effect it initiates loading the UI, so the UI extension checker can do its job.


## Suggested Alternative

@jreidinger suggested to add another exception to the code in the YaST ruby bindings that lists those YaST modules that should, unlike all others, not inhibit creating the UI if command line arguments are detected:

https://github.com/yast/yast-ruby-bindings/blob/master/src/y2start/y2start#L55

IMHO this is clumsy, fragile and dangerous, so I decided to explicitly force the UI to be created when that checker needs it.

Already we have a number of YaST modules where that UIExtensionChecker is used:

- YaST sw_single (always)
- YaST online_update (always)
- YaST add-on (if the user clicks on the "Run Software Manager" button)

...which of course means that we would have to list every single one of them in that yast-ruby-bindings code, and if we get more of them, we would have to remember to list them there as well. That does not sound like a stable and future-proof solution to me.


## Flexibility

The UIExtensionChecker now has another optional parameter `force_ui` (default: _true_) in its constructor. If enforcing creating the UI is not desired, the caller can pass _false_ for that parameter; but in that case, the checks need to be moved to the caller level.