### PR TITLE
Added Y2Packager::NewRepositorySetup class (bsc#1194453)

### DIFF
--- a/library/packages/src/lib/y2packager/new_repository_setup.rb
+++ b/library/packages/src/lib/y2packager/new_repository_setup.rb
@@ -1,0 +1,52 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2022 SUSE LINUX GmbH, Nuremberg, Germany.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require "yast"
+
+require "singleton"
+
+module Y2Packager
+  #
+  # This class stores the new repositories and services added during
+  # installation or upgrade. It can be used together with the
+  # OriginalRepositorySetup class to find the old and new repositories.
+  #
+  # @since 4.4.42
+  class NewRepositorySetup
+    include Yast::Logger
+    include Singleton
+
+    attr_reader :repositories, :services
+
+    # constructor, initialize the stored lists to empty lists
+    def initialize
+      @repositories = []
+      @services = []
+    end
+
+    # Store a repository name
+    #
+    # @param repo_alias [String] Repository alias
+    def add_repository(repo_alias)
+      log.info "Added #{repo_alias.inspect} to new repositories"
+      repositories << repo_alias
+    end
+
+    # Store a service name
+    #
+    # @param service_name [String] Name of the service
+    def add_service(service_name)
+      log.info "Added #{service_name.inspect} to new services"
+      services << service_name
+    end
+  end
+end

--- a/library/packages/test/y2packager/new_repository_setup_test.rb
+++ b/library/packages/test/y2packager/new_repository_setup_test.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env rspec
+# ------------------------------------------------------------------------------
+# Copyright (c) 2022 SUSE LLC, All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# ------------------------------------------------------------------------------
+
+require_relative "../test_helper"
+
+require "y2packager/new_repository_setup"
+
+describe Y2Packager::NewRepositorySetup do
+  # create anonymous subclass to have a fresh singleton instance for each test
+  subject { Class.new(Y2Packager::NewRepositorySetup).instance }
+
+  describe "#add_repository" do
+    it "stores the repository into the list" do
+      subject.add_repository("test_repo")
+      expect(subject.repositories).to include("test_repo")
+    end
+  end
+
+  describe "#add_service" do
+    it "stores the service into the list" do
+      subject.add_service("test_service")
+      expect(subject.services).to include("test_service")
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 26 18:27:40 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added Y2Packager::NewRepositorySetup to track new repositories
+  (related to bsc#1194453)
+- 4.4.42
+
+-------------------------------------------------------------------
 Wed Jan 26 13:21:21 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Fix PackageAI call to PackagesProposal.GetResolvable. It prevents

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.41
+Version:        4.4.42
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1194453
- Added Y2Packager::NewRepositorySetup class to track new repositories
- Similar to the already existing [Y2Packager::OriginalRepositorySetup](https://github.com/yast/yast-yast2/blob/4f0560a55f0b4ece41ed50063fd7baf00cd8eedc/library/packages/src/lib/y2packager/original_repository_setup.rb#L28) class 
- This class will used from other packages (y2-registration and y2-installation)
- 4.4.42

## Technical Details

During upgrade YaST removes the old repository services (e.g. SLE12) from the system. Unfortunately when upgrading via RMT it returns the same name for the new service (SLE15), YaST did not expected that and removed the "old" service from the system. But this accidentally removed the new service and that made troubles during upgrade.

## Testing

- Added unit tests
- Tested manually against the RMT server reported in the bug