### PR TITLE
Handle release notes error

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -447,11 +447,11 @@ module Yast
 
       log.info("installation.xml path: #{path}")
       path
-    rescue ::Packages::PackageDownloader::FetchError
+    rescue Y2Packager::PackageFetchError
       # TRANSLATORS: an error message
       Report.Error(_("Downloading the installer extension package failed."))
       nil
-    rescue ::Packages::PackageExtractor::ExtractionFailed
+    rescue Y2Packager::PackageExtractionError
       # TRANSLATORS: an error message
       Report.Error(_("Extracting the installer extension failed."))
       nil
@@ -1687,7 +1687,7 @@ module Yast
     # @param repo_id [Fixnum] repository ID
     # @param package [String] name of the package
     # @raise [::Packages::PackageDownloader::FetchError] if package download failed
-    # @raise [::Packages::PackageExtractor::ExtractionFailed] if package extraction failed
+    # @raise [Y2Packager::PackageExtractionError] if package extraction failed
     def fetch_package(repo_id, package, dir)
       downloader = ::Packages::PackageDownloader.new(repo_id, package)
 
@@ -1708,7 +1708,7 @@ module Yast
     # Extract an RPM package into the given directory.
     # @param package_file [String] the RPM package path
     # @param dir [String] a directory where the package will be extracted to
-    # @raise [::Packages::PackageExtractor::ExtractionFailed] if package extraction failed
+    # @raise [::Y2Packager::PackageExtractionError] if package extraction failed
     def extract(package_file, dir)
       log.info("Extracting file #{package_file}")
       extractor = ::Packages::PackageExtractor.new(package_file)

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -369,7 +369,7 @@ describe Yast::WorkflowManager do
 
     context "downloading the installer extension package fails" do
       before do
-        expect_any_instance_of(Packages::PackageDownloader).to receive(:download).and_raise(Packages::PackageDownloader::FetchError)
+        expect_any_instance_of(Packages::PackageDownloader).to receive(:download).and_raise(Y2Packager::PackageFetchError)
         allow(Yast::Report).to receive(:Error)
       end
 
@@ -385,7 +385,7 @@ describe Yast::WorkflowManager do
 
     context "extracting the installer extension package fails" do
       before do
-        expect_any_instance_of(Packages::PackageExtractor).to receive(:extract).and_raise(Packages::PackageExtractor::ExtractionFailed)
+        expect_any_instance_of(Packages::PackageExtractor).to receive(:extract).and_raise(Y2Packager::PackageFetchError)
         allow(Yast::Report).to receive(:Error)
       end
 

--- a/library/packages/src/lib/packages/package_downloader.rb
+++ b/library/packages/src/lib/packages/package_downloader.rb
@@ -17,6 +17,7 @@ require "tempfile"
 require "shellwords"
 
 require "yast2/execute"
+require "y2packager/exceptions"
 
 Yast.import "Pkg"
 
@@ -47,9 +48,6 @@ module Packages
     # @return [String] Name of the package
     attr_reader :package_name
 
-    # Error while downloading the package.
-    class FetchError < StandardError; end
-
     # Constructor
     #
     # @param [Integer] repo_id Repository ID
@@ -74,7 +72,7 @@ module Packages
       return if Yast::Pkg.ProvidePackage(repo_id, package_name, path.to_s)
 
       log.error("Package #{package_name} could not be retrieved.")
-      raise FetchError
+      raise Y2Packager::PackageFetchError
     end
   end
 end

--- a/library/packages/src/lib/packages/package_extractor.rb
+++ b/library/packages/src/lib/packages/package_extractor.rb
@@ -15,6 +15,7 @@ require "shellwords"
 
 require "yast"
 require "yast2/execute"
+require "y2packager/exceptions"
 
 module Packages
   # Extracts the RPM package contents to a directory.
@@ -31,9 +32,6 @@ module Packages
     # Path to the package to extract.
     # @return [String] package path
     attr_reader :package_path
-
-    # The package could not be extracted
-    class ExtractionFailed < StandardError; end
 
     # Constructor
     #
@@ -64,7 +62,7 @@ module Packages
         ret = Yast::Execute.locally("sh", "-c", cmd, allowed_exitstatus: 0..255)
         log.info("Extraction result: #{ret}")
 
-        raise ExtractionFailed unless ret.zero?
+        raise Y2Packager::PackageExtractionError unless ret.zero?
       end
     end
   end

--- a/library/packages/src/lib/y2packager/exceptions.rb
+++ b/library/packages/src/lib/y2packager/exceptions.rb
@@ -1,0 +1,32 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+module Y2Packager
+  # Base class for Y2Packager exceptions
+  class Error < RuntimeError
+  end
+
+  # It was not possible to download a package
+  class PackageFetchError < Error
+  end
+
+  # It was not possible to extract a package's content
+  class PackageExtractionError < Error
+  end
+end

--- a/library/packages/src/lib/y2packager/package.rb
+++ b/library/packages/src/lib/y2packager/package.rb
@@ -15,6 +15,7 @@ require "yast2/execute"
 require "packages/package_downloader"
 require "packages/package_extractor"
 require "tempfile"
+require "y2packager/exceptions"
 
 Yast.import "Pkg"
 
@@ -101,6 +102,7 @@ module Y2Packager
     #
     # @param path [String,Pathname] Path to download the package to
     # @see Packages::PackageDownloader
+    # @raise PackageFetchError
     def download_to(path)
       downloader = Packages::PackageDownloader.new(repo_id, name)
       downloader.download(path.to_s)
@@ -110,6 +112,8 @@ module Y2Packager
     #
     # @param directory [String,Pathname] Path to extract the package to
     # @see Packages::PackageExtractor
+    # @raise PackageFetchError
+    # @raise PackageExtractionError
     def extract_to(directory)
       tmpfile = Tempfile.new("downloaded-package-#{name}-")
       download_to(tmpfile.path)

--- a/library/packages/test/lib/package_downloader_test.rb
+++ b/library/packages/test/lib/package_downloader_test.rb
@@ -19,9 +19,9 @@ describe Packages::PackageDownloader do
       subject.download(path)
     end
 
-    it "raises FetchError when download fails" do
+    it "raises PackageFetchError when download fails" do
       expect(Yast::Pkg).to receive(:ProvidePackage).with(repo_id, package, path).and_return(nil)
-      expect { subject.download(path) }.to raise_error(Packages::PackageDownloader::FetchError)
+      expect { subject.download(path) }.to raise_error(Y2Packager::PackageFetchError)
     end
   end
 end

--- a/library/packages/test/lib/package_extractor_test.rb
+++ b/library/packages/test/lib/package_extractor_test.rb
@@ -25,10 +25,10 @@ describe Packages::PackageExtractor do
       end
     end
 
-    it "raises ExtractionFailed when the extraction fails" do
+    it "raises PackageExtractionError when the extraction fails" do
       Dir.mktmpdir do |tmpdir|
         extractor = Packages::PackageExtractor.new("non-existing-package")
-        expect { extractor.extract(tmpdir) }.to raise_error(Packages::PackageExtractor::ExtractionFailed)
+        expect { extractor.extract(tmpdir) }.to raise_error(Y2Packager::PackageExtractionError)
       end
     end
   end

--- a/library/packages/test/y2packager/package_test.rb
+++ b/library/packages/test/y2packager/package_test.rb
@@ -69,12 +69,12 @@ describe Y2Packager::Package do
     context "when package download fails" do
       before do
         allow(downloader).to receive(:download)
-          .and_raise(Packages::PackageDownloader::FetchError)
+          .and_raise(Y2Packager::PackageFetchError)
       end
 
       it "raises the error" do
         expect { package.download_to(PACKAGES_FIXTURES_PATH) }
-          .to raise_error(Packages::PackageDownloader::FetchError)
+          .to raise_error(Y2Packager::PackageFetchError)
       end
     end
   end
@@ -101,12 +101,12 @@ describe Y2Packager::Package do
     context "when the package could not be extracted" do
       before do
         allow(extractor).to receive(:extract)
-          .and_raise(Packages::PackageExtractor::ExtractionFailed)
+          .and_raise(Y2Packager::PackageExtractionError)
       end
 
       it "raises the error" do
         expect { package.extract_to("/path") }
-          .to raise_error(Packages::PackageExtractor::ExtractionFailed)
+          .to raise_error(Y2Packager::PackageExtractionError)
       end
     end
   end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  1 11:06:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not crash when it is not possible to fetch the package
+  containing the release notes (bsc#1193148).
+
+-------------------------------------------------------------------
 Tue Nov 30 18:34:38 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Prepare code for ruby3 (bsc#1193192)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.23
+Version:        4.4.24
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
Related to [bsc#1193148](https://bugzilla.suse.com/show_bug.cgi?id=1193148).

Do not crash when it is not possible to fetch the release notes package. It does not fix the real issue (why is the release notes package missing?), but at least the installer does not crash.

## Details

The initial fix was rather easy: just catching `PackageDownloader::FetchError` and `PackageExtractor::ExtractionFailed`. However, these exceptions look like an implementation detail from the outside: the caller needs to know that `PackageExtractor` and `PackageDownloader` are used by `Product#download`.

So after a short discussion with @ancorgs, he suggested following the same approach as `Y2Storage`: define a set of [domain-specific errors](https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/exceptions.rb). So, now, you do not know who raise the exception, but the error itself.

