### PR TITLE
Added RelURL class (jsc#SLE-22669)

### DIFF
--- a/library/general/src/lib/yast2/rel_url.rb
+++ b/library/general/src/lib/yast2/rel_url.rb
@@ -17,7 +17,10 @@
 # To contact SUSE LLC about this file by physical or electronic mail, you may
 # find current contact information at www.suse.com.
 
+require "yast"
 require "uri"
+
+Yast.import "InstURL"
 
 module Yast2
   # Class for working with relative URLs ("relurl://")

--- a/library/general/src/lib/yast2/rel_url.rb
+++ b/library/general/src/lib/yast2/rel_url.rb
@@ -1,0 +1,127 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "uri"
+
+module Yast2
+  # Class for working with relative URLs ("relurl://")
+  class RelURL
+    attr_reader :base, :relative
+
+    # Is the URL a relative URL?
+    #
+    # @param url [String, URI] the URL
+    # @return [Boolean] `true` if the URL uses the "relurl" schema, otherwise `false`
+    def self.relurl?(url)
+      URI(url).scheme == "relurl"
+    end
+
+    # Create RelURL object with URL relative to the installation repository
+    #
+    # @param rel_url [String, URI] the relative URL
+    # @return [RelURL]
+    #
+    # @note Works properly only during installation/upgrade, do not use
+    #   in an installed system.
+    def self.from_installation_repository(rel_url)
+      base_url = Yast::InstURL.installInf2Url("")
+      new(base_url, rel_url)
+    end
+
+    # Constructor
+    #
+    # @param base_url [String,URI] the base URL
+    # @param rel_url [String,URI] the relative URL, it should use the "relurl://"
+    #  schema otherwise the base URL is ignored
+    def initialize(base_url, rel_url)
+      @base = import_url(base_url)
+      @relative = import_url(rel_url)
+    end
+
+    # Build and absolute URL
+    #
+    # @param path [String,nil] optional URL subpath
+    # @return [URI] the absolute URL
+    #
+    # @note It internally uses the Ruby `File.expand_path` function which
+    # also evaluates the parent directory path ("../") so it is possible
+    # to go up in the tree using the "relurl://../foo" or the "../foo" path
+    # parameter.
+    def absolute_url(path = nil)
+      if (!relative.to_s.empty? && !RelURL.relurl?(relative)) || base.to_s.empty?
+        ret = relative.dup
+        relative_url = URI("")
+      else
+        ret = base.dup
+        relative_url = relative.dup
+      end
+
+      relative_path = relative_url.path
+      relative_path = File.join(relative_path, path) if path && !path.empty?
+
+      base_path = ret.path
+      if !base_path.empty? || !relative_path.empty?
+        # the path would be expanded from the current working directory
+        # by File.expand_path if the base path is not absolute
+        base_path.prepend("/") if !base_path.start_with?("/")
+
+        # escape the "~"" character, it is treated as a home directory name by File.expand_path,
+        # moreover it raises ArgumentError if that user does not exist in the system
+        relative_path.gsub!("~", "%7E")
+        # the relative path really needs to be relative, remove the leading slash(es)
+        relative_path.sub!(/\A\/+/, "")
+
+        ret.path = File.expand_path(relative_path, base_path)
+      end
+
+      export_url(ret)
+      ret
+    end
+
+  private
+
+    # a helper method for importing an URL,
+    # it creates a copy of the input object and pre-processes the
+    # "file://" and "relurl://" URLs
+    def import_url(url)
+      ret = URI(url).dup
+
+      # move the host part to the path part for some URL types
+      if ["file", "relurl"].include?(ret.scheme) && ret.host
+        # URI requires absolute path
+        ret.path = File.join("/", ret.host, ret.path)
+        ret.host = nil
+      end
+
+      ret
+    end
+
+    # adjust the result if it is a "file://" URL
+    def export_url(url)
+      return if url.scheme != "file" && !url.host.nil? && !url.host.empty?
+
+      path = url.path.sub(/\A\/+/, "").split("/")
+      url.host = path.shift
+
+      rest = File.join(path)
+      rest.prepend("/") unless path.empty?
+      url.path = rest
+    end
+  end
+end

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -1,0 +1,210 @@
+require_relative "../test_helper"
+require "yast2/rel_url"
+
+describe Yast2::RelURL do
+  describe ".is_relurl?" do
+    it "raises ArgumentError for nil" do
+      expect { Yast2::RelURL.relurl?(nil) }.to raise_error(ArgumentError)
+    end
+
+    it "raises ArgumentError for invalid parameter" do
+      expect { Yast2::RelURL.relurl?(42) }.to raise_error(ArgumentError)
+    end
+
+    it "raises URI::InvalidURIError for invalid URL" do
+      expect { Yast2::RelURL.relurl?("!@#$^") }.to raise_error(URI::InvalidURIError)
+    end
+
+    it "returns false for empty string" do
+      expect(Yast2::RelURL.relurl?("")).to be false
+    end
+
+    it "returns false for HTTP String URL" do
+      expect(Yast2::RelURL.relurl?("http://example.com")).to be false
+    end
+
+    it "returns false for HTTP URI URL" do
+      expect(Yast2::RelURL.relurl?(URI("http://example.com"))).to be false
+    end
+
+    it "returns true for relative String URL" do
+      expect(Yast2::RelURL.relurl?("relurl://test/test")).to be true
+    end
+
+    it "returns true for relative URI URL" do
+      expect(Yast2::RelURL.relurl?(URI("relurl://test/test"))).to be true
+    end
+
+    it "returns true for upper case URL" do
+      expect(Yast2::RelURL.relurl?("RELURL://test/test")).to be true
+    end
+
+    it "returns true for mixed case URL" do
+      expect(Yast2::RelURL.relurl?("RELurl://test/test")).to be true
+    end
+  end
+
+  describe "#initialize" do
+    it "raises ArgumentError for invalid parameter" do
+      expect { Yast2::RelURL.new(42, 42) }.to raise_error(ArgumentError)
+    end
+
+    it "raises URI::InvalidURIError for invalid URL" do
+      expect { Yast2::RelURL.new("@#$%^&*", "@#$%^&*") }.to raise_error(URI::InvalidURIError)
+    end
+  end
+
+  describe "#absolute_url" do
+    # empty URLs should not be used, just make sure it does not crash
+    # and returns sane values
+    it "returns the base URL if the relative URL is empty" do
+      relurl = Yast2::RelURL.new("http://example.com", "")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com")
+    end
+
+    it "returns the relative URL if the base URL is empty" do
+      relurl = Yast2::RelURL.new("", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("relurl://test")
+    end
+
+    it "returns empty URL if both relative and base URLs are empty" do
+      relurl = Yast2::RelURL.new("", "")
+      expect(relurl.absolute_url.to_s).to eq("")
+    end
+
+    it "returns the original relative URL if it does not use the relurl:// schema" do
+      relurl = Yast2::RelURL.new("http://example.com", "http://example2.com")
+      expect(relurl.absolute_url.to_s).to eq("http://example2.com")
+    end
+
+    it "returns the relative URL" do
+      relurl = Yast2::RelURL.new("http://example.com", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/test")
+    end
+
+    it "returns relative URL with full path" do
+      relurl = Yast2::RelURL.new("http://example.com", "relurl://test/test2/test3")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/test/test2/test3")
+    end
+
+    it "returns relative URL with base path" do
+      relurl = Yast2::RelURL.new("http://example.com/base", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/test")
+    end
+
+    it "treats the hostname in the relative URL as a path" do
+      relurl = Yast2::RelURL.new("http://example.com/base", "relurl://example.com/test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/example.com/test")
+    end
+
+    it "treats absolute_url path as relative in the relative URL" do
+      relurl = Yast2::RelURL.new("http://example.com/base", "relurl:///test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/test")
+    end
+
+    # this is rather a side effect of the used library function and not an intended
+    # behavior, but as ~ is used very rarely in path names (needs shell escaping)
+    # let's consider it as an acceptable behavior, the escaped path in URL is equal
+    # to unescaped one so there is no functional difference, only visual
+    it "escapes ~ character in the relative URL path" do
+      relurl = Yast2::RelURL.new("http://example.com/~base", "relurl://~test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/~base/%7Etest")
+    end
+
+    it "allows going up in the tree using ../" do
+      relurl = Yast2::RelURL.new("http://example.com/base/dir", "relurl://../test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/test")
+    end
+
+    it "allows going up in the tree using ../.." do
+      relurl = Yast2::RelURL.new("http://example.com/base/dir", "relurl://../../test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/test")
+    end
+
+    it "cannot go up beyond the root dir" do
+      relurl = Yast2::RelURL.new("http://example.com/base", "relurl://../../../../test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/test")
+    end
+
+    it "removes single dot item from relative path" do
+      relurl = Yast2::RelURL.new("http://example.com/base", "relurl://./test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/test")
+    end
+
+    it "removes multiple dot items from relative path" do
+      relurl = Yast2::RelURL.new("http://example.com/base", "relurl://././test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/test")
+    end
+
+    # again, this is rather a side effect of the used library, but as single dots
+    # do not make much sense in a path then just accept that
+    it "removes single dot path from base path" do
+      relurl = Yast2::RelURL.new("http://example.com/base/./dir", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/dir/test")
+    end
+
+    # same as above
+    it "removes single dot paths from base path" do
+      relurl = Yast2::RelURL.new("http://example.com/base/././dir", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/dir/test")
+    end
+
+    it "ignores query parameters in the relative URL" do
+      relurl = Yast2::RelURL.new("http://example.com", "relurl://test?foo=bar")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/test")
+    end
+
+    it "keeps the query parameters in the base URL" do
+      relurl = Yast2::RelURL.new("http://example.com?foo=bar", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/test?foo=bar")
+    end
+
+    it "keeps the query parameters in the base URL when going up" do
+      relurl = Yast2::RelURL.new("http://example.com/base/dir?foo=bar", "relurl://../test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com/base/test?foo=bar")
+    end
+
+    it "keeps the port parameter in the base URL" do
+      relurl = Yast2::RelURL.new("http://example.com:8080", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://example.com:8080/test")
+    end
+
+    it "keeps the user and password parameters in the base URL" do
+      relurl = Yast2::RelURL.new("http://user:password@example.com", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("http://user:password@example.com/test")
+    end
+
+    it "works with file:// base URL" do
+      relurl = Yast2::RelURL.new("file://foo/bar", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("file://foo/bar/test")
+    end
+
+    it "goes up with file:// base URL properly" do
+      relurl = Yast2::RelURL.new("file://foo/bar", "relurl://../../test")
+      expect(relurl.absolute_url.to_s).to eq("file://test")
+    end
+
+    it "adds the requested path to the absolute URL" do
+      relurl = Yast2::RelURL.new("http://example.com/foo", "relurl://test")
+      expect(relurl.absolute_url("path").to_s).to eq("http://example.com/foo/test/path")
+    end
+
+    it "allow the requested path to go up in the relative path" do
+      relurl = Yast2::RelURL.new("http://example.com/foo", "relurl://test")
+      expect(relurl.absolute_url("../path").to_s).to eq("http://example.com/foo/path")
+    end
+
+    it "allows the requested path to go up in the path even to the base URL" do
+      relurl = Yast2::RelURL.new("http://example.com/foo", "relurl://test")
+      expect(relurl.absolute_url("../../path").to_s).to eq("http://example.com/path")
+    end
+
+    it "returns the path if both relative and base URLs are empty" do
+      relurl = Yast2::RelURL.new("", "")
+      # might not be exactly what you would expect as the result but this is a corner
+      # case, do not overengineer the code, the most important fact is that it does
+      # not crash and the result is a valid file path
+      expect(relurl.absolute_url("foo/bar").to_s).to eq("//foo/bar")
+    end
+  end
+end

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -207,4 +207,29 @@ describe Yast2::RelURL do
       expect(relurl.absolute_url("foo/bar").to_s).to eq("//foo/bar")
     end
   end
+
+  describe ".from_installation_repository" do
+    before do
+      allow(Yast::InstURL).to receive(:installInf2Url).and_return(inst_url)
+    end
+
+    let(:rel_url) { "relurl://test" }
+    subject { Yast2::RelURL.from_installation_repository(rel_url) }
+
+    context "during installation" do
+      let(:inst_url) { "http://example.com/repo" }
+
+      it "returns URL relative to the installation repository" do
+        expect(subject.absolute_url.to_s).to eq("http://example.com/repo/test")
+      end
+    end
+
+    context "in an installed system" do
+      let(:inst_url) { "" }
+
+      it "returns the original relative URL" do
+        expect(subject.absolute_url.to_s).to eq(rel_url)
+      end
+    end
+  end
 end

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -104,7 +104,7 @@ describe Yast2::RelURL do
 
     # this is rather a side effect of the used library function and not an intended
     # behavior, but as ~ is used very rarely in path names (needs shell escaping)
-    # let's consider it as an acceptable behavior, the escaped path in URL is equal
+    # let's consider it as an acceptable behavior, the escaped character in URL is equal
     # to unescaped one so there is no functional difference, only visual
     it "escapes ~ character in the relative URL path" do
       relurl = Yast2::RelURL.new("http://example.com/~base", "relurl://~test")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Dec 14 16:24:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added RelURL class for working with relative URLs ("relurl://")
+  (jsc#SLE-22669)
+- 4.4.28
+
+-------------------------------------------------------------------
 Thu Dec  2 17:13:37 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Drop support for subscription-tools, that package is not present

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.27
+Version:        4.4.28
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only


### PR DESCRIPTION
## Description

- Related to https://jira.suse.com/browse/SLE-22669
- This PR adds support for evaluating the `relurl://` URLs
- It will be used by other YaST modules (self-update)

## Details

- It internally uses the [File.expand_path](https://ruby-doc.org/core-2.5.0/File.html#method-c-expand_path) Ruby function to convert the relative path to absolute.
- The advantage is that it also supports going up in the tree using the parent directory notation (`../`)
- The disadvantage is that some corner cases must be handled specifically, e.g. it replaces `~` with the home directory path on the local system which is not what you would expect in URLs.

## Testing

- Tested with unit tests with lots of corner cases.