### PR TITLE
Unify `Package`, `PackageSystem` and `PackageAI`

### DIFF
--- a/library/general/src/modules/PackagesProposal.rb
+++ b/library/general/src/modules/PackagesProposal.rb
@@ -184,7 +184,7 @@ module Yast
       end
 
       log.info("Removing #{log_label(optional)} #{resolvables.inspect} " \
-        "type #{type} for #{unique_id}")
+               "type #{type} for #{unique_id}")
 
       current_resolvables = data_for(unique_id, type, data(optional))
       current_resolvables.reject! { |r| resolvables.include?(r) }

--- a/library/general/src/modules/PackagesProposal.rb
+++ b/library/general/src/modules/PackagesProposal.rb
@@ -124,7 +124,7 @@ module Yast
         resolvables = []
       end
 
-      log.info("Adding #{log_label(optional)} #{resolvables} of type #{type} for #{unique_id}")
+      log.info("Adding #{log_label(optional)} #{resolvables.inspect} of type #{type} for #{unique_id}")
 
       current_resolvables = data_for(unique_id, type, data(optional))
       current_resolvables.concat(resolvables)
@@ -183,7 +183,8 @@ module Yast
         resolvables = []
       end
 
-      log.info("Removing #{log_label(optional)} #{resolvables} type #{type} for #{unique_id}")
+      log.info("Removing #{log_label(optional)} #{resolvables.inspect} " \
+        "type #{type} for #{unique_id}")
 
       current_resolvables = data_for(unique_id, type, data(optional))
       current_resolvables.reject! { |r| resolvables.include?(r) }
@@ -210,7 +211,7 @@ module Yast
       RemoveResolvables(unique_id, type, resolvables, optional: true)
 
       data_for(unique_id, type, @taboos).concat(resolvables)
-      log.info("Adding taboos #{resolvables} of type #{type} for #{unique_id}")
+      log.info("Adding taboos #{resolvables.inspect} of type #{type} for #{unique_id}")
 
       true
     end
@@ -242,7 +243,7 @@ module Yast
       current_taboos = data_for(unique_id, type, @taboos)
       current_taboos.reject! { |r| resolvables.include?(r) }
 
-      log.info("Removing taboos  #{resolvables} type #{type} for #{unique_id}")
+      log.info("Removing taboos  #{resolvables.inspect} type #{type} for #{unique_id}")
 
       true
     end
@@ -253,13 +254,14 @@ module Yast
     # @param type [Symbol] resolvable type
     # @return [Array<String>] List of taboos for the given ID
     def GetTaboos(unique_id, type)
-      return [] unless @taboos.key?(unique_id) && @taboos[unique_id].key?(type)
+      return [] unless @taboos.dig(unique_id, type)
 
       data_for(unique_id, type, @taboos)
     end
 
     # Returns the full list of taboos
     #
+    # @param type [Symbol] resolvable type
     # @return [Array<String>] List of taboos
     def GetAllTaboos(type)
       all_taboos = @taboos.values.each_with_object([]) do |tab, all|
@@ -401,8 +403,6 @@ module Yast
     # @param [String] unique_id
     # @param [Symbol] type
     # @param [Hash] Resolvables lists
-    # @param [Boolean] optional True for optional list, false (the default) for
-    #   the required list
     # @return [Array<String>] the stored resolvables list
     def data_for(unique_id, type, resolvables)
       if !resolvables.key?(unique_id)

--- a/library/general/src/modules/PackagesProposal.rb
+++ b/library/general/src/modules/PackagesProposal.rb
@@ -201,10 +201,11 @@ module Yast
     def AddTaboos(unique_id, resolvables)
       return false if !CheckParams(unique_id, :package)
 
-      log.info("Taboo #{resolvables} for #{unique_id}}")
+      log.info("Taboo #{resolvables.inspect} for #{unique_id}}")
 
-      # Remove the resolvable from the list of resolvables to install
+      # Remove the resolvable from the list of resolvables to install....
       RemoveResolvables(unique_id, :package, resolvables)
+      # ... and from the optional list too
       RemoveResolvables(unique_id, :package, resolvables, optional: true)
 
       @taboos[unique_id] ||= []

--- a/library/general/test/packages_proposal_test.rb
+++ b/library/general/test/packages_proposal_test.rb
@@ -14,6 +14,7 @@ describe Yast::PackagesProposal do
   let(:packages2) { ["kdump"] }
 
   before do
+    subject.ResetAll
     # store both required and optional resolvables
     subject.AddResolvables(proposal_id, :package, packages)
     subject.AddResolvables(proposal_id, :package, packages2, optional: true)

--- a/library/general/test/packages_proposal_test.rb
+++ b/library/general/test/packages_proposal_test.rb
@@ -201,4 +201,47 @@ describe Yast::PackagesProposal do
       expect(subject.IsUniqueID(proposal_id)).to eq(false)
     end
   end
+
+  describe "#AddTaboos" do
+    it "adds taboos for a given unique ID" do
+      expect { subject.AddTaboos("autoyast", ["yast2"]) }
+        .to change { subject.GetTaboos("autoyast") }
+        .from([]).to(["yast2"])
+    end
+  end
+
+  describe "#SetTaboos" do
+    it "sets the taboos for given unique ID" do
+      subject.SetTaboos("autoyast", ["yast2", "chronyd"])
+      expect(subject.GetTaboos("autoyast")).to eq(["yast2", "chronyd"])
+    end
+  end
+
+  describe "#RemoveTaboos" do
+    it "removes taboos for a given unique ID" do
+      subject.AddTaboos("autoyast", ["yast2"])
+
+      expect { subject.RemoveTaboos("autoyast", ["yast2"]) }
+        .to change { subject.GetTaboos("autoyast") }
+        .from(["yast2"]).to([])
+    end
+  end
+
+  describe "#GetTaboos" do
+    it "returns the list of taboos for the given unique ID" do
+      subject.AddTaboos("autoyast", ["yast2"])
+      subject.AddTaboos("bootloader", ["grub2-efi"])
+
+      expect(subject.GetTaboos("autoyast")).to eq(["yast2"])
+    end
+  end
+
+  describe "#GetAllTaboos" do
+    it "returns the list of taboos for the given unique ID" do
+      subject.AddTaboos("autoyast", ["yast2"])
+      subject.AddTaboos("bootloader", ["grub2-efi"])
+
+      expect(subject.GetAllTaboos).to contain_exactly("yast2", "grub2-efi")
+    end
+  end
 end

--- a/library/general/test/packages_proposal_test.rb
+++ b/library/general/test/packages_proposal_test.rb
@@ -204,45 +204,78 @@ describe Yast::PackagesProposal do
   end
 
   describe "#AddTaboos" do
-    it "adds taboos for a given unique ID" do
-      expect { subject.AddTaboos("autoyast", ["yast2"]) }
-        .to change { subject.GetTaboos("autoyast") }
+    it "adds package taboos for a given unique ID" do
+      expect { subject.AddTaboos("autoyast", :package, ["yast2"]) }
+        .to change { subject.GetTaboos("autoyast", :package) }
         .from([]).to(["yast2"])
+    end
+
+    it "adds pattern taboos for a given unique ID" do
+      expect { subject.AddTaboos("autoyast", :pattern, ["x11"]) }
+        .to change { subject.GetTaboos("autoyast", :pattern) }
+        .from([]).to(["x11"])
     end
   end
 
   describe "#SetTaboos" do
-    it "sets the taboos for given unique ID" do
-      subject.SetTaboos("autoyast", ["yast2", "chronyd"])
-      expect(subject.GetTaboos("autoyast")).to eq(["yast2", "chronyd"])
+    it "sets package taboos for given unique ID" do
+      subject.SetTaboos("autoyast", :package, ["yast2", "chronyd"])
+      expect(subject.GetTaboos("autoyast", :package)).to eq(["yast2", "chronyd"])
+    end
+
+    it "sets pattern taboos for given unique ID" do
+      subject.SetTaboos("autoyast", :pattern, ["x11"])
+      expect(subject.GetTaboos("autoyast", :pattern)).to eq(["x11"])
     end
   end
 
   describe "#RemoveTaboos" do
-    it "removes taboos for a given unique ID" do
-      subject.AddTaboos("autoyast", ["yast2"])
+    it "removes package taboos for a given unique ID" do
+      subject.AddTaboos("autoyast", :package, ["yast2"])
 
-      expect { subject.RemoveTaboos("autoyast", ["yast2"]) }
-        .to change { subject.GetTaboos("autoyast") }
+      expect { subject.RemoveTaboos("autoyast", :package, ["yast2"]) }
+        .to change { subject.GetTaboos("autoyast", :package) }
         .from(["yast2"]).to([])
+    end
+
+    it "removes package taboos for a given unique ID" do
+      subject.AddTaboos("autoyast", :pattern, ["x11"])
+
+      expect { subject.RemoveTaboos("autoyast", :pattern, ["x11"]) }
+        .to change { subject.GetTaboos("autoyast", :pattern) }
+        .from(["x11"]).to([])
     end
   end
 
   describe "#GetTaboos" do
-    it "returns the list of taboos for the given unique ID" do
-      subject.AddTaboos("autoyast", ["yast2"])
-      subject.AddTaboos("bootloader", ["grub2-efi"])
+    it "returns the list of package taboos for the given unique ID and type" do
+      subject.AddTaboos("autoyast", :package, ["yast2"])
+      subject.AddTaboos("bootloader", :package, ["grub2-efi"])
 
-      expect(subject.GetTaboos("autoyast")).to eq(["yast2"])
+      expect(subject.GetTaboos("autoyast", :package)).to eq(["yast2"])
+    end
+
+    it "returns the list of pattern taboos for the given unique ID and type" do
+      subject.AddTaboos("autoyast", :pattern, ["x11"])
+      subject.AddTaboos("security", :pattern, ["apparmor"])
+
+      expect(subject.GetTaboos("autoyast", :pattern)).to eq(["x11"])
     end
   end
 
   describe "#GetAllTaboos" do
-    it "returns the list of taboos for the given unique ID" do
-      subject.AddTaboos("autoyast", ["yast2"])
-      subject.AddTaboos("bootloader", ["grub2-efi"])
+    it "returns the list of package taboos for the given unique ID" do
+      subject.AddTaboos("autoyast", :package, ["yast2"])
+      subject.AddTaboos("bootloader", :package, ["grub2-efi"])
 
-      expect(subject.GetAllTaboos).to contain_exactly("yast2", "grub2-efi")
+      expect(subject.GetAllTaboos(:package)).to contain_exactly("yast2", "grub2-efi")
+    end
+
+    it "returns the list of pattern taboos for the given unique ID" do
+      subject.AddTaboos("autoyast", :pattern, ["x11"])
+      subject.AddTaboos("security", :pattern, ["apparmor"])
+
+      expect(subject.GetAllTaboos(:pattern)).to contain_exactly("x11", "apparmor")
     end
   end
 end

--- a/library/packages/src/include/packages/common.rb
+++ b/library/packages/src/include/packages/common.rb
@@ -42,60 +42,6 @@ module Yast
       Yast.import "CommandLine"
     end
 
-    # Are all of these packages available?
-    # @param [Array<String>] packages list of packages
-    # @return [Boolean] true if yes (nil = an error occurred)
-    def AvailableAll(packages)
-      packages = deep_copy(packages)
-      error = false
-
-      which = Builtins.find(packages) do |p|
-        avail = Available(p)
-        error = true if avail.nil?
-        !avail
-      end
-
-      return nil if error
-
-      which.nil?
-    end
-
-    # Is any of these packages available?
-    # @param [Array<String>] packages list of packages
-    # @return [Boolean] true if yes (nil = an error occurred)
-    def AvailableAny(packages)
-      packages = deep_copy(packages)
-      error = false
-
-      which = Builtins.find(packages) do |p|
-        avail = Available(p)
-        error = true if avail.nil?
-        avail
-      end
-
-      return nil if error
-
-      !which.nil?
-    end
-
-    # Are all of these packages installed?
-    # @param [Array<String>] packages list of packages
-    # @return [Boolean] true if yes
-    def InstalledAll(packages)
-      packages = deep_copy(packages)
-      which = Builtins.find(packages) { |p| !Installed(p) }
-      which.nil?
-    end
-
-    # Is any of these packages installed?
-    # @param [Array<String>] packages list of packages
-    # @return [Boolean] true if yes
-    def InstalledAny(packages)
-      packages = deep_copy(packages)
-      which = Builtins.find(packages) { |p| Installed(p) }
-      !which.nil?
-    end
-
     def AskPackages(packs, install)
       packs = deep_copy(packs)
       pkgs = Builtins.mergestring(packs, ", ")

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -40,6 +40,7 @@ Yast.import "PackageSystem"
 module Yast
   class PackageClass < Module
     extend Forwardable
+    include Yast::Logger
 
     def_delegators :backend, :Installed, :Available, :PackageInstalled,
       :PackageAvailable, :DoInstallAndRemove, :InstallKernel
@@ -89,12 +90,6 @@ module Yast
     #   Removes the given packages
     #   @param packages [Array<String>] Name of the packages to remove
     #   @return [Boolean] true if packages were successfully removed
-
-    # @!method DoInstallAndRemove(toinstall, toremove)
-    #   Install and remove packages in one go
-    #   @param toinstall [Array<String>] Name of the packages to install
-    #   @param toremove [Array<String>] Name of the packages to remove
-    #   @return [Boolean] true on success
 
     # @!method InstallKernel(kernel_modules)
     #   Installs the given kernel modules
@@ -171,6 +166,23 @@ module Yast
 
     def DoRemove(packages)
       DoInstallAndRemove([], packages)
+    end
+
+    # Install and remove packages in one go
+    #
+    # @param toinstall [Array<String>] Name of the packages to install
+    # @param toremove [Array<String>] Name of the packages to remove
+    # @return [Boolean] true on success
+    def DoInstallAndRemove(toinstall, toremove)
+      ret = backend.DoInstallAndRemove(toinstall, toremove)
+      return false unless ret
+
+      if !InstalledAll(toinstall)
+        log.error("Required packages have not been installed")
+        return false
+      end
+
+      true
     end
 
     def reset

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -338,7 +338,6 @@ module Yast
       packages = deep_copy(packages)
       PackageDialog(packages, true, message)
     end
-    # FIXME
 
     # Remove a package with a custom text message
     # @param [String] package  package to be removed
@@ -357,20 +356,35 @@ module Yast
       PackageDialog(packages, false, message)
     end
 
+    # Installs a package
+    #
+    # @param package [String] package to be installed
+    # @return [Boolean] true on success
     def Install(package)
       InstallMsg(package, nil)
     end
 
+    # Installs a list of packages
+    #
+    # @param packages [Array<String>] list of packages to be installed
+    # @return [Boolean] true on success
     def InstallAll(packages)
       packages = deep_copy(packages)
       InstallAllMsg(packages, nil)
     end
-    # FIXME
 
+    # Removes a package
+    #
+    # @param package [String] package to be removed
+    # @return [Boolean] true on success
     def Remove(package)
       RemoveMsg(package, nil)
     end
 
+    # Removes a list of packages
+    #
+    # @param packages [Array<String>] list of packages to be removed
+    # @return [Boolean] true on success
     def RemoveAll(packages)
       packages = deep_copy(packages)
       RemoveAllMsg(packages, nil)

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -41,8 +41,8 @@ module Yast
   class PackageClass < Module
     extend Forwardable
 
-    def_delegators :backend, :Installed, :Available, :DoInstall, :DoRemove, :DoInstallAndRemove,
-      :InstallKernel, :PackageInstalled, :PackageAvailable
+    def_delegators :backend, :Installed, :Available, :PackageInstalled,
+      :PackageAvailable, :DoInstallAndRemove, :InstallKernel
 
     # @!method Installed(package)
     #   Determines whether the package is provided or not
@@ -104,6 +104,8 @@ module Yast
       textdomain "base"
 
       @last_op_canceled = false
+      @installed_packages = []
+      @removed_packages = []
       Yast.include self, "packages/common.rb"
     end
 
@@ -161,6 +163,19 @@ module Yast
           )
         )
       end
+    end
+
+    def DoInstall(packages)
+      DoInstallAndRemove(packages, [])
+    end
+
+    def DoRemove(packages)
+      DoInstallAndRemove([], packages)
+    end
+
+    def reset
+      @installed_packages.clear
+      @removed_packages.clear
     end
 
     publish function: :Available, type: "boolean (string)"

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -178,6 +178,60 @@ module Yast
       @removed_packages.clear
     end
 
+    # Are all of these packages available?
+    # @param [Array<String>] packages list of packages
+    # @return [Boolean] true if yes (nil = an error occurred)
+    def AvailableAll(packages)
+      packages = deep_copy(packages)
+      error = false
+
+      which = Builtins.find(packages) do |p|
+        avail = Available(p)
+        error = true if avail.nil?
+        !avail
+      end
+
+      return nil if error
+
+      which.nil?
+    end
+
+    # Is any of these packages available?
+    # @param [Array<String>] packages list of packages
+    # @return [Boolean] true if yes (nil = an error occurred)
+    def AvailableAny(packages)
+      packages = deep_copy(packages)
+      error = false
+
+      which = Builtins.find(packages) do |p|
+        avail = Available(p)
+        error = true if avail.nil?
+        avail
+      end
+
+      return nil if error
+
+      !which.nil?
+    end
+
+    # Are all of these packages installed?
+    # @param [Array<String>] packages list of packages
+    # @return [Boolean] true if yes
+    def InstalledAll(packages)
+      packages = deep_copy(packages)
+      which = Builtins.find(packages) { |p| !Installed(p) }
+      which.nil?
+    end
+
+    # Is any of these packages installed?
+    # @param [Array<String>] packages list of packages
+    # @return [Boolean] true if yes
+    def InstalledAny(packages)
+      packages = deep_copy(packages)
+      which = Builtins.find(packages) { |p| Installed(p) }
+      !which.nil?
+    end
+
     publish function: :Available, type: "boolean (string)"
     publish function: :Installed, type: "boolean (string)"
     publish function: :DoInstall, type: "boolean (list <string>)"

--- a/library/packages/src/modules/PackageAI.rb
+++ b/library/packages/src/modules/PackageAI.rb
@@ -35,12 +35,19 @@ module Yast
   class PackageAIClass < Module
     def main
       textdomain "base"
-
-      @last_op_canceled = false
-
-      Yast.include self, "packages/common.rb"
     end
 
+    # Install and remove packages in one go
+    #
+    # @note In AutoYaST, packages are added or removed from the
+    #       {Yast::PackagesProposalClass packages proposal} instead of actually
+    #       installing or removing them from the system.
+    #
+    # @param toinstall [Array<String>] Name of the packages to install
+    # @param toremove [Array<String>] Name of the packages to remove
+    # @return [Boolean] true on success
+    #
+    # @see Yast::PackageClass#DoInstallAndRemove
     def DoInstallAndRemove(toinst, torem)
       if !toinst.empty?
         Yast::PackagesProposal.AddResolvables("autoyast", :package, toinst)
@@ -55,54 +62,68 @@ module Yast
       true
     end
 
+    # Determines whether the package is installed or not
+    #
+    # @note In AutoYaST, this method always returns true.
+    #
+    # @param package [String] Package name
+    # @return [Boolean] true if the package exists; false otherwise
+    # @see Yast::PackageClass#Available
     def Available(_package)
       true
     end
 
+    # Determines whether the package is installed or not
+    #
+    # @note In AutoYaST, this method just checks whether the package is included
+    #       in the {Yast::PackagesProposalClass packages proposal}.
+    #
+    # @param package [String] Package name
+    # @return [Boolean] true if the package exists; false otherwise
+    #
+    # @see Yast::PackageClass#Installed
     def Installed(package)
       PackagesProposal.GetResolvables("autoyast").include?(package)
     end
 
-    # Is a package installed? Checks only the package name in contrast to Installed() function.
-    # @return true if yes
+    # Determines whether the package is installed or not
+    #
+    # @note In AutoYaST this method is equivalent to #Installed
+    #
+    # @param package [String] Package name
+    # @return [Boolean] true if the package exists; false otherwise
+    #
+    # @see Yast::PackageClass#PackageInstalled
     def PackageInstalled(package)
       Installed(package)
     end
 
-    # Is a package available? Checks only package name, not list of provides.
-    # @return true if yes
+    # Determines whether the package  with the given name is available
+    #
+    # @note In AutoYaST this method is equivalent to #Available
+    #
+    # @param package [String] Package name
+    # @return [Boolean] true if the package is available; false otherwise
+    # @see Yast::PackageClass#Available
     def PackageAvailable(package)
       Available(package)
     end
 
+    # Installs the given kernel modules
+    #
+    # @note The kernel packages are handled by AutoYaST on its own, so this
+    #       method just does nothing and always returns true.
+    #
+    # @param _kernel_modules [Array<String>] Names of the kernel modules to install
+    # @return [Boolean] Always returns true
+    # @see Yast::PackageClass#InstallKernel
     def InstallKernel(_kernel_modules)
-      # the kernel packages are handled by autoyast on its own
       true
     end
 
-    publish variable: :toinstall, type: "list <string>"
-    publish variable: :toremove, type: "list <string>"
     publish function: :Available, type: "boolean (string)"
     publish function: :Installed, type: "boolean (string)"
-    publish function: :DoInstall, type: "boolean (list <string>)"
-    publish function: :DoRemove, type: "boolean (list <string>)"
     publish function: :DoInstallAndRemove, type: "boolean (list <string>, list <string>)"
-    publish function: :AvailableAll, type: "boolean (list <string>)"
-    publish function: :AvailableAny, type: "boolean (list <string>)"
-    publish function: :InstalledAll, type: "boolean (list <string>)"
-    publish function: :InstalledAny, type: "boolean (list <string>)"
-    publish function: :InstallMsg, type: "boolean (string, string)"
-    publish function: :InstallAllMsg, type: "boolean (list <string>, string)"
-    publish function: :InstallAnyMsg, type: "boolean (list <string>, string)"
-    publish function: :RemoveMsg, type: "boolean (string, string)"
-    publish function: :RemoveAllMsg, type: "boolean (list <string>, string)"
-    publish function: :Install, type: "boolean (string)"
-    publish function: :InstallAll, type: "boolean (list <string>)"
-    publish function: :InstallAny, type: "boolean (list <string>)"
-    publish function: :Remove, type: "boolean (string)"
-    publish function: :RemoveAll, type: "boolean (list <string>)"
-    publish function: :LastOperationCanceled, type: "boolean ()"
-    publish variable: :modified, type: "boolean"
     publish function: :PackageInstalled, type: "boolean (string)"
     publish function: :PackageAvailable, type: "boolean (string)"
     publish function: :InstallKernel, type: "boolean (list <string>)"

--- a/library/packages/src/modules/PackageAI.rb
+++ b/library/packages/src/modules/PackageAI.rb
@@ -51,11 +51,11 @@ module Yast
     def DoInstallAndRemove(toinst, torem)
       if !toinst.empty?
         Yast::PackagesProposal.AddResolvables("autoyast", :package, toinst)
-        Yast::PackagesProposal.RemoveTaboos("autoyast", toinst) # FIXME: should be done by PackagesProposal
+        Yast::PackagesProposal.RemoveTaboos("autoyast", :package, toinst)
       end
 
       if !torem.empty?
-        Yast::PackagesProposal.AddTaboos("autoyast", torem)
+        Yast::PackagesProposal.AddTaboos("autoyast", :package, torem)
         Yast::PackagesProposal.RemoveResolvables("autoyast", :package, torem)
       end
 

--- a/library/packages/src/modules/PackageSystem.rb
+++ b/library/packages/src/modules/PackageSystem.rb
@@ -268,12 +268,6 @@ module Yast
         SCR.RegisterNewAgents
       end
 
-      # check if the required packages have been installed
-      if !InstalledAll(toinstall)
-        Builtins.y2error("Required packages have not been installed")
-        return false
-      end
-
       true
     end
 

--- a/library/packages/src/modules/PackageSystem.rb
+++ b/library/packages/src/modules/PackageSystem.rb
@@ -386,11 +386,9 @@ module Yast
     # @return [Boolean] true if installation succeeded or packages were installed,
     # false otherwise
     def CheckAndInstallPackages(packages)
-      packages = deep_copy(packages)
-      return true if Mode.config
-      return true if InstalledAll(packages)
-
-      InstallAll(packages)
+      log.warn "DEPRECATED: call Package.CheckAndInstallPackages instead"
+      Yast.import "Package"
+      Package.CheckAndInstallPackages(packages)
     end
 
     # Check if packages are installed
@@ -403,37 +401,9 @@ module Yast
     # @return [Boolean] true if installation succeeded, packages were installed
     # before or user decided to continue, false otherwise
     def CheckAndInstallPackagesInteractive(packages)
-      packages = deep_copy(packages)
-      success = CheckAndInstallPackages(packages)
-      return true if success
-
-      if !LastOperationCanceled()
-        if Mode.commandline
-          # error report
-          Report.Error(_("Installing required packages failed."))
-        else
-          Popup.ContinueCancel(
-            # continue/cancel popup
-            _(
-              "Installing required packages failed. If you continue\n" \
-              "without installing required packages,\n" \
-              "YaST may not work properly.\n"
-            )
-          )
-        end
-      elsif Mode.commandline
-        Report.Error(
-          # error report
-          _("Cannot continue without installing required packages.")
-        )
-      else
-        Popup.ContinueCancel(
-          # continue/cancel popup
-          _(
-            "If you continue without installing required \npackages, YaST may not work properly.\n"
-          )
-        )
-      end
+      log.warn "DEPRECATED: call Package.CheckAndInstallPackagesInteractive instead"
+      Yast.import "Package"
+      Package.CheckAndInstallPackagesInteractive(packages)
     end
 
     def InstallKernel(kernel_modules)

--- a/library/packages/test/package_ai_test.rb
+++ b/library/packages/test/package_ai_test.rb
@@ -33,7 +33,7 @@ describe Yast::PackageAI do
       subject.DoInstallAndRemove(["yast2"], ["ntpd"])
 
       expect(Yast::PackagesProposal.GetResolvables("autoyast", :package)).to eq(["yast2"])
-      expect(Yast::PackagesProposal.GetTaboos("autoyast")).to eq(["ntpd"])
+      expect(Yast::PackagesProposal.GetTaboos("autoyast", :package)).to eq(["ntpd"])
     end
   end
 end

--- a/library/packages/test/package_ai_test.rb
+++ b/library/packages/test/package_ai_test.rb
@@ -1,0 +1,39 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "PackageAI"
+
+describe Yast::PackageAI do
+  subject { Yast::PackageAI }
+
+  before do
+    Yast::PackagesProposal.ResetAll
+  end
+
+  describe "#DoInstallAndRemove" do
+    it "updates the packages proposal according to the given lists" do
+      subject.DoInstallAndRemove(["yast2"], ["ntpd"])
+
+      expect(Yast::PackagesProposal.GetResolvables("autoyast", :package)).to eq(["yast2"])
+      expect(Yast::PackagesProposal.GetTaboos("autoyast")).to eq(["ntpd"])
+    end
+  end
+end

--- a/library/packages/test/package_system_test.rb
+++ b/library/packages/test/package_system_test.rb
@@ -76,94 +76,18 @@ describe "Yast::PackageSystem" do
   end
 
   describe "#CheckAndInstallPackages" do
-    let(:installed) { false }
-
-    before do
-      allow(subject).to receive(:InstalledAll).and_return(installed)
-    end
-
-    context "when given packages are not installed" do
-      let(:installed) { false }
-
-      it "install the packages" do
-        expect(subject).to receive(:InstallAll).with(["pkg1"]).and_return(true)
-        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
-      end
-    end
-
-    context "when given packages are installed" do
-      let(:installed) { true }
-
-      it "does not install the packages again" do
-        expect(subject).to_not receive(:InstallAll)
-        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
-      end
-    end
-
-    context "when running in config mode" do
-      before do
-        allow(Yast::Mode).to receive(:config).and_return(true)
-      end
-
-      it "does not install the packages" do
-        expect(subject).to_not receive(:InstallAll)
-        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
-      end
+    it "delegates to Yast::Package" do
+      expect(Yast::Package).to receive(:CheckAndInstallPackages)
+        .with(["pkg1"]).and_return(true)
+      expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
     end
   end
 
   describe "#CheckAndInstallPackagesInteractive" do
-    let(:canceled) { false }
-
-    before do
-      allow(subject).to receive(:LastOperationCanceled).and_return(canceled)
-    end
-
-    it "installs the given package" do
-      expect(subject).to receive(:CheckAndInstallPackages).with(["pkg1"]).and_return(true)
+    it "delegates to Yast::Package" do
+      expect(Yast::Package).to receive(:CheckAndInstallPackagesInteractive)
+        .with(["pkg1"]).and_return(true)
       expect(subject.CheckAndInstallPackagesInteractive(["pkg1"])).to eq(true)
-    end
-
-    context "when the packages cannot be installed" do
-      before do
-        allow(subject).to receive(:CheckAndInstallPackages).and_return(false)
-      end
-
-      context "when the last operation was canceled" do
-        let(:canceled) { true }
-
-        it "reports the error when running on commandline" do
-          allow(Yast::Mode).to receive(:commandline).and_return(true)
-
-          expect(Yast::Report).to receive(:Error)
-          subject.CheckAndInstallPackagesInteractive(["pkg1"])
-        end
-
-        it "reports the error when not running on commandline" do
-          allow(Yast::Mode).to receive(:commandline).and_return(false)
-
-          expect(Yast::Popup).to receive(:ContinueCancel)
-          subject.CheckAndInstallPackagesInteractive(["pkg1"])
-        end
-      end
-
-      context "when the last operation was not canceled" do
-        let(:canceled) { false }
-
-        it "reports the error when running on commandline" do
-          allow(Yast::Mode).to receive(:commandline).and_return(true)
-
-          expect(Yast::Report).to receive(:Error)
-          subject.CheckAndInstallPackagesInteractive(["pkg1"])
-        end
-
-        it "reports the error when not running on commandline" do
-          allow(Yast::Mode).to receive(:commandline).and_return(false)
-
-          expect(Yast::Popup).to receive(:ContinueCancel)
-          subject.CheckAndInstallPackagesInteractive(["pkg1"])
-        end
-      end
     end
   end
 end

--- a/library/packages/test/package_system_test.rb
+++ b/library/packages/test/package_system_test.rb
@@ -74,4 +74,96 @@ describe "Yast::PackageSystem" do
       end
     end
   end
+
+  describe "#CheckAndInstallPackages" do
+    let(:installed) { false }
+
+    before do
+      allow(subject).to receive(:InstalledAll).and_return(installed)
+    end
+
+    context "when given packages are not installed" do
+      let(:installed) { false }
+
+      it "install the packages" do
+        expect(subject).to receive(:InstallAll).with(["pkg1"]).and_return(true)
+        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
+      end
+    end
+
+    context "when given packages are installed" do
+      let(:installed) { true }
+
+      it "does not install the packages again" do
+        expect(subject).to_not receive(:InstallAll)
+        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
+      end
+    end
+
+    context "when running in config mode" do
+      before do
+        allow(Yast::Mode).to receive(:config).and_return(true)
+      end
+
+      it "does not install the packages" do
+        expect(subject).to_not receive(:InstallAll)
+        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
+      end
+    end
+  end
+
+  describe "#CheckAndInstallPackagesInteractive" do
+    let(:canceled) { false }
+
+    before do
+      allow(subject).to receive(:LastOperationCanceled).and_return(canceled)
+    end
+
+    it "installs the given package" do
+      expect(subject).to receive(:CheckAndInstallPackages).with(["pkg1"]).and_return(true)
+      expect(subject.CheckAndInstallPackagesInteractive(["pkg1"])).to eq(true)
+    end
+
+    context "when the packages cannot be installed" do
+      before do
+        allow(subject).to receive(:CheckAndInstallPackages).and_return(false)
+      end
+
+      context "when the last operation was canceled" do
+        let(:canceled) { true }
+
+        it "reports the error when running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(true)
+
+          expect(Yast::Report).to receive(:Error)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+
+        it "reports the error when not running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(false)
+
+          expect(Yast::Popup).to receive(:ContinueCancel)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+      end
+
+      context "when the last operation was not canceled" do
+        let(:canceled) { false }
+
+        it "reports the error when running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(true)
+
+          expect(Yast::Report).to receive(:Error)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+
+        it "reports the error when not running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(false)
+
+          expect(Yast::Popup).to receive(:ContinueCancel)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+      end
+    end
+  end
 end

--- a/library/packages/test/package_system_test.rb
+++ b/library/packages/test/package_system_test.rb
@@ -4,6 +4,7 @@ require_relative "test_helper"
 
 Yast.import "PackageSystem"
 Yast.import "PackagesUI"
+Yast.import "Package"
 
 describe "Yast::PackageSystem" do
   subject(:system) { Yast::PackageSystem }
@@ -46,7 +47,6 @@ describe "Yast::PackageSystem" do
       allow(system).to receive(:SelectPackages).and_return(true)
       allow(Yast::Pkg).to receive(:IsAnyResolvable).with(:package, :to_install).and_return(true)
       allow(Yast::Pkg).to receive(:PkgCommit).with(0).and_return(result)
-      allow(system).to receive(:InstalledAll).and_return(true)
     end
 
     context "when package system is locked" do

--- a/library/packages/test/package_test.rb
+++ b/library/packages/test/package_test.rb
@@ -202,4 +202,92 @@ describe Yast::Package do
       subject.InstallKernel([])
     end
   end
+
+  describe "#AvailableAll" do
+    let(:available) { ["yast2", "autoyast2"] }
+
+    before do
+      allow(subject).to receive(:Available) do |pkg|
+        available.include?(pkg)
+      end
+    end
+
+    context "when the given packages are available" do
+      it "returns true" do
+        expect(subject.AvailableAll(["yast2", "autoyast2"])).to eq(true)
+      end
+    end
+
+    context "when any of the given packages is not available" do
+      it "returns false" do
+        expect(subject.AvailableAll(["yast2", "unknown"])).to eq(false)
+      end
+    end
+  end
+
+  describe "#AvailableAny" do
+    let(:available) { ["yast2", "autoyast2"] }
+
+    before do
+      allow(subject).to receive(:Available) do |pkg|
+        available.include?(pkg)
+      end
+    end
+
+    context "when any of the given packages is available" do
+      it "returns true" do
+        expect(subject.AvailableAny(["yast2", "unknown"])).to eq(true)
+      end
+    end
+
+    context "when none of the given packages is available" do
+      it "returns false" do
+        expect(subject.AvailableAny(["unknown"])).to eq(false)
+      end
+    end
+  end
+
+  describe "#InstalledAll" do
+    let(:installed) { ["yast2", "autoyast2"] }
+
+    before do
+      allow(subject).to receive(:Installed) do |pkg|
+        installed.include?(pkg)
+      end
+    end
+
+    context "when the given packages are installed" do
+      it "returns true" do
+        expect(subject.InstalledAll(["yast2", "autoyast2"])).to eq(true)
+      end
+    end
+
+    context "when any of the given packages is not installed" do
+      it "returns false" do
+        expect(subject.InstalledAll(["yast2", "unknown"])).to eq(false)
+      end
+    end
+  end
+
+  describe "#InstalledAny" do
+    let(:installed) { ["yast2", "autoyast2"] }
+
+    before do
+      allow(subject).to receive(:Installed) do |pkg|
+        installed.include?(pkg)
+      end
+    end
+
+    context "when any of the given packages is installed" do
+      it "returns true" do
+        expect(subject.InstalledAny(["yast2", "unknown"])).to eq(true)
+      end
+    end
+
+    context "when none of the given packages is installed" do
+      it "returns false" do
+        expect(subject.InstalledAny(["unknown"])).to eq(false)
+      end
+    end
+  end
 end

--- a/library/packages/test/package_test.rb
+++ b/library/packages/test/package_test.rb
@@ -1,0 +1,119 @@
+# Copyright (c) [2021] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "test_helper"
+
+Yast.import "Package"
+Yast.import "Mode"
+
+describe Yast::Package do
+  subject { Yast::Package }
+
+  describe "#CheckAndInstallPackages" do
+    let(:installed) { false }
+
+    before do
+      allow(subject).to receive(:InstalledAll).and_return(installed)
+    end
+
+    context "when given packages are not installed" do
+      let(:installed) { false }
+
+      it "install the packages" do
+        expect(subject).to receive(:InstallAll).with(["pkg1"]).and_return(true)
+        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
+      end
+    end
+
+    context "when given packages are installed" do
+      let(:installed) { true }
+
+      it "does not install the packages again" do
+        expect(subject).to_not receive(:InstallAll)
+        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
+      end
+    end
+
+    context "when running in config mode" do
+      before do
+        allow(Yast::Mode).to receive(:config).and_return(true)
+      end
+
+      it "does not install the packages" do
+        expect(subject).to_not receive(:InstallAll)
+        expect(subject.CheckAndInstallPackages(["pkg1"])).to eq(true)
+      end
+    end
+  end
+
+  describe "#CheckAndInstallPackagesInteractive" do
+    let(:canceled) { false }
+
+    before do
+      allow(subject).to receive(:LastOperationCanceled).and_return(canceled)
+    end
+
+    it "installs the given package" do
+      expect(subject).to receive(:CheckAndInstallPackages).with(["pkg1"]).and_return(true)
+      expect(subject.CheckAndInstallPackagesInteractive(["pkg1"])).to eq(true)
+    end
+
+    context "when the packages cannot be installed" do
+      before do
+        allow(subject).to receive(:CheckAndInstallPackages).and_return(false)
+      end
+
+      context "when the last operation was canceled" do
+        let(:canceled) { true }
+
+        it "reports the error when running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(true)
+
+          expect(Yast::Report).to receive(:Error)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+
+        it "reports the error when not running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(false)
+
+          expect(Yast::Popup).to receive(:ContinueCancel)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+      end
+
+      context "when the last operation was not canceled" do
+        let(:canceled) { false }
+
+        it "reports the error when running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(true)
+
+          expect(Yast::Report).to receive(:Error)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+
+        it "reports the error when not running on commandline" do
+          allow(Yast::Mode).to receive(:commandline).and_return(false)
+
+          expect(Yast::Popup).to receive(:ContinueCancel)
+          subject.CheckAndInstallPackagesInteractive(["pkg1"])
+        end
+      end
+    end
+  end
+end

--- a/library/packages/test/package_test.rb
+++ b/library/packages/test/package_test.rb
@@ -117,6 +117,20 @@ describe Yast::Package do
     end
   end
 
+  describe "#DoInstall" do
+    it "installs the given packages" do
+      expect(subject).to receive(:DoInstallAndRemove).with(["yast2"], [])
+      subject.DoInstall(["yast2"])
+    end
+  end
+
+  describe "#DoRemove" do
+    it "removes the given packages" do
+      expect(subject).to receive(:DoInstallAndRemove).with([], ["ntpd"])
+      subject.DoRemove(["ntpd"])
+    end
+  end
+
   context "when not running in config mode" do
     before do
       allow(Yast::Mode).to receive(:config).and_return(false)
@@ -140,16 +154,6 @@ describe Yast::Package do
     it "delegates #PackageAvailable to PackageSystem" do
       expect(Yast::PackageSystem).to receive(:PackageAvailable)
       subject.PackageAvailable("yast2")
-    end
-
-    it "delegates #DoInstall to PackageSystem" do
-      expect(Yast::PackageSystem).to receive(:DoInstall)
-      subject.DoInstall(["yast2"])
-    end
-
-    it "delegates #DoRemove to PackageSystem" do
-      expect(Yast::PackageSystem).to receive(:DoRemove)
-      subject.DoRemove("yast2")
     end
 
     it "delegates #DoInstallAndRemove to PackageSystem" do
@@ -186,16 +190,6 @@ describe Yast::Package do
     it "delegates #PackageAvailable to PackageAI" do
       expect(Yast::PackageAI).to receive(:PackageAvailable)
       subject.PackageAvailable("yast2")
-    end
-
-    it "delegates #DoInstall to PackageAI" do
-      expect(Yast::PackageAI).to receive(:DoInstall)
-      subject.DoInstall(["yast2"])
-    end
-
-    it "delegates #DoRemove to PackageAI" do
-      expect(Yast::PackageAI).to receive(:DoRemove)
-      subject.DoRemove("yast2")
     end
 
     it "delegates #DoInstallAndRemove to PackageAI" do

--- a/library/packages/test/package_test.rb
+++ b/library/packages/test/package_test.rb
@@ -116,4 +116,96 @@ describe Yast::Package do
       end
     end
   end
+
+  context "when not running in config mode" do
+    before do
+      allow(Yast::Mode).to receive(:config).and_return(false)
+    end
+
+    it "delegates #Installed to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:Installed)
+      subject.Installed("yast2")
+    end
+
+    it "delegates #PackageInstalled to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:PackageInstalled)
+      subject.PackageInstalled("yast2")
+    end
+
+    it "delegates #Available to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:Available)
+      subject.Available("yast2")
+    end
+
+    it "delegates #PackageAvailable to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:PackageAvailable)
+      subject.PackageAvailable("yast2")
+    end
+
+    it "delegates #DoInstall to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:DoInstall)
+      subject.DoInstall(["yast2"])
+    end
+
+    it "delegates #DoRemove to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:DoRemove)
+      subject.DoRemove("yast2")
+    end
+
+    it "delegates #DoInstallAndRemove to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:DoInstallAndRemove)
+      subject.DoInstallAndRemove(["yast2"], ["ntpd"])
+    end
+
+    it "delegates #InstallKernel to PackageSystem" do
+      expect(Yast::PackageSystem).to receive(:InstallKernel)
+      subject.InstallKernel([])
+    end
+  end
+
+  context "when running in config mode" do
+    before do
+      allow(Yast::Mode).to receive(:config).and_return(true)
+    end
+
+    it "delegates #Installed to PackageAI" do
+      expect(Yast::PackageAI).to receive(:Installed)
+      subject.Installed("yast2")
+    end
+
+    it "delegates #PackageInstalled to PackageAI" do
+      expect(Yast::PackageAI).to receive(:PackageInstalled)
+      subject.PackageInstalled("yast2")
+    end
+
+    it "delegates #Available to PackageAI" do
+      expect(Yast::PackageAI).to receive(:Available)
+      subject.Available("yast2")
+    end
+
+    it "delegates #PackageAvailable to PackageAI" do
+      expect(Yast::PackageAI).to receive(:PackageAvailable)
+      subject.PackageAvailable("yast2")
+    end
+
+    it "delegates #DoInstall to PackageAI" do
+      expect(Yast::PackageAI).to receive(:DoInstall)
+      subject.DoInstall(["yast2"])
+    end
+
+    it "delegates #DoRemove to PackageAI" do
+      expect(Yast::PackageAI).to receive(:DoRemove)
+      subject.DoRemove("yast2")
+    end
+
+    it "delegates #DoInstallAndRemove to PackageAI" do
+      expect(Yast::PackageAI).to receive(:DoInstallAndRemove)
+      subject.DoInstallAndRemove(["yast2"], ["ntpd"])
+    end
+
+    it "delegates #InstallKernel to PackageAI" do
+      expect(Yast::PackageAI).to receive(:InstallKernel)
+      subject.InstallKernel([])
+    end
+  end
 end

--- a/library/packages/test/package_test.rb
+++ b/library/packages/test/package_test.rb
@@ -290,4 +290,46 @@ describe Yast::Package do
       end
     end
   end
+
+  describe "#DoInstallAndRemove" do
+    let(:backend) do
+      double("backend", DoInstallAndRemove: result)
+    end
+
+    let(:result) { true }
+    let(:toinstall) { ["yast2"] }
+    let(:toremove) { ["dummy"] }
+
+    before do
+      allow(subject).to receive(:backend).and_return(backend)
+      allow(subject).to receive(:InstalledAll).with(toinstall).and_return(true)
+    end
+
+    it "delegates in the backend" do
+      expect(backend).to receive(:DoInstallAndRemove).with(toinstall, toremove)
+      subject.DoInstallAndRemove(toinstall, toremove)
+    end
+
+    it "returns true on success" do
+      expect(subject.DoInstallAndRemove(toinstall, toremove)).to eq(true)
+    end
+
+    context "when the installation fails" do
+      let(:result) { false }
+
+      it "returns false" do
+        expect(subject.DoInstallAndRemove(toinstall, toremove)).to eq(false)
+      end
+    end
+
+    context "when not all packages are installed" do
+      before do
+        allow(subject).to receive(:InstalledAll).with(toinstall).and_return(false)
+      end
+
+      it "returns false" do
+        expect(subject.DoInstallAndRemove(toinstall, toremove)).to eq(false)
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Wed Jan 19 11:46:14 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Unify Package, PackageSystem and PackageAI. Now the Package
+  module is the entry point. PackageSystem and PackageAI implement
+  specific logic and they should not be referenced from outside
+  (bsc#1194886).
+- 4.3.37
+
+-------------------------------------------------------------------
 Fri Jan 14 13:56:49 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adapted Report.yesno_popup to Ruby 3 (bsc#1193192)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.36
+Version:        4.4.37
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
This PR is part of the plan to unify `Package.rb`, `PackageSystem.rb`, and `PackageIA.rb` and, by the way, get rid of `PackagesCommonInclude`. See https://trello.com/c/GnnQQcDa for further details.

Once we merge this code, we should avoid calling `PackageSystem` methods and use `Package` instead. This module should know whether to forward the call to `PackageSystem` or `PackageAI`. 

The following changes are included:

* `CheckAndInstallPackages*` are now implemented in the `Package` module. For backward compatibility reasons, the `PackageSystem` implements those methods too (although it forwards those calls to the `Package` module).
* Add support for packages to uninstall (taboos) to the `PackagesProposal`, so `PackageAI` does not keep its list of packages anymore.
* Drop the `PackagesCommonInclude` module. Its methods are now implemented directly in `Package`.
* Improved test-unit coverage.

Bug report: [bsc#1194886](https://bugzilla.suse.com/show_bug.cgi?id=1194886).