### PR TITLE
Fixed test failure in Ruby 2.5

### DIFF
--- a/library/cwm/src/lib/cwm/dialog.rb
+++ b/library/cwm/src/lib/cwm/dialog.rb
@@ -26,6 +26,11 @@ module CWM
     # @return [CWM::WidgetTerm]
     abstract_method :contents
 
+    # Constructor (empty to just allow passing extra options)
+    def initialize(*args, **kws)
+      super
+    end
+
     # A shortcut for `.new(*args).run`
     def self.run(*args, **kws)
       new(*args, **kws).run

--- a/library/cwm/src/lib/cwm/popup.rb
+++ b/library/cwm/src/lib/cwm/popup.rb
@@ -26,6 +26,11 @@ module CWM
   # This class offers a CWM dialog which behaves as a pop-up.
   # @see {CWM::Dialog} for remaining configuration options.
   class Popup < Dialog
+    # Constructor (empty to just allow passing extra options)
+    def initialize(*args, **kws)
+      super
+    end
+
     # Determines that a dialog should always be open
     #
     # @return [true]

--- a/library/general/test/ui/installation/layout_test.rb
+++ b/library/general/test/ui/installation/layout_test.rb
@@ -24,6 +24,12 @@ require_relative "../../test_helper"
 require "ui/wizards/layout"
 
 describe UI::Wizards::Layout do
+  before do
+    # ProductFeatures read the defaults from the system when running
+    # in an installed system
+    allow(Yast::Stage).to receive(:normal).and_return(false)
+  end
+
   describe ".with_steps" do
     it "creates a layout with steps sidebar" do
       layout = described_class.with_steps

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan  7 14:41:15 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed test failure in Ruby 2.5, caused by the fix for Ruby 3.0
+  (related to bsc#1193192)
+- 4.4.34
+
+-------------------------------------------------------------------
 Fri Jan  7 08:32:21 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Y2Packager::Resolvable: added none? method in order to not crash

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.33
+Version:        4.4.34
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
- The fix for Ruby 3.0 (#1225) caused a regression in Ruby 2.5
- Also added missing `Stage.normal` mock, for me the tests failed when running locally