### PR TITLE
Remove useless "super"

### DIFF
--- a/library/cwm/src/lib/cwm/dialog.rb
+++ b/library/cwm/src/lib/cwm/dialog.rb
@@ -28,7 +28,6 @@ module CWM
 
     # Constructor (empty to just allow passing extra options)
     def initialize(*args, **kws)
-      super
     end
 
     # A shortcut for `.new(*args).run`


### PR DESCRIPTION
- Fix up for #1228
- The super is actually not needed as the class does not inherit from any base class (besides implicit `Object`)
- Tested with `YAST_SUBMIT=sle_latest rake osc:build`, builds fine