### PR TITLE
Popup.YesNo(): Unify the internal [No] button ID (bsc#1193326)

### DIFF
--- a/library/general/src/modules/Popup.rb
+++ b/library/general/src/modules/Popup.rb
@@ -250,31 +250,19 @@ module Yast
     #
     # @return [Yast::Term] button box
     def AnyQuestionButtonBox(yes_button_message, no_button_message, focus)
-      yes_button = Empty()
-      no_button = Empty()
+      yes_opts = [:okButton]
+      no_opts = [:cancelButton]
 
       if focus == :focus_no
-        yes_button = PushButton(Id(:yes), Opt(:okButton), yes_button_message)
-        no_button = PushButton(
-          Id(:no_button),
-          Opt(:default, :cancelButton),
-          no_button_message
-        )
+        no_opts << :default
       else
-        yes_button = PushButton(
-          Id(:yes),
-          Opt(:default, :okButton),
-          yes_button_message
-        )
-        no_button = PushButton(
-          Id(:no_button),
-          Opt(:cancelButton),
-          no_button_message
-        )
+        yes_opts << :default
       end
 
-      button_box = ButtonBox(yes_button, no_button)
-      deep_copy(button_box)
+      yes_button = PushButton(Id(:yes), Opt(*yes_opts), yes_button_message)
+      no_button = PushButton(Id(:no), Opt(*no_opts), no_button_message)
+
+      ButtonBox(yes_button, no_button)
     end
 
     # Generic question popup with two buttons.

--- a/library/general/test/popup_test.rb
+++ b/library/general/test/popup_test.rb
@@ -409,4 +409,23 @@ describe Yast::Popup do
       expect(subject.AnyTimedRichMessage("headline", "message", 5)).to eq nil
     end
   end
+
+  describe ".YesNo" do
+    before do
+      allow(ui).to receive(:OpenDialog).and_return(true)
+      allow(ui).to receive(:CloseDialog).and_return(true)
+    end
+
+    it "returns true when user clicks [Yes]" do
+      expect(ui).to receive(:UserInput).and_return(:yes)
+
+      expect(subject.YesNo("question")).to eq(true)
+    end
+
+    it "returns false when user clicks [No]" do
+      expect(ui).to receive(:UserInput).and_return(:no)
+
+      expect(subject.YesNo("question")).to eq(false)
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  2 13:47:27 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Popup.YesNo(): Unify the internal [No] button ID (bsc#1193326)
+- 4.4.26
+
+-------------------------------------------------------------------
 Wed Dec  1 13:13:34 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add register_target to the Y2Packager::Product class

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.25
+Version:        4.4.26
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
- Unify the internal button IDs
- The new [Yast2::Popup]() class use the `:yes` and `:no` IDs while the old `Popup` module uses the `:yes` and `:no_button` IDs
- That's inconsistent and makes testing via libyui REST API more difficult as you need to know which implementation is used to display a particular popup
- So let's use the same IDs everywhere :+1: 
- Additionally the code has been refactored and simplified
