### PR TITLE
[PoC] Run unit tests against both Ruby 2.5 and Ruby 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,13 @@ on: [push, pull_request]
 jobs:
   Tests:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        docker_repo: [ "containers", "containers_15.4" ]
+
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
 
     steps:
 
@@ -38,8 +43,12 @@ jobs:
 
   Rubocop:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        docker_repo: [ "containers", "containers_15.4" ]
+
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
 
     steps:
 
@@ -51,8 +60,13 @@ jobs:
 
   Package:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        docker_repo: [ "containers", "containers_15.4" ]
+
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
 
     steps:
 
@@ -64,8 +78,13 @@ jobs:
 
   Yardoc:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        docker_repo: [ "containers", "containers_15.4" ]
+
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
 
     steps:
 
@@ -79,8 +98,13 @@ jobs:
   # checks into one job avoids that overhead
   Checks:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        docker_repo: [ "containers", "containers_15.4" ]
+
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ "tumbleweed", "15.4" ]
+        distro: [ "tumbleweed", "leap_latest" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ "15.4" ]
+        distro: [ "leap_latest" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ "15.4" ]
+        distro: [ "leap_latest" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ "15.4" ]
+        distro: [ "leap_latest" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
@@ -101,7 +101,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ "15.4" ]
+        distro: [ "leap_latest" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ "TW", "15.4" ]
+        distro: [ "tumbleweed", "15.4" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_repo: [ "containers", "containers_15.4" ]
+        docker_repo: [ "containers_15.4" ]
 
     container:
       image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers", "containers_15.4" ]
+        docker_repo: [ "containers_15.4" ]
 
     container:
       image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
@@ -81,7 +81,7 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers", "containers_15.4" ]
+        docker_repo: [ "containers_15.4" ]
 
     container:
       image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
@@ -101,7 +101,7 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers", "containers_15.4" ]
+        docker_repo: [ "containers_15.4" ]
 
     container:
       image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers", "containers_15.4" ]
+        distro: [ "TW", "15.4" ]
 
     container:
-      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
 
     steps:
 
@@ -45,10 +45,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        docker_repo: [ "containers_15.4" ]
+        distro: [ "15.4" ]
 
     container:
-      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
 
     steps:
 
@@ -63,10 +63,10 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers_15.4" ]
+        distro: [ "15.4" ]
 
     container:
-      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
 
     steps:
 
@@ -81,10 +81,10 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers_15.4" ]
+        distro: [ "15.4" ]
 
     container:
-      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
 
     steps:
 
@@ -101,10 +101,10 @@ jobs:
 
     strategy:
       matrix:
-        docker_repo: [ "containers_15.4" ]
+        distro: [ "15.4" ]
 
     container:
-      image: registry.opensuse.org/yast/head/${{matrix.docker_repo}}/yast-ruby:latest
+      image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
 
     # send the coverage report to coveralls.io
     - name: Coveralls Report
+      # send it only once from the TW build to avoid duplicate submits
+      if: ${{ matrix.distro == 'tumbleweed' }}
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
 
     strategy:
       matrix:
-        distro: [ "leap_latest" ]
+        distro: [ "tumbleweed", "leap_latest" ]
 
     container:
       image: registry.opensuse.org/yast/head/containers_${{matrix.distro}}/yast-ruby

--- a/library/cwm/src/lib/cwm/dialog.rb
+++ b/library/cwm/src/lib/cwm/dialog.rb
@@ -27,8 +27,7 @@ module CWM
     abstract_method :contents
 
     # Constructor (empty to just allow passing extra options)
-    def initialize(*args, **kws)
-    end
+    def initialize(*args, **kws); end
 
     # A shortcut for `.new(*args).run`
     def self.run(*args, **kws)


### PR DESCRIPTION
- We currently run the GitHub Actions using the TumbleWeed based docker image
- That means it runs the unit tests against Ruby 3.0 (or Ruby 3.1 soon....)
- The problem is that we should run the unit tests also against Ruby 2.5 included in SLE15-SP4/Leap15.4 to make sure it also works fine in older Ruby
- This also fixes the problem with (old) Rubocop and Yard which do not work properly in Ruby 3.x, just run them in the Ruby 2.5 image
- We do not need to run *all* checks using both Docker images, e.g. the Perl syntax check or the POT check are enough to run just in one Docker image, these should not depend on the Ruby version included. (Um, which one should we prefer in this case? The TW image or the 15.4 image? :thinking: )