### PR TITLE
Fixed RelURL to work properly with the FTP URLs

### DIFF
--- a/library/general/src/lib/yast2/rel_url.rb
+++ b/library/general/src/lib/yast2/rel_url.rb
@@ -97,7 +97,11 @@ module Yast2
         # the relative path really needs to be relative, remove the leading slash(es)
         relative_path.sub!(/\A\/+/, "")
 
-        ret.path = File.expand_path(relative_path, base_path)
+        absolute_path = File.expand_path(relative_path, base_path)
+        # URI::FTP escapes the initial "/" to "%2F" which we do not want here
+        absolute_path.sub!(/\A\/+/, "") if ret.scheme == "ftp"
+
+        ret.path = absolute_path
       end
 
       postprocess_url(ret)

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -199,6 +199,11 @@ describe Yast2::RelURL do
       expect(relurl.absolute_url.to_s).to eq("file://foo/bar/test")
     end
 
+    it "works with file:/// base URL" do
+      relurl = Yast2::RelURL.new("file:///", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("file://test")
+    end
+
     it "goes up with file:// base URL properly" do
       relurl = Yast2::RelURL.new("file://foo/bar", "relurl://../../test")
       expect(relurl.absolute_url.to_s).to eq("file://test")

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -174,6 +174,26 @@ describe Yast2::RelURL do
       expect(relurl.absolute_url.to_s).to eq("http://user:password@example.com/test")
     end
 
+    it "works with ftp:// URL" do
+      relurl = Yast2::RelURL.new("ftp://example.com", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("ftp://example.com/test")
+    end
+
+    it "works with cd:// URL" do
+      relurl = Yast2::RelURL.new("cd://", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("cd://test")
+    end
+
+    it "works with cifs:// URL" do
+      relurl = Yast2::RelURL.new("cifs://server/share/path", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("cifs://server/share/path/test")
+    end
+
+    it "works with nfs:// URL" do
+      relurl = Yast2::RelURL.new("nfs://server/export/path", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("nfs://server/export/path/test")
+    end
+
     it "works with file:// base URL" do
       relurl = Yast2::RelURL.new("file://foo/bar", "relurl://test")
       expect(relurl.absolute_url.to_s).to eq("file://foo/bar/test")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 16 08:39:01 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed RelURL to work properly with the FTP URLs (related to
+  jsc#SLE-22669)
+- 4.4.30
+
+-------------------------------------------------------------------
 Wed Dec 15 13:21:31 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed RelURL unit test randomly crashing (related to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.29
+Version:        4.4.30
 Release:        0
 Summary:        YaST2 Main Package
 License:        GPL-2.0-only

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,13 +59,20 @@ if ENV["COVERAGE"]
 end
 
 # mock missing YaST modules
-module Yast
-  # we cannot depend on this module (circular dependency)
-  class InstURLClass
-    def installInf2Url(_extra_dir = "")
-      ""
+begin
+  # try loading the Yast::InstURL module, we cannot depend on it (because of
+  # circular build dependency), but it is present when running the tests
+  # locally or in GitHub Actions
+  Yast.import "InstURL"
+rescue NameError
+  # if it is missing then mock it
+  module Yast
+    class InstURLClass
+      def installInf2Url(_extra_dir = "")
+        ""
+      end
     end
-  end
 
-  InstURL = InstURLClass.new
+    InstURL = InstURLClass.new
+  end
 end


### PR DESCRIPTION
## FTP URL Fix

It turned out that the `URI` class processes FTP URL paths a bit differently. Normally you have to use an absolute path otherwise you get an exception:

```
irb(main):001:0> u = URI("http://example.com")
=> #<URI::HTTP http://example.com>
irb(main):002:0> u.path = "path"
Traceback (most recent call last):
        4: from /usr/bin/irb:11:in `<main>'
        3: from (irb):2
        2: from /usr/lib64/ruby/2.5.0/uri/generic.rb:819:in `path='
        1: from /usr/lib64/ruby/2.5.0/uri/generic.rb:771:in `check_path'
URI::InvalidComponentError (bad component(expected absolute path component): path)
irb(main):003:0> u.path = "/path"
=> "/path"
```

But FTP URL is escaped when the path starts with `/`:

```
irb(main):001:0> u = URI("ftp://example.com")
=> #<URI::FTP ftp://example.com/>
irb(main):002:0> u.path = "/path"
=> "/path"
irb(main):003:0> u.to_s
=> "ftp://example.com/%2Fpath"
```

And it is allowed to use a relative path:

```
irb(main):004:0> u.path = "path"
=> "path"
irb(main):005:0> u.to_s
=> "ftp://example.com/path"
```

So there is an exception in the code for the FTP URLs to process them correctly.

*Note: that's because FTP really allows using absolute paths for files!*

## Improve Mocking Yast::InstURL Module

Originally the module was always mocked but then the problem is that the RSpec verifying doubles will not work as expected. There might be an inconsistency between the mocked `InstURL` and the real `InstURL`.

But when running the tests locally or in GitHub Actions the real module is actually present and we do no need to reimplement it completely. Then the verifying doubles would use the real module and provide more reliable testing.