### PR TITLE
do not strip trailing white space in XML elements (bsc#1195910)

### DIFF
--- a/library/xml/src/modules/XML.rb
+++ b/library/xml/src/modules/XML.rb
@@ -247,7 +247,11 @@ module Yast
       children = children.select(&:element?)
       # we need just direct text under node. Can be splitted with another elements
       # but remove whitespace only text
-      text = node.xpath("text()").text.strip
+      #
+      # Do NOT strip trailing white space in CDATA blocks. Maybe people put
+      # it intentionally there (bsc#1195910).
+      text_nodes = node.xpath("text()")
+      text = text_nodes.map { |n| n.cdata? ? n.content.lstrip : n.content.strip }.join
 
       type = fetch_type(text, children, node)
 

--- a/library/xml/src/modules/XML.rb
+++ b/library/xml/src/modules/XML.rb
@@ -250,6 +250,8 @@ module Yast
       #
       # Do NOT strip trailing white space in CDATA blocks. Maybe people put
       # it intentionally there (bsc#1195910).
+      #
+      # See also #add_element.
       text_nodes = node.xpath("text()")
       text = text_nodes.map { |n| n.cdata? ? n.content.lstrip : n.content.strip }.join
 
@@ -305,7 +307,13 @@ module Yast
         element = Nokogiri::XML::Node.new(key, doc)
         case value
         when ::String
-          element.content = value
+          # Write CDATA block if string ends with white space. This matches
+          # the stripping in #parse_node.
+          if value.match?(/\s\z/)
+            element.add_child(doc.create_cdata(value))
+          else
+            element.content = value
+          end
         when ::Integer
           element[type_attr] = "integer"
           element.content = value.to_s

--- a/library/xml/test/xml_test.rb
+++ b/library/xml/test/xml_test.rb
@@ -85,6 +85,30 @@ describe "Yast::XML" do
 
         expect(subject.YCPToXMLString("test", input)).to eq expected
       end
+
+      it "creates no CDATA element if string starts with spaces" do
+        input = { "test" => " test", "lest" => "\nlest" }
+        expected = "<?xml version=\"1.0\"?>\n" \
+          "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
+          "<test>\n" \
+          "  <lest>\nlest</lest>\n" \
+          "  <test> test</test>\n" \
+          "</test>\n"
+
+        expect(subject.YCPToXMLString("test", input)).to eq expected
+      end
+
+      it "creates CDATA element if string ends with spaces" do
+        input = { "test" => "test ", "lest" => "lest\n" }
+        expected = "<?xml version=\"1.0\"?>\n" \
+          "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
+          "<test>\n" \
+          "  <lest><![CDATA[lest\n]]></lest>\n" \
+          "  <test><![CDATA[test ]]></test>\n" \
+          "</test>\n"
+
+        expect(subject.YCPToXMLString("test", input)).to eq expected
+      end
     end
 
     context "for hash" do
@@ -280,6 +304,52 @@ describe "Yast::XML" do
         "  </lest>\n" \
         "</test>\n"
       expected = { "test" => "5", "lest" => "-5" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "strips spaces at the end of strings" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test>foo </test>\n" \
+        "  <lest>bar\n" \
+        "  </lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo", "lest" => "bar" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "preserves spaces at the end of CDATA elements" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test><![CDATA[foo ]]></test>\n" \
+        "  <lest><![CDATA[bar\n]]></lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo ", "lest" => "bar\n" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "strips spaces at the start of strings" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test> foo</test>\n" \
+        "  <lest>\nbar" \
+        "  </lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo", "lest" => "bar" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "strips spaces at the start of CDATA elements" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test><![CDATA[ foo]]></test>\n" \
+        "  <lest><![CDATA[\nbar]]></lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo", "lest" => "bar" }
 
       expect(subject.XMLToYCPString(input)).to eq expected
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 16 15:41:54 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- do not strip trailing white space in XML elements (bsc#1195910)
+- 4.3.67
+
+-------------------------------------------------------------------
 Mon Dec 20 11:07:31 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Do not reinitialize the packaging system during offline

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.66
+Version:        4.3.67
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1195910
- https://trello.com/c/1uUwxpq6

Surrounding white space in some elements may be desired. Like in scripts or other file content. Be more careful when removing it.

## The catch

The AutoYaST profile is processed by YaST to construct the final profile. It's written, modified by scripts, then read again, for example. Ensure that during this processing the CDATA 'attribute' to elements is not lost.

## Solution

Strip leading white space when reading XML CDATA blocks. And create CDATA blocks when generating XML if an element contains trailing white space.

## Note

Why not also keeping leading white space? - It's common to have a leading newline in `script` sections. They must be removed.