### PR TITLE
Keep the user defined $Y2STYLE and $XCURSOR_THEME environment variables

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 16 15:17:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Keep the user defined $Y2STYLE and $XCURSOR_THEME environment
+  variables, allow changing the installer theme via these
+  environment variables (related to jsc#SLE-20547)
+- 4.4.44
+
+-------------------------------------------------------------------
 Fri Jan 28 14:03:04 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - ProductFeatures: add boot timeout option (jsc#SLE-22667)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.43
+Version:        4.4.44
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/scripts/yast2-funcs
+++ b/scripts/yast2-funcs
@@ -129,8 +129,12 @@ function set_qt_env()
 
 function set_inst_qt_env()
 {
-    export XCURSOR_THEME="DMZ-White"
-    export Y2STYLE="installation.qss"
+    # default values
+    : "${Y2STYLE=installation.qss}"
+    : "${XCURSOR_THEME=DMZ-White}"
+
+    export XCURSOR_THEME
+    export Y2STYLE
     export QT_HOME_DIR="/tmp/.qt/"
     if [ "$Screenmode" != "" ] && [ "$Screenmode" != "default" ]; then
         export Y2ALTSTYLE="$Screenmode"


### PR DESCRIPTION
##  The problem

- Setting the `Y2STYLE` environment variable to `installation-light.qss` before starting the installer does not take effect, the variable is always set to `installation.qss`.
- Related to [jsc#SLE-20547](https://jira.suse.com/browse/SLE-20547)

## The Fix

- Set the default value only when not set already. 
- Handle the `XCURSOR_THEME` value the same way.

## Testing

Tested manually, with `Y2STYLE=installation-light.qss` and the manually added `installation-light.qss` file it looks like this:

![installation-light](https://user-images.githubusercontent.com/907998/154299147-d335e6a3-2b09-4cf7-9fc0-4855bcfa0f28.png)



