### PR TITLE
Checking File Conflicts using only Words

### DIFF
--- a/library/general/src/lib/ui/delayed_progress_popup.rb
+++ b/library/general/src/lib/ui/delayed_progress_popup.rb
@@ -53,15 +53,16 @@ module Yast
 
     # Constructor.
     #
-    # This also starts the timer with a default (4 seconds) timeout.
-    # Call stop_timer() immediately if that is not desired.
+    # If `auto_start` is `true` (default), this also starts the timer with a
+    # default (4 seconds) timeout.
     #
     # The `close` method must be explicitly called at the end when the progress
     # is finished.
     #
-    # @param delay [Integer,nil] optional delay in seconds
+    # @param delay [Integer,nil]  optional delay in seconds
+    # @param auto_start [Boolean] start the timer immediately
     # @param heading [String,nil] optional popup heading
-    def initialize(delay: nil, heading: nil)
+    def initialize(delay: nil, auto_start: true, heading: nil)
       Yast.import "UI"
       Yast.import "Label"
 
@@ -69,7 +70,8 @@ module Yast
       @heading = heading
       @use_cancel_button = true
       @is_open = false
-      start_timer
+      start_timer if auto_start
+      log.info "Created delayed progress popup"
     end
 
     # A static variant with block, it automatically closes the popup at the end.
@@ -83,8 +85,8 @@ module Yast
     #      sleep(1)
     #    end
     #  end
-    def self.run(delay: nil, heading: nil, &block)
-      popup = new(delay: delay, heading: heading)
+    def self.run(delay: nil, auto_start: true, heading: nil, &block)
+      popup = new(delay: delay, auto_start: auto_start, heading: heading)
       block.call(popup)
     ensure
       popup&.close
@@ -98,6 +100,7 @@ module Yast
     # @param [nil|String] progress_text  optional progress bar label text
     #
     def progress(progress_percent, progress_text = nil)
+      log.info "progress_percent: #{progress_percent}"
       open_if_needed
       return unless open?
 

--- a/library/general/src/lib/ui/delayed_progress_popup.rb
+++ b/library/general/src/lib/ui/delayed_progress_popup.rb
@@ -56,14 +56,38 @@ module Yast
     # This also starts the timer with a default (4 seconds) timeout.
     # Call stop_timer() immediately if that is not desired.
     #
-    def initialize
+    # The `close` method must be explicitly called at the end when the progress
+    # is finished.
+    #
+    # @param delay [Integer,nil] optional delay in seconds
+    # @param heading [String,nil] optional popup heading
+    def initialize(delay: nil, heading: nil)
       Yast.import "UI"
       Yast.import "Label"
 
-      @delay_seconds = 4
+      @delay_seconds = delay || 4
+      @heading = heading
       @use_cancel_button = true
       @is_open = false
       start_timer
+    end
+
+    # A static variant with block, it automatically closes the popup at the end.
+    #
+    # @param delay [Integer,nil] optional delay in seconds
+    # @param heading [String,nil] optional popup heading
+    # @example
+    #  Yast::DelayedProgressPopup.run(delay: 5, heading: "Working...") do |popup|
+    #    10.times do |sec|
+    #      popup.progress(10 * sec, "Working #{sec}")
+    #      sleep(1)
+    #    end
+    #  end
+    def self.run(delay: nil, heading: nil, &block)
+      popup = new(delay: delay, heading: heading)
+      block.call(popup)
+    ensure
+      popup&.close
     end
 
     # Update the progress.

--- a/library/general/src/lib/ui/delayed_progress_popup.rb
+++ b/library/general/src/lib/ui/delayed_progress_popup.rb
@@ -1,0 +1,205 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) 2022 SUSE LLC
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of version 2 of the GNU General Public License as published by the
+# Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# ------------------------------------------------------------------------------
+
+require "yast2/system_time"
+require "yast"
+
+module Yast
+  # Progress popup dialog that only opens after a certain delay, so it never
+  # opens for very short operations (< 4 seconds by default), only when an
+  # operation takes long enough to actually give feedback to the user.
+  #
+  # This is less disruptive than a progress dialog that always opens, and in
+  # most cases, flashes by so fast that the user can't recognize what it says.
+  #
+  # The tradeoff is that it takes a few seconds until there is any visual
+  # feedback (until the delay is expired).
+  #
+  # Notice that this does not use an active timer; the calling application has
+  # to trigger the check for the timeout by calling progress() in regular
+  # intervals.
+  #
+  # You can change the delay by changing the delay_seconds member variable, you
+  # can force the dialog to open with open!, and you can stop and (re-) start
+  # the timer.
+  #
+  # In any case, when done with this progress reporting, call close(). You
+  # don't need to check if it ever opened; close() does that automatically.
+  #
+  # see   examples/delayed_progress_1.rb  for a usage example.
+  #
+  class DelayedProgressPopup
+    include Yast::UIShortcuts
+    include Yast::Logger
+
+    # @return [String] Text for the dialog heading. Default: nil.
+    attr_accessor :heading
+
+    # @return [Integer] Delay (timeout) in seconds.
+    attr_accessor :delay_seconds
+
+    # @return [Boolean] Add a "Cancel" button to the dialog. Default: true.
+    attr_accessor :use_cancel_button
+
+    # Constructor.
+    #
+    # This also starts the timer with a default (4 seconds) timeout.
+    # Call stop_timer() immediately if that is not desired.
+    #
+    def initialize
+      Yast.import "UI"
+      Yast.import "Label"
+
+      @delay_seconds = 4
+      @use_cancel_button = true
+      @is_open = false
+      start_timer
+    end
+
+    # Update the progress.
+    #
+    # If the dialog is not open yet, this opens it if the timeout is expired.
+    #
+    # @param [Integer] progress_percent  numeric progress bar value
+    # @param [nil|String] progress_text  optional progress bar label text
+    #
+    def progress(progress_percent, progress_text = nil)
+      open_if_needed
+      return unless open?
+
+      update_progress(progress_percent, progress_text)
+    end
+
+    # Open the dialog if needed, i.e. if it's not already open and if the timer
+    # expired.
+    #
+    # Notice that progress() does this automatically.
+    #
+    def open_if_needed
+      return if open?
+
+      open! if timer_expired?
+    end
+
+    # Open the dialog unconditionally.
+    def open!
+      log.info "Opening the delayed progress popup"
+      UI.OpenDialog(dialog_widgets)
+      @is_open = true
+      stop_timer
+    end
+
+    # Close the dialog if it is open. Only stop the timer if it is not (because
+    # the timer didn't expire).
+    #
+    # Do not call this if another dialog was opened on top of this one in the
+    # meantime: Just like a normal UI.CloseDialog call, this closes the topmost
+    # dialog; which in that case might not be the right one.
+    #
+    def close
+      stop_timer
+      return unless open?
+
+      UI.CloseDialog
+      @is_open = false
+    end
+
+    # Start or restart the timer.
+    def start_timer
+      @start_time = Yast2::SystemTime.uptime
+    end
+
+    # Stop the timer.
+    def stop_timer
+      @start_time = nil
+    end
+
+    # Check if the dialog is open.
+    def open?
+      @is_open
+    end
+
+    # Check if the timer expired.
+    def timer_expired?
+      return false unless timer_running?
+
+      now = Yast2::SystemTime.uptime
+      now > @start_time + delay_seconds
+    end
+
+    # Check if the timer is running.
+    def timer_running?
+      !@start_time.nil?
+    end
+
+  protected
+
+    # Return a widget term for the dialog widgets.
+    # Reimplement this in inherited classes for a different dialog content.
+    #
+    def dialog_widgets
+      placeholder_label = " " # at least one blank
+      heading_spacing = @heading.nil? ? 0 : 0.4
+      MinWidth(
+        40,
+        VBox(
+          MarginBox(
+            1, 0.4,
+            VBox(
+              dialog_heading,
+              VSpacing(heading_spacing),
+              VCenter(
+                ProgressBar(Id(:progress_bar), placeholder_label, 100, 0)
+              )
+            )
+          ),
+          VSpacing(0.4),
+          dialog_buttons
+        )
+      )
+    end
+
+    # Return a widget term for the dialog heading.
+    def dialog_heading
+      return Empty() if @heading.nil?
+
+      Left(Heading(@heading))
+    end
+
+    # Return a widget term for the dialog buttons.
+    # Reimplement this in inherited classes for different buttons.
+    #
+    # Notice that the buttons only do anything if the calling application
+    # handles them, e.g. with UI.PollInput().
+    #
+    # Don't forget that in the Qt UI, every window has a WM_CLOSE button (the
+    # [x] icon in the window title bar that is meant for closing the window)
+    # that returns :cancel in UI.UserInput() / UI.PollInput().
+    #
+    def dialog_buttons
+      return Empty() unless @use_cancel_button
+
+      ButtonBox(
+        PushButton(Id(:cancel), Opt(:cancelButton), Yast::Label.CancelButton)
+      )
+    end
+
+    # Update the progress bar.
+    def update_progress(progress_percent, progress_text = nil)
+      return unless UI.WidgetExists(:progress_bar)
+
+      UI.ChangeWidget(Id(:progress_bar), :Value, progress_percent)
+      UI.ChangeWidget(Id(:progress_bar), :Label, progress_text) unless progress_text.nil?
+    end
+  end
+end

--- a/library/general/src/lib/ui/examples/delayed_progress_1.rb
+++ b/library/general/src/lib/ui/examples/delayed_progress_1.rb
@@ -1,0 +1,37 @@
+# Example for the DelayedProgressPopup
+#
+# Start with:
+#
+#   y2start ./delayed_progress_1.rb qt
+# or
+#   y2start ./delayed_progress_1.rb ncurses
+#
+
+require "yast"
+require "ui/delayed_progress_popup"
+
+popup = Yast::DelayedProgressPopup.new
+
+# All those parameters are optional;
+# comment out or uncomment to experiment.
+popup.heading = "Deep Think Mode"
+popup.delay_seconds = 2
+# popup.use_cancel_button = false
+
+puts("Nothing happens for #{popup.delay_seconds} seconds, then the popup opens.")
+
+10.times do |sec|
+  puts "#{sec} sec"
+  popup.progress(10 * sec, "Working #{sec}")
+  if popup.open?
+    # Checking for popup.open? is only needed here because otherwise there is
+    # no window at all yet, so UI.WaitForEvent() throws an exception. Normal
+    # applications have a main window at this point.
+
+    event = Yast::UI.WaitForEvent(1000) # implicitly sleeps
+    break if event["ID"] == :cancel
+  else
+    sleep(1)
+  end
+end
+popup.close

--- a/library/general/src/lib/ui/examples/delayed_progress_2.rb
+++ b/library/general/src/lib/ui/examples/delayed_progress_2.rb
@@ -1,0 +1,35 @@
+# Example for the DelayedProgressPopup
+#
+# Start with:
+#
+#   y2start ./delayed_progress_2.rb qt
+# or
+#   y2start ./delayed_progress_2.rb ncurses
+#
+
+require "yast"
+require "ui/delayed_progress_popup"
+
+Yast::DelayedProgressPopup.run(delay: 2, heading: "Deep Think Mode") do |popup|
+  # All those parameters are optional;
+  # comment out or uncomment to experiment.
+  # popup.heading = "Deep Think Mode"
+  # popup.use_cancel_button = false
+
+  puts("Nothing happens for #{popup.delay_seconds} seconds, then the popup opens.")
+
+  10.times do |sec|
+    puts "#{sec} sec"
+    popup.progress(10 * sec, "Working #{sec}")
+    if popup.open?
+      # Checking for popup.open? is only needed here because otherwise there is
+      # no window at all yet, so UI.WaitForEvent() throws an exception. Normal
+      # applications have a main window at this point.
+
+      event = Yast::UI.WaitForEvent(1000) # implicitly sleeps
+      break if event["ID"] == :cancel
+    else
+      sleep(1)
+    end
+  end
+end

--- a/library/general/src/lib/ui/examples/delayed_progress_almost_done.rb
+++ b/library/general/src/lib/ui/examples/delayed_progress_almost_done.rb
@@ -1,0 +1,36 @@
+# Example for the DelayedProgressPopup
+#
+# Start with:
+#
+#   y2start ./delayed_progress_almost_done.rb qt
+# or
+#   y2start ./delayed_progress_almost_done.rb ncurses
+#
+
+require "yast"
+require "ui/delayed_progress_popup"
+
+Yast::DelayedProgressPopup.run(delay: 3, heading: "Deep Think Mode") do |popup|
+  # All those parameters are optional;
+  # comment out or uncomment to experiment.
+  # popup.heading = "Deep Think Mode"
+  # popup.use_cancel_button = false
+
+  puts("This will never open, not even after the #{popup.delay_seconds} sec delay.")
+
+  5.times do |sec|
+    percent = 80 + sec
+    puts "#{sec} sec; progress: #{percent}%"
+    popup.progress(percent, "Working #{sec}")
+    if popup.open?
+      # Checking for popup.open? is only needed here because otherwise there is
+      # no window at all yet, so UI.WaitForEvent() throws an exception. Normal
+      # applications have a main window at this point.
+
+      event = Yast::UI.WaitForEvent(1000) # implicitly sleeps
+      break if event["ID"] == :cancel
+    else
+      sleep(1)
+    end
+  end
+end

--- a/library/packages/src/lib/packages/file_conflict_callbacks.rb
+++ b/library/packages/src/lib/packages/file_conflict_callbacks.rb
@@ -107,7 +107,7 @@ module Packages
       # @param [Fixnum] progress progress in percents
       # @return [Boolean] true = continue, false = abort
       def progress(progress)
-        log.info "File conflict progress: #{progress}%"
+        log.debug "File conflict progress: #{progress}%"
 
         if Yast::Mode.commandline
           Yast::CommandLine.PrintVerboseNoCR("#{Yast::PackageCallbacksClass::CLEAR_PROGRESS_TEXT}#{progress}%")

--- a/library/packages/src/lib/packages/file_conflict_callbacks.rb
+++ b/library/packages/src/lib/packages/file_conflict_callbacks.rb
@@ -62,6 +62,10 @@ module Packages
         nil
       end
 
+      def delayed_progress_popup
+        @@delayed_progress_popup ||= Yast::DelayedProgressPopup.new
+      end
+
       # Handle the file conflict detection start callback.
       def start
         log.info "Starting the file conflict check..."
@@ -71,7 +75,7 @@ module Packages
         if Yast::Mode.commandline
           Yast::CommandLine.PrintVerbose(label)
         else
-          @@delayed_progress_popup = Yast::DelayedProgressPopup.new(heading: label)
+          @@delayed_progress_popup ||= Yast::DelayedProgressPopup.new(heading: label)
         end
       end
 
@@ -84,7 +88,7 @@ module Packages
         if Yast::Mode.commandline
           Yast::CommandLine.PrintVerboseNoCR("#{Yast::PackageCallbacksClass::CLEAR_PROGRESS_TEXT}#{progress}%")
         else
-          @@delayed_progress_popup.progress(progress)
+          delayed_progress_popup.progress(progress)
         end
 
         ui = Yast::UI.PollInput unless Yast::Mode.commandline
@@ -131,9 +135,10 @@ module Packages
       # Handle the file conflict detection finish callback.
       def finish
         log.info "File conflict check finished"
-        return if Yast::Mode.commandline ||  @@delayed_progress_popup.nil?
+        return if Yast::Mode.commandline || @@delayed_progress_popup.nil?
 
-        @@delayed_progress_popup.progress.close
+        @@delayed_progress_popup.close
+        @@delayed_progress_popup = nil
       end
 
       # Construct the file conflicts dialog.

--- a/library/packages/src/lib/packages/file_conflict_callbacks.rb
+++ b/library/packages/src/lib/packages/file_conflict_callbacks.rb
@@ -68,7 +68,7 @@ module Packages
 
       def checking_percent(percent)
         # TRANSLATORS: progress bar label; %1 is the percent value.
-        Yast::Builtins.sformat(_("Checking file conflicts (%1%%)"))
+        Yast::Builtins.sformat(_("Checking file conflicts (%1%%)"), percent)
       end
 
       # Set the label text of the global progress bar, if it exists.
@@ -89,6 +89,7 @@ module Packages
           Yast::CommandLine.PrintVerbose(checking_label)
         else
           update_progress_text(checking_label)
+          sleep(1)
         end
       end
 
@@ -102,6 +103,7 @@ module Packages
           Yast::CommandLine.PrintVerboseNoCR("#{Yast::PackageCallbacksClass::CLEAR_PROGRESS_TEXT}#{progress}%")
         else
           update_progress_text(checking_percent(progress))
+          sleep(1)
         end
 
         ui = Yast::UI.PollInput unless Yast::Mode.commandline

--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -133,12 +133,6 @@ describe Packages::FileConflictCallbacks do
         allow(Yast::Mode).to receive(:commandline).and_return(false)
       end
 
-      # Must come first since this uses a class variable
-      it "creates a delayed progress popup in advance" do
-        expect(Yast::DelayedProgressPopup).to receive(:new).at_least(:once)
-        Packages::FileConflictCallbacks.register
-      end
-
       it "calls the Pkg methods for registering the file conflicts handlers" do
         expect(dummy_pkg).to receive(:CallbackFileConflictStart).at_least(:once)
         expect(dummy_pkg).to receive(:CallbackFileConflictProgress).at_least(:once)


### PR DESCRIPTION
**Rejected in favor of https://github.com/yast/yast-yast2/pull/1250**

We picked some details of this for the final version which became PR #1125: 

Changing the static text of the progress bar label in the "start" callback of the file conflicts check.


-----------------------------

## Original PR

https://github.com/yast/yast-yast2/pull/1250


## Change

This is very much like #1250, but it does not use a `DelayedProgressPopup`, just a textual description of the progress during checking file conflicts.


## Video

https://user-images.githubusercontent.com/11538225/161789739-987d9a1f-2331-45a7-b827-2f8020e44b55.mp4


## Static Screenshot

![checking-12-vs-total-20](https://user-images.githubusercontent.com/11538225/161789851-f2415bc8-38df-43ff-9fc6-03976da62723.jpg)

The text says "Checking File Conflicts (12%)" while the progress bar shows "20%". That confusing.

And the progress bar doesn't move at all.


