### PR TITLE
bsc#1193212: add Product#register_target

### DIFF
--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -146,7 +146,7 @@ module Y2Packager
     # @param installation_package [String]  Installation package name
     # @param register_target      [String]  Register target
     def initialize(name: nil, short_name: nil, display_name: nil, version: nil, arch: nil,
-      category: nil, vendor: nil, order: nil, installation_package: nil, register_target: nil)
+      category: nil, vendor: nil, order: nil, installation_package: nil, register_target: "")
       @name = name
       @short_name = short_name
       @display_name = display_name
@@ -156,7 +156,7 @@ module Y2Packager
       @vendor = vendor
       @order = order
       @installation_package = installation_package
-      @register_target = register_target || ""
+      @register_target = register_target
     end
 
     # Compare two different products

--- a/library/packages/src/lib/y2packager/product.rb
+++ b/library/packages/src/lib/y2packager/product.rb
@@ -45,6 +45,8 @@ module Y2Packager
     attr_reader :installation_package
     # @return [Integer] repository for the installation_package
     attr_reader :installation_package_repo
+    # @return [String] Registration target name used for registering the product
+    attr_reader :register_target
 
     class << self
       PKG_BINDINGS_ATTRS = ["name", "short_name", "display_name", "version", "arch",
@@ -77,6 +79,7 @@ module Y2Packager
           display_name: product.display_name, version: product.version,
           arch: product.arch, category: product.category,
           vendor: product.vendor, order: displayorder,
+          register_target: product.register_target,
           installation_package: installation_package
         )
       end
@@ -141,8 +144,9 @@ module Y2Packager
     # @param vendor               [String]  Vendor
     # @param order                [Integer] Display order
     # @param installation_package [String]  Installation package name
+    # @param register_target      [String]  Register target
     def initialize(name: nil, short_name: nil, display_name: nil, version: nil, arch: nil,
-      category: nil, vendor: nil, order: nil, installation_package: nil)
+      category: nil, vendor: nil, order: nil, installation_package: nil, register_target: nil)
       @name = name
       @short_name = short_name
       @display_name = display_name
@@ -152,6 +156,7 @@ module Y2Packager
       @vendor = vendor
       @order = order
       @installation_package = installation_package
+      @register_target = register_target || ""
     end
 
     # Compare two different products

--- a/library/packages/src/lib/y2packager/product_reader.rb
+++ b/library/packages/src/lib/y2packager/product_reader.rb
@@ -159,7 +159,7 @@ module Y2Packager
     # read the available products, remove potential duplicates
     # @return [Array<Hash>] pkg-bindings data structure
     def zypp_products
-      products = Y2Packager::Resolvable.find(kind: :product)
+      products = Y2Packager::Resolvable.find({ kind: :product }, [:register_target])
 
       # remove duplicates, there might be different flavors ("DVD"/"POOL")
       # or archs (x86_64/i586), when selecting the product to install later

--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -77,8 +77,7 @@ describe Y2Packager::ProductReader do
           "version" => "1.0", "arch" => "x86_64", "product_package" => "testpackage",
           "display_name" => "display_name", "category" => "addon",
           "vendor" => "SUSE LINUX Products GmbH, Nuernberg, Germany",
-          "register_target" => ""
-        )
+          "register_target" => "")
       end
 
       let(:prod2) do
@@ -87,8 +86,7 @@ describe Y2Packager::ProductReader do
           "version" => "1.0", "arch" => "x86_64", "product_package" => "testpackage",
           "display_name" => "display_name", "category" => "addon",
           "vendor" => "SUSE LINUX Products GmbH, Nuernberg, Germany",
-          "register_target" => ""
-        )
+          "register_target" => "")
       end
 
       before do

--- a/library/packages/test/y2packager/product_reader_test.rb
+++ b/library/packages/test/y2packager/product_reader_test.rb
@@ -33,19 +33,20 @@ describe Y2Packager::ProductReader do
     end
 
     it "returns empty list if there is no product" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return([])
       expect(subject.available_base_products).to eq([])
     end
 
     it "returns Installation::Product objects" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return(products)
       expect(subject.available_base_products.first).to be_a(Y2Packager::Product)
     end
 
     it "returns the correct product properties" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
+        .and_return(products)
         .and_return(products)
       ret = subject.available_base_products.first
       expect(ret.name).to eq("SLES")
@@ -62,7 +63,7 @@ describe Y2Packager::ProductReader do
       addon1 = Y2Packager::Resolvable.new(addon1_hash)
       addon2 = Y2Packager::Resolvable.new(addon2_hash)
 
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return([addon2, addon1, sp3])
 
       expect(subject.available_base_products.size).to eq(1)
@@ -75,7 +76,9 @@ describe Y2Packager::ProductReader do
           "name" => "SLES", "status" => :available, "source" => 1, "short_name" => "short_name",
           "version" => "1.0", "arch" => "x86_64", "product_package" => "testpackage",
           "display_name" => "display_name", "category" => "addon",
-          "vendor" => "SUSE LINUX Products GmbH, Nuernberg, Germany")
+          "vendor" => "SUSE LINUX Products GmbH, Nuernberg, Germany",
+          "register_target" => ""
+        )
       end
 
       let(:prod2) do
@@ -83,11 +86,13 @@ describe Y2Packager::ProductReader do
           "name" => "SLED", "status" => :available, "source" => 2, "short_name" => "short_name",
           "version" => "1.0", "arch" => "x86_64", "product_package" => "testpackage",
           "display_name" => "display_name", "category" => "addon",
-          "vendor" => "SUSE LINUX Products GmbH, Nuernberg, Germany")
+          "vendor" => "SUSE LINUX Products GmbH, Nuernberg, Germany",
+          "register_target" => ""
+        )
       end
 
       before do
-        allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+        allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
           .and_return(products)
       end
 
@@ -120,7 +125,7 @@ describe Y2Packager::ProductReader do
     end
 
     it "returns the installed base product" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return(products + [base_prod])
       expect(subject.installed_base_product.name).to eq("base_product")
     end
@@ -139,7 +144,7 @@ describe Y2Packager::ProductReader do
     end
 
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return(products + [special_prod])
       allow(Yast::Pkg).to receive(:PkgQueryProvides).with("system-installation()")
         .and_return([])
@@ -196,7 +201,7 @@ describe Y2Packager::ProductReader do
       installed = Y2Packager::Resolvable.new(installed_hash)
 
       # return the installed product first to ensure the following available duplicate is not lost
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return([installed, available])
 
       expect(subject.all_products).to_not be_empty
@@ -211,7 +216,7 @@ describe Y2Packager::ProductReader do
       selected = Y2Packager::Resolvable.new(selected_hash)
       available = Y2Packager::Resolvable.new(available_hash)
 
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }, [:register_target])
         .and_return([selected, available])
 
       expect(subject.all_products.size).to eq(1)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -3,6 +3,9 @@ Wed Dec  1 11:06:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when it is not possible to fetch the package
   containing the release notes (bsc#1193148).
+- Add register_target to the Y2Packager::Product class
+  (bsc#1193212).
+- 4.4.24
 
 -------------------------------------------------------------------
 Tue Nov 30 18:34:38 UTC 2021 - Josef Reidinger <jreidinger@suse.com>

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,10 +1,15 @@
 -------------------------------------------------------------------
+Wed Dec  1 13:13:34 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add register_target to the Y2Packager::Product class
+  (bsc#1193212).
+- 4.4.25
+
+-------------------------------------------------------------------
 Wed Dec  1 11:06:33 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not crash when it is not possible to fetch the package
   containing the release notes (bsc#1193148).
-- Add register_target to the Y2Packager::Product class
-  (bsc#1193212).
 - 4.4.24
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.24
+Version:        4.4.25
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
yast2.rpm counterpart to https://github.com/yast/yast-update/pull/175.