### PR TITLE
Force package backend

### DIFF
--- a/library/network/src/lib/network/susefirewall.rb
+++ b/library/network/src/lib/network/susefirewall.rb
@@ -557,7 +557,7 @@ module Yast
         @needed_packages_installed = Package.CheckAndInstallPackages([@FIREWALL_PACKAGE])
         log.info "CheckAndInstallPackages -> #{@needed_packages_installed}"
       else
-        @needed_packages_installed = Package.Installed(@FIREWALL_PACKAGE)
+        @needed_packages_installed = Package.Installed(@FIREWALL_PACKAGE, target: :system)
         log.info "Installed -> #{@needed_packages_installed}"
       end
 

--- a/library/network/src/lib/y2firewall/firewalld.rb
+++ b/library/network/src/lib/y2firewall/firewalld.rb
@@ -206,7 +206,7 @@ module Y2Firewall
     def installed?
       return true if @installed
 
-      @installed = Yast::Package.Installed(PACKAGE)
+      @installed = Yast::Package.Installed(PACKAGE, target: :system)
     end
 
     # Check whether the firewalld service is enable or not

--- a/library/network/src/lib/y2firewall/firewalld/api.rb
+++ b/library/network/src/lib/y2firewall/firewalld/api.rb
@@ -91,7 +91,7 @@ module Y2Firewall
       # @return [Boolean] true if the state is running; false otherwise
       def running?
         return false if Yast::Stage.initial
-        return false if !Yast::Package.Installed(PACKAGE)
+        return false if !Yast::Package.Installed(PACKAGE, target: :system)
 
         state == "running"
       end

--- a/library/network/src/modules/DnsServerAPI.pm
+++ b/library/network/src/modules/DnsServerAPI.pm
@@ -52,7 +52,7 @@ textdomain("base");
 
 use YaST::YCP qw( sformat y2milestone y2error y2warning );
 YaST::YCP::Import ("DnsServer");
-YaST::YCP::Import ("Package");
+YaST::YCP::Import ("PackageSystem");
 YaST::YCP::Import ("Service");
 YaST::YCP::Import ("Progress");
 # for reporting errors
@@ -657,15 +657,15 @@ sub UnquoteString {
 sub Init {
     if (Mode->test ()) {
       $package_installed = 1;
-      y2milestone("TestMode -> Package->Installed: ", $package_installed);
+      y2milestone("TestMode -> PackageSystem->Installed: ", $package_installed);
     }
 
     if ($package_installed != -1){
         return $package_installed;
     }
 
-    $package_installed = Package->Installed('yast2-dns-server');
-    y2milestone("Package->Installed: ", $package_installed);
+    $package_installed = PackageSystem->Installed('yast2-dns-server');
+    y2milestone("PackageSystem->Installed: ", $package_installed);
     if ($package_installed == 0){
         y2warning("yast2-dns-server is not installed. Functions of DnsServerAPI will be disabled") 
     }
@@ -2761,7 +2761,7 @@ sub IsServiceConfigurableExternally {
 
     my $service_enabled   = Service->Enabled         ("named");
     my $service_status    = Service->Status          ("named");
-    my $service_installed = Package->Installed ("bind");
+    my $service_installed = PackageSystem->Installed ("bind");
 
     y2milestone (
 	"Enabled: ".$service_enabled.", ".

--- a/library/network/src/modules/NetworkService.rb
+++ b/library/network/src/modules/NetworkService.rb
@@ -124,7 +124,7 @@ module Yast
 
     # Checks if given network backend is available in the system
     def backend_available?(backend)
-      Package.Installed(BACKEND_PKG_NAMES[backend])
+      Package.Installed(BACKEND_PKG_NAMES[backend], target: :system)
     end
 
     alias_method :is_backend_available, :backend_available?

--- a/library/network/test/y2firewall/firewalld_test.rb
+++ b/library/network/test/y2firewall/firewalld_test.rb
@@ -43,14 +43,14 @@ describe Y2Firewall::Firewalld do
 
     it "returns false it the firewalld is not installed" do
       allow(Yast::Package).to receive("Installed")
-        .with(described_class::PACKAGE).and_return(false)
+        .with(described_class::PACKAGE, target: :system).and_return(false)
 
       expect(firewalld.installed?).to eq(false)
     end
 
     it "returns true it the firewalld is installed" do
       allow(Yast::Package).to receive("Installed")
-        .with(described_class::PACKAGE).and_return true
+        .with(described_class::PACKAGE, target: :system).and_return true
 
       expect(firewalld.installed?).to eq(true)
     end

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -53,7 +53,7 @@ module Yast
   # There might a scenario where you want to force Package to work with the real packages. For
   # instance, while reading the configuration during a `clone_system` operation: the mode is still
   # `autoinst_config` but you are dealing with the underlying system. In those cases, you can force
-  # {Package} to work with {PackageSystem}. {Package} to work with {PackageSystem}.
+  # {Package} to work with {PackageSystem}.
   #
   # @example Forcing to check for packages on the underlying system
   #   Yast::Package.Installed("firewalld", target: :system)

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -43,10 +43,10 @@ module Yast
   # ## Prefer Package to PackageSystem
   #
   # Depending on the mode, this module decides if it should interact with PackageSystem (libzypp) or
-  # PackagesProposal. For instance, if you open a module in the AutoYaST UI, calling to
+  # PackageAI (AutoYaST). For instance, if you open a module in the AutoYaST UI, calling to
   # {CheckAndInstallPackages} does not install the package for real. Instead, it adds the package to
-  # the {PackagesProposal} so it gets exported in the profile. However, when running on other modes
-  # (normal, installation, etc.), it just installs the package.
+  # the list of packages to include in the profile. However, when running on other modes (normal,
+  # installation, etc.), it just installs the package.
   #
   # ## Overriding default behavior
   #

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -63,8 +63,7 @@ module Yast
     extend Forwardable
     include Yast::Logger
 
-    def_delegators :backend, :Installed, :Available, :PackageInstalled,
-      :PackageAvailable, :DoInstallAndRemove, :InstallKernel
+    def_delegators :backend, :Available, :PackageAvailable, :DoInstallAndRemove, :InstallKernel
 
     # @!method Available(package)
     #   Determines whether the package is available or not

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -55,6 +55,10 @@ module Yast
   # `autoinst_config` but you are dealing with the underlying system. In those cases, you can force
   # {Package} to work with {PackageSystem}.
   #
+  # If you are accessing this module through YCP (for instance, using Perl), you cannot pass the
+  # :target option. If you need to specify this option, please consider using {PackageSystem} or
+  # {PackageAI} functions directly.
+  #
   # @example Forcing to check for packages on the underlying system
   #   Yast::Package.Installed("firewalld", target: :system)
   #

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -38,30 +38,33 @@ Yast.import "PackageAI"
 Yast.import "PackageSystem"
 
 module Yast
+  # This module implements support to query, install and remove packages.
+  #
+  # ## Prefer Package to PackageSystem
+  #
+  # Depending on the mode, this module decides if it should interact with PackageSystem (libzypp) or
+  # PackagesProposal. For instance, if you open a module in the AutoYaST UI, calling to
+  # {CheckAndInstallPackages} does not install the package for real. Instead, it adds the package to
+  # the {PackagesProposal} so it gets exported in the profile. However, when running on other modes
+  # (normal, installation, etc.), it just installs the package.
+  #
+  # ## Overriding default behavior
+  #
+  # There might a scenario where you want to force Package to work with the real packages. For
+  # instance, while reading the configuration during a `clone_system` operation: the mode is still
+  # `autoinst_config` but you are dealing with the underlying system. In those cases, you can force
+  # {Package} to work with {PackageSystem}. {Package} to work with {PackageSystem}.
+  #
+  # @example Forcing to check for packages on the underlying system
+  #   Yast::Package.Installed("firewalld", target: :system)
+  #
+  # See https://bugzilla.suse.com/show_bug.cgi?id=1196963 for further details.
   class PackageClass < Module
     extend Forwardable
     include Yast::Logger
 
     def_delegators :backend, :Installed, :Available, :PackageInstalled,
       :PackageAvailable, :DoInstallAndRemove, :InstallKernel
-
-    # @!method Installed(package)
-    #   Determines whether the package is provided or not
-    #
-    #   This method checks whether any installed package provides the given "package".
-    #
-    #   @param package [String] Package name
-    #   @return [Boolean] true if the package exists; false otherwise
-    #   @see PackageInstalled
-
-    # @!method PackageInstalled(package)
-    #   Determines whether the package is installed or not
-    #
-    #   This method check just the package's name.
-    #
-    #   @param package [String] Package name
-    #   @return [Boolean] true if the package exists; false otherwise
-    #   @see Installed
 
     # @!method Available(package)
     #   Determines whether the package is available or not
@@ -101,6 +104,32 @@ module Yast
       @last_op_canceled = false
       @installed_packages = []
       @removed_packages = []
+    end
+
+    # Determines whether the package is provided or not
+    #
+    # This method checks whether any installed package provides the given "package".
+    #
+    # @param package [String] Package name
+    # @param target [Symbol,nil] :autoinst or :system. If it is nil,
+    #   it guesses the backend depending on the mode.
+    # @return [Boolean] true if the package exists; false otherwise
+    # @see PackageInstalled
+    def Installed(package, target: nil)
+      find_backend(target).Installed(package)
+    end
+
+    # Determines whether the package is installed or not
+    #
+    # This method check just the package's name.
+    #
+    # @param package [String] Package name
+    # @param target [Symbol,nil] :autoinst or :system. If it is nil,
+    #   it guesses the backend depending on the mode.
+    # @return [Boolean] true if the package exists; false otherwise
+    # @see Installed
+    def PackageInstalled(package, target: nil)
+      find_backend(target).PackageInstalled(package)
     end
 
     # Check if packages are installed
@@ -227,19 +256,23 @@ module Yast
 
     # Are all of these packages installed?
     # @param [Array<String>] packages list of packages
+    # @param target [Symbol,nil] :autoinst or :system. If it is nil,
+    #   it guesses the backend depending on the mode.
     # @return [Boolean] true if yes
-    def InstalledAll(packages)
+    def InstalledAll(packages, target: nil)
       packages = deep_copy(packages)
-      which = Builtins.find(packages) { |p| !Installed(p) }
+      which = Builtins.find(packages) { |p| !Installed(p, target: target) }
       which.nil?
     end
 
     # Is any of these packages installed?
     # @param [Array<String>] packages list of packages
+    # @param target [Symbol,nil] :autoinst or :system. If it is nil,
+    #   it guesses the backend depending on the mode.
     # @return [Boolean] true if yes
-    def InstalledAny(packages)
+    def InstalledAny(packages, target: nil)
       packages = deep_copy(packages)
-      which = Builtins.find(packages) { |p| Installed(p) }
+      which = Builtins.find(packages) { |p| Installed(p, target: target) }
       !which.nil?
     end
 
@@ -427,6 +460,25 @@ module Yast
     # the PackageAI class.
     def backend
       Mode.config ? PackageAI : PackageSystem
+    end
+
+    # Find the backend for the given target
+    #
+    # @param target [Symbol,nil] :autoinst or :system. If it is nil,
+    #   it guesses the backend depending on the mode.
+    def find_backend(target)
+      return backend if target.nil?
+
+      found_backend = case target
+      when :system
+        PackageSystem
+      when :autoinst
+        PackageAI
+      end
+
+      log.warn "select_backend: target '#{target}' is unknown." if found_backend.nil?
+
+      found_backend || backend
     end
   end
 

--- a/library/packages/src/modules/Product.rb
+++ b/library/packages/src/modules/Product.rb
@@ -41,7 +41,7 @@ module Yast
       Yast.import "Stage"
       Yast.import "OSRelease"
       Yast.import "PackageLock"
-      Yast.import "Package"
+      Yast.import "PackageSystem"
     end
 
     # Loads and returns base product property

--- a/library/packages/test/package_test.rb
+++ b/library/packages/test/package_test.rb
@@ -267,6 +267,13 @@ describe Yast::Package do
         expect(subject.InstalledAll(["yast2", "unknown"])).to eq(false)
       end
     end
+
+    context "when the target is set" do
+      it "asks for packages in the corresponding backend" do
+        expect(subject).to receive(:Installed).with("yast2", target: :system)
+        subject.InstalledAll(["yast2"], target: :system)
+      end
+    end
   end
 
   describe "#InstalledAny" do
@@ -287,6 +294,13 @@ describe Yast::Package do
     context "when none of the given packages is installed" do
       it "returns false" do
         expect(subject.InstalledAny(["unknown"])).to eq(false)
+      end
+    end
+
+    context "when the target is set" do
+      it "asks for packages in the corresponding backend" do
+        expect(subject).to receive(:Installed).with("yast2", target: :system)
+        subject.InstalledAny(["yast2"], target: :system)
       end
     end
   end
@@ -467,6 +481,38 @@ describe Yast::Package do
           "", "Should I install random packages?", any_args
         )
         subject.PackageDialog(packages, true, "Should I install random packages?")
+      end
+    end
+  end
+
+  describe "#Installed" do
+    context "when the target is set to :system" do
+      it "delegates to the PackageSystem module" do
+        expect(Yast::PackageSystem).to receive(:Installed).with("firewalld")
+        subject.Installed("firewalld", target: :system)
+      end
+    end
+
+    context "when the target is set to :system" do
+      it "delegates to the PackageAI module" do
+        expect(Yast::PackageAI).to receive(:Installed).with("firewalld")
+        subject.Installed("firewalld", target: :autoinst)
+      end
+    end
+  end
+
+  describe "#PackageInstalled" do
+    context "when the target is set to :system" do
+      it "delegates to the PackageSystem module" do
+        expect(Yast::PackageSystem).to receive(:PackageInstalled).with("firewalld")
+        subject.PackageInstalled("firewalld", target: :system)
+      end
+    end
+
+    context "when the target is set to :system" do
+      it "delegates to the PackageAI module" do
+        expect(Yast::PackageAI).to receive(:PackageInstalled).with("firewalld")
+        subject.PackageInstalled("firewalld", target: :autoinst)
       end
     end
   end

--- a/library/packages/test/product_test.rb
+++ b/library/packages/test/product_test.rb
@@ -7,15 +7,6 @@ require "yaml"
 # Important: Loads data in constructor
 Yast.import "Product"
 
-Yast.import "Mode"
-Yast.import "Stage"
-Yast.import "OSRelease"
-Yast.import "Package"
-Yast.import "Pkg"
-Yast.import "PackageLock"
-Yast.import "Mode"
-Yast.import "Stage"
-
 def load_zypp(file_name)
   file_name = File.join(PACKAGES_FIXTURES_PATH, "zypp", file_name)
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,7 +2,10 @@
 Fri Mar 11 13:05:14 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Extend the Package module to force using PackageSystem or
-  PackageAI without having the mode into account (bsc#1196963).
+  PackageAI without having the mode into account.
+- AutoYaST: properly detect whether firewalld, bind and
+  yast2-dns-server packages are installed when cloning a system
+  (bsc#1196963).
 - 4.4.47
 
 -------------------------------------------------------------------

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Mar 11 13:05:14 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Extend the Package module to force using PackageSystem or
+  PackageAI without having the mode into account (bsc#1196963).
+- 4.4.47
+
+-------------------------------------------------------------------
 Tue Mar  8 13:24:14 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Reverted LD_PRELOAD change (GitHub PR#1236) (bsc#1196326)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.46
+Version:        4.4.47
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
In the recent past, we decided to merge `Package`, `PackageSystem` and `PackageAI`. The idea was to use `Package` as the entry point and rely on `PackageAI` and `PackageSystem`, depending on the situation. However, we found out later that things are not that easy. See [bsc#1196963](https://bugzilla.suse.com/show_bug.cgi?id=1196963).

There might a scenario where you want to force Package to work with the real packages. For instance, while reading the configuration during a `clone_system` operation: the mode is still `autoinst_config` but you are dealing with the underlying system. In those cases, you can force `Package` to work with `PackageSystem`. `Package` to work with `PackageSystem`.

As an escape hatch, we have decided to add an option to Package to override the decision about which module to use. This behavior is now documented in the Package module.