### PR TITLE
Preload libsuseconnect.so if avaiable (bsc#1194996)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Mon Jan 24 21:04:10 UTC 2022 - Jacek Tomasiak <jtomasiak@suse.com>
+
+- Preload libsuseconnect.so if avaiable. On aarch64 installer/YaST
+  sometimes failed to load libsuseconnect.so with "cannot allocate
+  memory in static TLS block" error.
+  Loading the library before others solves the problem until a better
+  solution is found (bsc#1194996).
+- 4.3.39
+
+-------------------------------------------------------------------
 Fri Jan 21 15:41:19 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Unify Package, PackageSystem and PackageAI. Now the Package

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.38
+Version:        4.4.39
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -13,6 +13,11 @@
 # wise ncurses. It starts then the module 'menu' which implements
 # the configuration and administration menu.
 
+# bsc#1194996: workaround for "cannot allocate memory in static TLS block"
+if [ -f /usr/lib64/libsuseconnect.so ]; then
+  export LD_PRELOAD="/usr/lib64/libsuseconnect.so $LD_PRELOAD"
+fi
+
 # FATE#317637, bsc#877447: In installation system, we call the installer
 # script directly and then exit
 if [ -f /.instsys.config ]; then


### PR DESCRIPTION
On aarch64 installer/YaST sometimes failed to load libsuseconnect.so
with "cannot allocate memory in static TLS block" error.
Loading the library before others solves the problem until a better
solution is found.