### PR TITLE
Fixed RelURL unit test randomly crashing

### DIFF
--- a/library/general/src/lib/yast2/rel_url.rb
+++ b/library/general/src/lib/yast2/rel_url.rb
@@ -20,8 +20,6 @@
 require "yast"
 require "uri"
 
-Yast.import "InstURL"
-
 module Yast2
   # Class for working with relative URLs ("relurl://")
   class RelURL
@@ -48,6 +46,7 @@ module Yast2
     # @note Works properly only during installation/upgrade, do not use
     #   in an installed system.
     def self.from_installation_repository(rel_url)
+      Yast.import "InstURL"
       base_url = Yast::InstURL.installInf2Url("")
       new(base_url, rel_url)
     end

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -1,6 +1,4 @@
-# this mocks the Yast::InstURL module
-require_relative "../../../packages/test/test_helper.rb"
-
+require_relative "../test_helper"
 require "yast2/rel_url"
 
 describe Yast2::RelURL do

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -1,4 +1,6 @@
-require_relative "../test_helper"
+# this mocks the Yast::InstURL module
+require_relative "../../../packages/test/test_helper.rb"
+
 require "yast2/rel_url"
 
 describe Yast2::RelURL do

--- a/library/packages/test/test_helper.rb
+++ b/library/packages/test/test_helper.rb
@@ -2,15 +2,3 @@ require_relative "../../../test/test_helper.rb"
 require "pathname"
 
 PACKAGES_FIXTURES_PATH = Pathname.new(File.dirname(__FILE__)).join("data")
-
-# mock missing YaST modules
-module Yast
-  # we cannot depend on this module (circular dependency)
-  class InstURLClass
-    def installInf2Url(_extra_dir = "")
-      ""
-    end
-  end
-
-  InstURL = InstURLClass.new
-end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 15 13:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed RelURL unit test randomly crashing (related to
+  jsc#SLE-22669)
+- 4.4.29
+
+-------------------------------------------------------------------
 Tue Dec 14 16:24:00 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added RelURL class for working with relative URLs ("relurl://")

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.28
+Version:        4.4.29
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,3 +57,15 @@ if ENV["COVERAGE"]
     ]
   end
 end
+
+# mock missing YaST modules
+module Yast
+  # we cannot depend on this module (circular dependency)
+  class InstURLClass
+    def installInf2Url(_extra_dir = "")
+      ""
+    end
+  end
+
+  InstURL = InstURLClass.new
+end


### PR DESCRIPTION
- Fixes a [Jenkins crash](https://ci.suse.de/job/yast-yast-yast2-master/173/console) ("component cannot import namespace 'InstURL'").
- The problem was that the `Yast::InstURL` module is part of the `yast2-packager` package, but we cannot build depend on it to avoid circular dependecies.
- That module is mocked at some else unit tests so it depended on the order of executing the tests, if the RelURL test was executed too early the `Yast::InstURL` module was not mocked yet and it crashed.
- Fixed by moving the mock to the top level test helper.