### PR TITLE
Revert LD_PRELOAD Change

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  8 13:24:14 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Reverted LD_PRELOAD change (GitHub PR#1236) (bsc#1196326)
+- 4.4.46
+
+-------------------------------------------------------------------
 Wed Mar  2 12:00:57 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - New doc: Invoking External Commands in YaST (in doc/)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.45
+Version:        4.4.46
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/scripts/yast2
+++ b/scripts/yast2
@@ -13,11 +13,6 @@
 # wise ncurses. It starts then the module 'menu' which implements
 # the configuration and administration menu.
 
-# bsc#1194996: workaround for "cannot allocate memory in static TLS block"
-if [ -f /usr/lib64/libsuseconnect.so ]; then
-  export LD_PRELOAD="/usr/lib64/libsuseconnect.so $LD_PRELOAD"
-fi
-
 # FATE#317637, bsc#877447: In installation system, we call the installer
 # script directly and then exit
 if [ -f /.instsys.config ]; then


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1196326

## Trello

https://trello.com/c/YlPWQ3YP/


## Problem

PR #1236 added a workaround for a long-standing problem on the aarch64 platform: An error
_Can't load libsuseconnect.so_  due to an error  _cannot allocate memory in static TLS block_.

A well-known workaround in the aarch64 Linux world is to force-load the affected library with `LD_PRELOAD`. That is what that PR did.

But since that is inherited by child processes, it also affects them, considerably adding to their memory footprint since now it force-links (!) _libsuseconnect.so_ to every binary started that way, and YaST starts a lot of external binaries; for example for storage probing.


## Fix

Don't use `LD_PRELOAD`; revert that first workaround.


## Alternative Fix

Use `LD_PRELOAD`, but sanitize it immediately after starting the YaST process (after _libsuseconnect.so_ is already loaded), so child processes don't do that as well:

Fetch the `LD_PRELOAD` environment variable, split it up into its components (it may contain several paths, just like `LD_CONFIG` or `PATH`, remove the part with _libsuseconnect_, put it back together and write it to the process environment, so child processes inherit a sanitized version.


## Why not Use the Alternative Fix?

See https://bugzilla.suse.com/show_bug.cgi?id=1194996#c11:

> The workaround for this was to set LD_PRELOAD in the YaST start script if libsuseconnect.so was found, but that causes new problems: This is inherited by child processes, and now every binary started from YaST also gets this LD_PRELOAD, so they are now also force-linked to libsuseconnect.so.
> 
> YaST uses external programs extensively; among lots of other things, for storage probing. That means that in many cases, storage probing now fails because of this; mostly due to out of memory because libsuseconnect.so (and the Go runtime libs that it uses?) consumes a lot more RAM.
> 
> Not only are we always on the verge of OOM anyway (and we are at the end of the food chain after the kernel, kernel modules, kernel firmware, glibc, libQt and dozens of others), but who knows what other problems this causes. This needs to stop.
> 
> It has been suggested that we should clean up LD_PRELOAD again after the YaST start. But after an internal discussion, we decided against that: It would be adding a hack on top of a hack; a workaround for a workaround. And that might create even more problems.
> 
> The original problem appears in a low-memory scenario only on aarch64; and now the first hack spread the problem to other architectures as well.
> 
> This clearly needs a real solution, not adding hacks on top of hacks. The original problem has been known since early 2019; it even made it to Stack Overflow, where they suggest do set LD_PRELOAD as a workaround.
> 
> After almost 3 years (maybe longer), there must be a real fix for this. It really can't be an acceptable solution to spread those workarounds all over all kinds of software; other projects will have the same problem as well.
> 
> LD_PRELOAD is a debugging tool for desperate situations, a last-ditch effort; it can't be the regular way to go. But recommendations on the web seem to indicate just that for the aarch64 platform.
> 
> It doesn't help the Open Source world if we keep fighting the symptoms and disguise the real problem; this basically forces everyone who ever uses any Golang-based lib to do the same hacky approach, and most of them won't even be aware of follow-up problems for child processes.
> 
> That is why we are going to revert the LD_PRELOAD change. This needs a true fix.


## What will this Break?

SLE products installation with registration on aarch64 in low-RAM setups.


## What will this Fix?

SLE products installation on all other platforms in low-RAM setups.

It was never a problem with enough RAM or in non-SLE installations (because there is no _libsuseconnect.so_).