### PR TITLE
Adapt Report.yesno_popup to Ruby 3 (bsc#1193192)

### DIFF
--- a/library/general/src/modules/Report.rb
+++ b/library/general/src/modules/Report.rb
@@ -427,7 +427,7 @@ module Yast
         if @display_yesno_messages
           args = { buttons: :yes_no }.merge(extra_args)
           args[:timeout] = @timeout_yesno_messages
-          answer = Yast2::Popup.show(message, args)
+          answer = Yast2::Popup.show(message, **args)
           answer == :yes
         else
           false

--- a/library/general/test/report_test.rb
+++ b/library/general/test/report_test.rb
@@ -345,6 +345,16 @@ describe Yast::Report do
         subject.yesno_popup("Message", buttons: { yes: "Sir" })
       end
 
+      it "forwards any extra argument to Popup.show" do
+        # Use block syntax in the expectaton instead of ".with" to unveil the problem with Ruby3
+        # and named params
+        expect(Yast2::Popup).to receive(:show) do |msg, **args|
+          expect(msg).to eq "Message"
+          expect(args).to include(headline: "Breaking News")
+        end
+        subject.yesno_popup("Message", headline: "Breaking News", focus: :yes)
+      end
+
       it "returns true if :yes is pressed" do
         allow(Yast2::Popup).to receive(:show).and_return :yes
         expect(subject.yesno_popup("Message")).to eq true

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jan 14 13:56:49 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Adapted Report.yesno_popup to Ruby 3 (bsc#1193192)
+- 4.4.36
+
+-------------------------------------------------------------------
 Wed Jan 12 11:46:50 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Simplify slide show to support future parallel installations

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.35
+Version:        4.4.36
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
A hash was being passed to a method expecting the hash would be interpreted as a set of keyword params. That works in Ruby 2 as-is, but in Ruby 3 the `**` operator must be used.
 
The problem was detected by me when trying to open two instances of the Partitioner and also by the internal SUSE openQA instance during this test: https://openqa.suse.de/tests/overview?distri=sle&version=15-SP4&build=Y.52.5&groupid=125