### PR TITLE
bsc#1193784: do not reinitialize repos during upgrade

### DIFF
--- a/library/control/src/modules/WorkflowManager.rb
+++ b/library/control/src/modules/WorkflowManager.rb
@@ -60,6 +60,7 @@ module Yast
       Yast.import "String"
       Yast.import "XML"
       Yast.import "Report"
+      Yast.import "Mode"
 
       #
       #    This API uses some new terms that need to be explained:
@@ -1694,7 +1695,9 @@ module Yast
       Tempfile.open("downloaded-package-") do |tmp|
         # libzypp needs the target for verifying the GPG signatures of the downloaded packages,
         # keep the target initialized, it might be needed later for verifying other packages
-        Pkg.TargetInitialize("/") if Stage.initial
+        # However, avoid this call when running on update mode because we need the repositories
+        # from the system to upgrade too.
+        Pkg.TargetInitialize("/") if Stage.initial && !Mode.update
         downloader.download(tmp.path)
 
         extract(tmp.path, dir)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 20 11:07:31 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Do not reinitialize the packaging system during offline
+  upgrade (bsc#1193784 and bsc#1192437).
+- 4.3.66
+
+-------------------------------------------------------------------
 Thu Jul 15 11:04:50 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not escape "$" in URL paths (bsc#1187581).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.65
+Version:        4.3.66
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
Reinitializing the repositories during upgrade to `/` makes the process fail. The problem is that, in that case, we need to use repositories of the system we are updating too (`/mnt`) and, after that call, they are gone.

See [bsc#1193784](https://bugzilla.suse.com/show_bug.cgi?id=1193784) and [bsc#1192437](https://bugzilla.suse.com/show_bug.cgi?id=1192437).