### PR TITLE
Do not check Report internals in the commandline test

### DIFF
--- a/library/commandline/test/commandline_test.rb
+++ b/library/commandline/test/commandline_test.rb
@@ -25,7 +25,7 @@ describe Yast::CommandLine do
 
   it "displays errors and aborts" do
     expect(STDOUT).to receive(:puts).with("Initialize called").ordered
-    expect(Yast::CommandLine).to receive(:Print).with(/I crashed/).ordered
+    expect(Yast::WFM).to receive(:handle_exception).with(RuntimeError, /dummy_cmdline/).ordered
     expect(STDOUT).to_not receive(:puts).with("Finish called")
 
     Yast::WFM.CallFunction("dummy_cmdline", ["crash"])


### PR DESCRIPTION
The command line does some assertions on the WFM and Report internals. So when they change, the test breaks. Asserting on a private method is not the ideal solution, but it moves the test one level up and it does not break so easily.