### PR TITLE
Add Y2Packager::Resolvable.none? method

### DIFF
--- a/library/packages/src/lib/y2packager/resolvable.rb
+++ b/library/packages/src/lib/y2packager/resolvable.rb
@@ -81,6 +81,15 @@ module Y2Packager
       Yast::Pkg.AnyResolvable(params)
     end
 
+    # Return true when there is no resolvable matching the requested parameters or false
+    # otherwise.
+    #
+    # @param params [Hash<Symbol,Object>] The requested attributes
+    # @return [Boolean] `true` if no matching resolvable is found, `false` otherwise.
+    def self.none?(params)
+      !any?(params)
+    end
+
     #
     # Constructor, initialize the object from a pkg-bindings resolvable hash.
     #

--- a/library/packages/test/y2packager/resolvable_test.rb
+++ b/library/packages/test/y2packager/resolvable_test.rb
@@ -141,6 +141,25 @@ describe Y2Packager::Resolvable do
     end
   end
 
+  describe ".none?" do
+    it "returns true if no package is found" do
+      expect(Y2Packager::Resolvable.none?(kind: :package, name: "not existing")).to be true
+    end
+
+    it "returns true if no product is found" do
+      expect(Y2Packager::Resolvable.none?(kind: :product, name: "openSUSE")).to be true
+    end
+
+    it "returns false if a package with name is found" do
+      # use some noarch package here, the testing data covers only the x86_64 arch
+      expect(Y2Packager::Resolvable.none?(kind: :package, name: "yast2-add-on")).to be false
+    end
+
+    it "returns false if a package is found" do
+      expect(Y2Packager::Resolvable.none?(kind: :package)).to be false
+    end
+  end
+
   describe "#vendor" do
     it "lazy loads the missing attributes" do
       # use some noarch package here, the testing data covers only the x86_64 arch

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan  7 08:32:21 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Y2Packager::Resolvable: added none? method in order to not crash
+  in case of rubocop automatic change (bsc#1194387)
+- 4.4.33
+
+-------------------------------------------------------------------
 Thu Dec 23 18:08:19 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - properly pass named arguments in ruby3 (bsc#1193192)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.32
+Version:        4.4.33
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

We recently have updated rubocop to 0.71.0 version in **yast2-installation** renaming the **Y2Packager::Resolvable.any?** call to **Y2Packager::Resolvable.none?** automatically, but the **.none?** method is not implemented

- https://bugzilla.suse.com/show_bug.cgi?id=1194387

## Solution

Added **Y2Packager::Resolvable.none?** method in order to fix the crash but also prevent future rubocop auto change issue.

https://github.com/yast/yast-installation/pull/1009/files#diff-9e5517485ccbd905e33ffea54a28ce8474b226e3faea35dc1893f28ee769b70aR244