### PR TITLE
Backports fix for bsc#1180142 to SLE 12

### DIFF
--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -60,8 +60,8 @@ module Yast2
 
     Yast.import "Linuxrc"
 
-    FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --root=%{root} list-configs | grep \"^root \" >/dev/null".freeze
-    CREATE_SNAPSHOT_CMD = "/usr/lib/snapper/installation-helper --step 5 --root-prefix=%{root} --snapshot-type %{snapshot_type} --description \"%{description}\"".freeze
+    FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --root=%{root} list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
+    CREATE_SNAPSHOT_CMD = "/usr/bin/snapper --no-dbus --root=%{root} create --type %{snapshot_type} --description %{description}".freeze
     LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list".freeze
     VALID_LINE_REGEX = /\A\w+\s+\| \d+/
 
@@ -195,7 +195,7 @@ module Yast2
       out = Yast::SCR.Execute(Yast::Path.new(".target.bash_output"), cmd)
 
       if out["exit"] == 0
-        find(out["stdout"].to_i) # The CREATE_SNAPSHOT_CMD returns the number of the new snapshot.
+        all.last
       else
         log.error "Snapshot could not be created: #{cmd} returned: #{out}"
         raise SnapshotCreationFailed

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -266,6 +266,34 @@ module Yast2
 
     # Parses the snapshots list
     #
+    # The snapshots list is a table like the following one:
+    #
+    #   # | Type   | Pre # | Date                            | User | Cleanup | Description           | Userdata
+    # ----+--------+-------+---------------------------------+------+---------+-----------------------+--------------
+    #  0  | single |       |                                 | root |         | current               |
+    #  1* | single |       | Wed 20 Jan 2021 09:57:01 PM WET | root |         | first root filesystem |
+    #  2  | single |       | Wed 20 Jan 2021 10:09:46 PM WET | root | number  | after installation    | important=yes
+    #
+    # This method returns an array of hashes containing the information from
+    # the previous table:
+    #
+    # @example Parsing result ouput
+    #   [
+    #     {
+    #       "#"            => "0",
+    #       "Type"         => "single",
+    #       "Pre #"        => "",
+    #       "Date"         => "",
+    #       "User"         => "root",
+    #       "Cleanup"      => "",
+    #       "Description"  => "current",
+    #       "Userdata"     => ""},
+    #       # ...
+    #     }
+    #   ]
+    #
+    # Not that values are not processed.
+    #
     # @param content [String] Snapshots list content
     # @return Array<Hash> An array of hashes containing the data for each snapshot
     def self.parse_snapshots_list(content)

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -63,7 +63,6 @@ module Yast2
     FIND_CONFIG_CMD = "/usr/bin/snapper --no-dbus --root=%{root} list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
     CREATE_SNAPSHOT_CMD = "/usr/bin/snapper --no-dbus --root=%{root} create --type %{snapshot_type} --description %{description}".freeze
     LIST_SNAPSHOTS_CMD = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=%{root} list".freeze
-    VALID_LINE_REGEX = /\A\w+\s+\| \d+/
 
     # Predefined snapshot cleanup strategies (the user can define custom ones, too)
     CLEANUP_STRATEGY = { number: "number", timeline: "timeline" }.freeze
@@ -234,20 +233,22 @@ module Yast2
         Yast::Path.new(".target.bash_output"),
         format(LIST_SNAPSHOTS_CMD, root: target_root)
       )
-      lines = out["stdout"].lines.grep(VALID_LINE_REGEX) # relevant lines from output.
       log.info("Retrieving snapshots list: #{LIST_SNAPSHOTS_CMD} returned: #{out}")
-      lines.each_with_object([]) do |line, snapshots|
-        data = line.split("|").map(&:strip)
-        next if data[1] == "0" # Ignores 'current' snapshot (id = 0) because it's not a real snapshot
+      return [] unless out["exit"].zero?
+
+      parse_snapshots_list(out["stdout"]).each_with_object([]) do |data, snapshots|
+        next if data["#"] == "0" # Ignores 'current' snapshot (id = 0) because it's not a real snapshot
+
         begin
-          timestamp = DateTime.parse(data[3])
+          timestamp = DateTime.parse(data["Date"])
         rescue ArgumentError
           log.warn("Error when parsing date/time: #{timestamp}")
-          timestamp = nil
         end
-        previous_number = data[2] == "" ? nil : data[2].to_i
-        snapshots << new(data[1].to_i, data[0].to_sym, previous_number, timestamp,
-          data[4], data[5].to_sym, data[6])
+        previous_number = data["Pre #"].to_s.empty? ? nil : data["Pre #"].to_i
+        snapshots << new(
+          data["#"].to_i, data["Type"].to_sym, previous_number, timestamp,
+          data["User"], data["Cleanup"].to_sym, data["Description"]
+        )
       end
     end
 
@@ -261,6 +262,23 @@ module Yast2
     # @see FsSnapshot.all
     def self.find(number)
       all.find { |s| s.number == number }
+    end
+
+    # Parses the snapshots list
+    #
+    # @param content [String] Snapshots list content
+    # @return Array<Hash> An array of hashes containing the data for each snapshot
+    def self.parse_snapshots_list(content)
+      lines = content.lines
+      return [] if lines.size <= 2
+
+      columns = lines.first.split("|").map(&:strip)
+      lines[2..-1].map do |line|
+        values = line.split("|").map(&:strip)
+        values.each_with_index.each_with_object({}) do |(v, i), all|
+          all[columns[i]] = v
+        end
+      end
     end
 
     # FsSnapshot constructor
@@ -286,7 +304,7 @@ module Yast2
       @description = description
     end
 
-    private_class_method :new
+    private_class_method :new, :parse_snapshots_list
 
     # Returns the previous snapshot
     #

--- a/library/system/src/lib/yast2/fs_snapshot.rb
+++ b/library/system/src/lib/yast2/fs_snapshot.rb
@@ -78,7 +78,7 @@ module Yast2
 
       out = Yast::SCR.Execute(
         Yast::Path.new(".target.bash_output"),
-        format(FIND_CONFIG_CMD, root: target_root)
+        format(FIND_CONFIG_CMD, root: target_root.shellescape)
       )
 
       log.info("Checking if Snapper is configured: \"#{FIND_CONFIG_CMD}\" returned: #{out}")
@@ -179,15 +179,15 @@ module Yast2
       raise SnapperNotConfigured unless configured?
 
       cmd = format(CREATE_SNAPSHOT_CMD,
-        root:          target_root,
-        snapshot_type: snapshot_type,
-        description:   description)
-      cmd << " --pre-num #{previous.number}" if previous
+        root:          target_root.shellescape,
+        snapshot_type: snapshot_type.to_s.shellescape,
+        description:   description.shellescape)
+      cmd << " --pre-num #{previous.number.to_s.shellescape}" if previous
       cmd << " --userdata \"important=yes\"" if important
 
       if cleanup
         strategy = CLEANUP_STRATEGY[cleanup]
-        cmd << " --cleanup \"#{strategy}\"" if strategy
+        cmd << " --cleanup #{strategy.shellescape}" if strategy
       end
 
       log.info("Executing: \"#{cmd}\"")

--- a/library/system/src/lib/yast2/fs_snapshot_store.rb
+++ b/library/system/src/lib/yast2/fs_snapshot_store.rb
@@ -28,6 +28,8 @@ module Yast2
   # Goal of this module is to provide easy to use api to store id of pre
   # snapshots, so post snapshots can be then easy to make.
   module FsSnapshotStore
+    class IOError < StandardError; end
+
     # Stores pre snapshot with given id and purpose
     # @param[String] purpose of snapshot like "upgrade"
     # @raise[RuntimeError] if writing to file failed
@@ -38,7 +40,7 @@ module Yast2
         snapshot_id.to_s
       )
 
-      raise "Failed to write Pre Snapshot id for #{purpose} to store. See logs." unless result
+      raise IOError, "Failed to write Pre Snapshot id for #{purpose} to store. See logs." unless result
     end
 
     # Loads id of pre snapshot for given purpose
@@ -52,7 +54,7 @@ module Yast2
       )
 
       if !content || content !~ /^\d+$/
-        raise "Failed to read Pre Snapshot id for #{purpose} from store. See logs."
+        raise IOError, "Failed to read Pre Snapshot id for #{purpose} from store. See logs."
       end
 
       content.to_i

--- a/library/system/test/fs_snapshot_store_test.rb
+++ b/library/system/test/fs_snapshot_store_test.rb
@@ -22,7 +22,7 @@ describe Yast2::FsSnapshotStore do
         "42"
       ).and_return(nil)
 
-      expect { described_class.save("test", 42) }.to raise_error(/Failed to write/)
+      expect { described_class.save("test", 42) }.to raise_error(Yast2::FsSnapshotStore::IOError)
     end
   end
 
@@ -42,7 +42,7 @@ describe Yast2::FsSnapshotStore do
         "/var/lib/YaST2/pre_snapshot_test.id"
       ).and_return(nil)
 
-      expect { described_class.load("test") }.to raise_error(/Failed to read/)
+      expect { described_class.load("test") }.to raise_error(Yast2::FsSnapshotStore::IOError)
     end
 
     it "raises exception if file content is not number" do
@@ -51,7 +51,7 @@ describe Yast2::FsSnapshotStore do
         "/var/lib/YaST2/pre_snapshot_test.id"
       ).and_return("blabla\n")
 
-      expect { described_class.load("test") }.to raise_error(/Failed to read/)
+      expect { described_class.load("test") }.to raise_error(Yast2::FsSnapshotStore::IOError)
     end
   end
 

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -8,11 +8,11 @@ describe Yast2::FsSnapshot do
     described_class.log
   end
 
-  FIND_CONFIG = "/usr/bin/snapper --no-dbus --root=/ list-configs | grep \"^root \" >/dev/null".freeze
-  FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | grep \"^root \" >/dev/null".freeze
+  FIND_CONFIG = "/usr/bin/snapper --no-dbus --root=/ list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
+  FIND_IN_ROOT_CONFIG = "/usr/bin/snapper --no-dbus --root=/mnt list-configs | /usr/bin/grep \"^root \" >/dev/null".freeze
   LIST_SNAPSHOTS = "LANG=en_US.UTF-8 /usr/bin/snapper --no-dbus --root=/ list".freeze
 
-  let(:dummy_snapshot) { double("snapshot") }
+  let(:dummy_snapshot) { double("snapshot", number: 2) }
 
   before do
     # reset configured cache
@@ -68,14 +68,15 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".create_single" do
-    CREATE_SINGLE_SNAPSHOT = "/usr/lib/snapper/installation-helper --step 5 "\
-      "--root-prefix=/ --snapshot-type single --description \"some-description\"".freeze
+    CREATE_SINGLE_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
+      "--root=/ create --type single --description some-description".freeze
     OPTION_CLEANUP_NUMBER = " --cleanup \"number\"".freeze
     OPTION_IMPORTANT = " --userdata \"important=yes\"".freeze
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
       allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:single).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:all).and_return([dummy_snapshot])
     end
 
     context "when snapper is configured" do
@@ -90,7 +91,7 @@ describe Yast2::FsSnapshot do
       end
 
       context "when snapshot creation fails" do
-        let(:output) { { "stdout" => "", "exit" => 1 } }
+        let(:output) { { "exit" => 1 } }
 
         it "logs the error and returns nil" do
           expect(logger).to receive(:error).with(/Snapshot could not be created/)
@@ -100,23 +101,19 @@ describe Yast2::FsSnapshot do
       end
 
       context "when snapshot creation is successful" do
-        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:output) { { "exit" => 0 } }
 
         it "returns the created snapshot" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description")
           expect(snapshot).to be(dummy_snapshot)
         end
       end
 
       context "when a cleanup strategy is set" do
-        let(:output) { { "stdout" => "2", "exit" => 0 } }
+        let(:output) { { "exit" => 0 } }
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
 
         it "creates a snapshot with that strategy" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description", cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -127,8 +124,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_IMPORTANT }
 
         it "creates a snapshot marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description", important: true)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -139,8 +134,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_SINGLE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
 
         it "creates a snapshot with that strategy that is marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_single("some-description", cleanup: :number, important: true)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -168,12 +161,13 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".create_pre" do
-    CREATE_PRE_SNAPSHOT = "/usr/lib/snapper/installation-helper --step 5 "\
-      "--root-prefix=/ --snapshot-type pre --description \"some-description\"".freeze
+    CREATE_PRE_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
+      "--root=/ create --type pre --description some-description".freeze
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
       allow(Yast2::FsSnapshot).to receive(:create_snapshot?).with(:around).and_return(create_snapshot)
+      allow(Yast2::FsSnapshot).to receive(:all).and_return([dummy_snapshot])
     end
 
     context "when snapper is configured" do
@@ -188,7 +182,7 @@ describe Yast2::FsSnapshot do
       end
 
       context "when snapshot creation fails" do
-        let(:output) { { "stdout" => "", "exit" => 1 } }
+        let(:output) { { "exit" => 1 } }
 
         it "logs the error and returns nil" do
           expect(logger).to receive(:error).with(/Snapshot could not be created/)
@@ -201,8 +195,6 @@ describe Yast2::FsSnapshot do
         let(:output) { { "stdout" => "2", "exit" => 0 } }
 
         it "returns the created snapshot" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description")
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -213,8 +205,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_CLEANUP_NUMBER }
 
         it "creates a pre snapshot with that strategy" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description", cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -225,8 +215,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT }
 
         it "creates a pre snapshot marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description", important: true)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -237,8 +225,6 @@ describe Yast2::FsSnapshot do
         let(:snapshot_command) { CREATE_PRE_SNAPSHOT + OPTION_IMPORTANT + OPTION_CLEANUP_NUMBER }
 
         it "creates a pre snapshot with that strategy that is marked as important" do
-          expect(described_class).to receive(:find).with(2)
-            .and_return(dummy_snapshot)
           snapshot = described_class.create_pre("some-description", important: true, cleanup: :number)
           expect(snapshot).to be(dummy_snapshot)
         end
@@ -266,9 +252,9 @@ describe Yast2::FsSnapshot do
   end
 
   describe ".create_post" do
-    CREATE_POST_SNAPSHOT = "/usr/lib/snapper/installation-helper --step 5 "\
-      "--root-prefix=/ --snapshot-type post --description \"some-description\" "\
-      "--pre-num 2".freeze
+    CREATE_POST_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
+      "--root=/ create --type post --description some-description "\
+      "--pre-num 1".freeze
 
     before do
       allow(Yast2::FsSnapshot).to receive(:configured?).and_return(configured)
@@ -279,16 +265,18 @@ describe Yast2::FsSnapshot do
       let(:configured) { true }
       let(:create_snapshot) { true }
 
-      let(:pre_snapshot) { double("snapshot", snapshot_type: :pre, number: 2) }
+      let(:pre_snapshot) { double("snapshot", snapshot_type: :pre, number: 1) }
       let(:snapshots) { [pre_snapshot] }
-      let(:output) { { "stdout" => "3", "exit" => 0 } }
+      let(:output) { { "exit" => 0 } }
 
       before do
         allow(Yast::SCR).to receive(:Execute)
           .with(path(".target.bash_output"), CREATE_POST_SNAPSHOT)
           .and_return(output)
         allow(Yast2::FsSnapshot).to receive(:all)
-          .and_return(snapshots)
+          .and_return([pre_snapshot])
+        allow(Yast2::FsSnapshot).to receive(:all)
+          .and_return([pre_snapshot, dummy_snapshot])
       end
 
       context "when previous snapshot exists" do
@@ -296,12 +284,8 @@ describe Yast2::FsSnapshot do
 
         context "when snapshot creation is successful" do
           it "returns the created snapshot" do
-            allow(Yast2::FsSnapshot).to receive(:find).with(pre_snapshot.number)
-              .and_return(pre_snapshot)
-            expect(Yast2::FsSnapshot).to receive(:find).with(3)
-              .and_return(dummy_snapshot)
             expect(described_class.create_post("some-description", pre_snapshot.number))
-              .to be(dummy_snapshot)
+              .to eq(dummy_snapshot)
           end
         end
 

--- a/library/system/test/fs_snapshot_test.rb
+++ b/library/system/test/fs_snapshot_test.rb
@@ -70,7 +70,7 @@ describe Yast2::FsSnapshot do
   describe ".create_single" do
     CREATE_SINGLE_SNAPSHOT = "/usr/bin/snapper --no-dbus "\
       "--root=/ create --type single --description some-description".freeze
-    OPTION_CLEANUP_NUMBER = " --cleanup \"number\"".freeze
+    OPTION_CLEANUP_NUMBER = " --cleanup number".freeze
     OPTION_IMPORTANT = " --userdata \"important=yes\"".freeze
 
     before do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Dec  9 16:56:23 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not use the 'installation-helper' binary to create snapshots
+  during installation or offline upgrade (bsc#1180142).
+- Add a new exception to properly handle exceptions
+  when reading/writing snapshots numbers (related to bsc#1180142).
+- 3.2.46.2
+
+-------------------------------------------------------------------
 Tue Apr 30 08:52:35 UTC 2019 - mvidner@suse.com
 
 - Stop "ls: write error: Broken pipe" messages (bsc#1128032)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        3.2.46.1
+Version:        3.2.46.2
 Release:        0
 Summary:        YaST2 - Main Package
 License:        GPL-2.0


### PR DESCRIPTION
Backport fix for [bsc#1180142](https://bugzilla.suse.com/show_bug.cgi?id=1180142) to SLE 12 SP3. Please, check #1125 for details about the original fix.

Related to:

* https://github.com/yast/yast-installation/pull/1003
* https://github.com/yast/yast-update/pull/176

Manually tested upgrading from SLE 12 SP2 to SLE 12 SP4.