### PR TITLE
Fix CWM dialog

### DIFF
--- a/library/cwm/src/lib/cwm/dialog.rb
+++ b/library/cwm/src/lib/cwm/dialog.rb
@@ -31,7 +31,18 @@ module CWM
 
     # A shortcut for `.new(*args).run`
     def self.run(*args, **kws)
-      new(*args, **kws).run
+      # Argument delegation is handled differently since ruby 2.7:
+      #
+      # An empty Hash argument is automatically converted and absorbed into **kws, and the delegation
+      # call removes the empty keyword hash, so no argument is passed to target. In ruby 2.6 and before,
+      # an empty hash is passed:
+      #
+      # * Ruby 2.6 or before: run("foo") passes new("foo", {})
+      # * Ruby 2.7 or later:  run("foo") passes new("foo")
+      #
+      # See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+      dialog = kws.empty? ? new(*args) : new(*args, **kws)
+      dialog.run
     end
 
     # The entry point.

--- a/library/cwm/test/dialog_test.rb
+++ b/library/cwm/test/dialog_test.rb
@@ -32,10 +32,16 @@ describe "CWM::Dialog" do
       allow(Yast::CWM).to receive(:show).and_return(:next)
     end
 
-    it "pass all arguments to constructor" do
+    it "pass all given arguments to constructor" do
       expect(TestCWMDialog).to receive(:new).with("test2", disable: :next).and_call_original
 
       TestCWMDialog.run("test2", disable: :next)
+    end
+
+    it "does not past extra arguments to constructor" do
+      expect(TestCWMDialog).to receive(:new).with(no_args).and_call_original
+
+      TestCWMDialog.run
     end
 
     it "opens a dialog when needed, and calls CWM#show" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jan 21 12:51:45 UTC 2022 - José Iván López González <jlopez@suse.com>
+
+- Fix CWM dialog: argument delegation is handled differently in
+  ruby 2.6 and before (bsc#1194984).
+- 4.4.37
+
+-------------------------------------------------------------------
 Fri Jan 14 13:56:49 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Adapted Report.yesno_popup to Ruby 3 (bsc#1193192)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.36
+Version:        4.4.37
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

Method `Dialog#run` delegates arguments to `Dialog.new`. Argument delegation is handled differently in ruby 2.6 and before, see [explanation here](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/):

In ruby 2.7 or later, an empty Hash argument is automatically converted and absorbed into **kwargs, and the delegation call removes the empty keyword hash, so no argument is passed to target:

~~~
def target(*args, **kwargs)
end

def foo(*args, **kwargs, &block)
  target(*args, **kwargs, &block)
end

foo(1)       #=> Ruby 2.7: calls target(1)
foo(1)       #=> Ruby 2.6: calls target(1, {})
~~~

https://bugzilla.suse.com/show_bug.cgi?id=1194984

## Solution

Do not pass empty `**kwargs` to the target method.

## Testing

* Added unit test, and checked in different ruby versions.
