### PR TITLE
do not strip surrounding white space in CDATA XML elements (bsc#1195910)

### DIFF
--- a/library/xml/test/xml_test.rb
+++ b/library/xml/test/xml_test.rb
@@ -85,6 +85,30 @@ describe "Yast::XML" do
 
         expect(subject.YCPToXMLString("test", input)).to eq expected
       end
+
+      it "creates CDATA element if string starts with spaces" do
+        input = { "test" => " test", "lest" => "\nlest" }
+        expected = "<?xml version=\"1.0\"?>\n" \
+          "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
+          "<test>\n" \
+          "  <lest><![CDATA[\nlest]]></lest>\n" \
+          "  <test><![CDATA[ test]]></test>\n" \
+          "</test>\n"
+
+        expect(subject.YCPToXMLString("test", input)).to eq expected
+      end
+
+      it "creates CDATA element if string ends with spaces" do
+        input = { "test" => "test ", "lest" => "lest\n" }
+        expected = "<?xml version=\"1.0\"?>\n" \
+          "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
+          "<test>\n" \
+          "  <lest><![CDATA[lest\n]]></lest>\n" \
+          "  <test><![CDATA[test ]]></test>\n" \
+          "</test>\n"
+
+        expect(subject.YCPToXMLString("test", input)).to eq expected
+      end
     end
 
     context "for hash" do
@@ -280,6 +304,52 @@ describe "Yast::XML" do
               "  </lest>\n" \
               "</test>\n"
       expected = { "test" => "5", "lest" => "-5" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "strips spaces at the end of strings" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test>foo </test>\n" \
+        "  <lest>bar\n" \
+        "  </lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo", "lest" => "bar" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "preserves spaces at the end of CDATA elements" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test><![CDATA[foo ]]></test>\n" \
+        "  <lest><![CDATA[bar\n]]></lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo ", "lest" => "bar\n" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "strips spaces at the start of strings" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test> foo</test>\n" \
+        "  <lest>\nbar" \
+        "  </lest>\n" \
+        "</test>\n"
+      expected = { "test" => "foo", "lest" => "bar" }
+
+      expect(subject.XMLToYCPString(input)).to eq expected
+    end
+
+    it "preserves spaces at the start of CDATA elements" do
+      input = "<?xml version=\"1.0\"?>\n" \
+        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+        "  <test><![CDATA[ foo]]></test>\n" \
+        "  <lest><![CDATA[\nbar]]></lest>\n" \
+        "</test>\n"
+      expected = { "test" => " foo", "lest" => "\nbar" }
 
       expect(subject.XMLToYCPString(input)).to eq expected
     end

--- a/library/xml/test/xml_test.rb
+++ b/library/xml/test/xml_test.rb
@@ -89,11 +89,11 @@ describe "Yast::XML" do
       it "creates CDATA element if string starts with spaces" do
         input = { "test" => " test", "lest" => "\nlest" }
         expected = "<?xml version=\"1.0\"?>\n" \
-          "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
-          "<test>\n" \
-          "  <lest><![CDATA[\nlest]]></lest>\n" \
-          "  <test><![CDATA[ test]]></test>\n" \
-          "</test>\n"
+                   "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
+                   "<test>\n" \
+                   "  <lest><![CDATA[\nlest]]></lest>\n" \
+                   "  <test><![CDATA[ test]]></test>\n" \
+                   "</test>\n"
 
         expect(subject.YCPToXMLString("test", input)).to eq expected
       end
@@ -101,11 +101,11 @@ describe "Yast::XML" do
       it "creates CDATA element if string ends with spaces" do
         input = { "test" => "test ", "lest" => "lest\n" }
         expected = "<?xml version=\"1.0\"?>\n" \
-          "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
-          "<test>\n" \
-          "  <lest><![CDATA[lest\n]]></lest>\n" \
-          "  <test><![CDATA[test ]]></test>\n" \
-          "</test>\n"
+                   "<!DOCTYPE test SYSTEM \"just_testing.dtd\">\n" \
+                   "<test>\n" \
+                   "  <lest><![CDATA[lest\n]]></lest>\n" \
+                   "  <test><![CDATA[test ]]></test>\n" \
+                   "</test>\n"
 
         expect(subject.YCPToXMLString("test", input)).to eq expected
       end
@@ -310,11 +310,11 @@ describe "Yast::XML" do
 
     it "strips spaces at the end of strings" do
       input = "<?xml version=\"1.0\"?>\n" \
-        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
-        "  <test>foo </test>\n" \
-        "  <lest>bar\n" \
-        "  </lest>\n" \
-        "</test>\n"
+              "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+              "  <test>foo </test>\n" \
+              "  <lest>bar\n" \
+              "  </lest>\n" \
+              "</test>\n"
       expected = { "test" => "foo", "lest" => "bar" }
 
       expect(subject.XMLToYCPString(input)).to eq expected
@@ -322,10 +322,10 @@ describe "Yast::XML" do
 
     it "preserves spaces at the end of CDATA elements" do
       input = "<?xml version=\"1.0\"?>\n" \
-        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
-        "  <test><![CDATA[foo ]]></test>\n" \
-        "  <lest><![CDATA[bar\n]]></lest>\n" \
-        "</test>\n"
+              "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+              "  <test><![CDATA[foo ]]></test>\n" \
+              "  <lest><![CDATA[bar\n]]></lest>\n" \
+              "</test>\n"
       expected = { "test" => "foo ", "lest" => "bar\n" }
 
       expect(subject.XMLToYCPString(input)).to eq expected
@@ -333,11 +333,11 @@ describe "Yast::XML" do
 
     it "strips spaces at the start of strings" do
       input = "<?xml version=\"1.0\"?>\n" \
-        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
-        "  <test> foo</test>\n" \
-        "  <lest>\nbar" \
-        "  </lest>\n" \
-        "</test>\n"
+              "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+              "  <test> foo</test>\n" \
+              "  <lest>\nbar" \
+              "  </lest>\n" \
+              "</test>\n"
       expected = { "test" => "foo", "lest" => "bar" }
 
       expect(subject.XMLToYCPString(input)).to eq expected
@@ -345,10 +345,10 @@ describe "Yast::XML" do
 
     it "preserves spaces at the start of CDATA elements" do
       input = "<?xml version=\"1.0\"?>\n" \
-        "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
-        "  <test><![CDATA[ foo]]></test>\n" \
-        "  <lest><![CDATA[\nbar]]></lest>\n" \
-        "</test>\n"
+              "<test xmlns=\"http://www.suse.com/1.0/yast2ns\" xmlns:config=\"http://www.suse.com/1.0/configns\">\n" \
+              "  <test><![CDATA[ foo]]></test>\n" \
+              "  <lest><![CDATA[\nbar]]></lest>\n" \
+              "</test>\n"
       expected = { "test" => " foo", "lest" => "\nbar" }
 
       expect(subject.XMLToYCPString(input)).to eq expected

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 17 13:25:33 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- do not strip surrounding white space in CDATA XML elements (bsc#1195910)
+- 4.4.45
+
+-------------------------------------------------------------------
 Wed Feb 16 15:17:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Keep the user defined $Y2STYLE and $XCURSOR_THEME environment

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.44
+Version:        4.4.45
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Task

Port https://github.com/yast/yast-yast2/pull/1244 to SLE15-SP4/TW.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1195910
- https://trello.com/c/1uUwxpq6

Surrounding white space in some elements may be desired. Like in scripts or other file content.

## Solution

Do not strip surrounding white space when reading XML CDATA elements. And create CDATA elements when generating XML if an element contains surrounding white space.

## Note

This reworks https://github.com/yast/yast-yast2/pull/1243.

I did some checks and prior to SLE15-SP3 we did preserve all white space in CDATA elements. This also does not pose a problem in script elements. Leading white space is ok there.

So, this pull request fully restores the old behavior.