### PR TITLE
Show what Product is Being Installed [master / Factory]

### DIFF
--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -100,15 +100,11 @@
 # - release notes viewer
 require "yast"
 require "yast2/system_time"
+require "y2packager/product_spec"
 
 module Yast
   class SlideShowClass < Module
     include Yast::Logger
-
-    module UI_ID
-      TOTAL_PROGRESS = :progressTotal
-      CURRENT_PACKAGE = :progressCurrentPackage
-    end
 
     def main
       Yast.import "UI"
@@ -158,18 +154,21 @@ module Yast
 
     # Start the internal (global) timer.
     #
+    # FIXME: Obsolete published method
     def StartTimer
       nil
     end
 
     # Reset the internal (global) timer.
     #
+    # FIXME: Obsolete published method
     def ResetTimer
       nil
     end
 
     # Stop the internal (global) timer and account elapsed time.
     #
+    # FIXME: Obsolete published method
     def StopTimer
       nil
     end
@@ -184,6 +183,7 @@ module Yast
     # Check if currently the "Slide Show" page is shown
     # @return true if showing details, false otherwise
     #
+    # FIXME: Obsolete published method
     def ShowingSlide
       false
     end
@@ -202,6 +202,8 @@ module Yast
     # Restart the subprogress of the slideshow. This means the
     # label will be set to given text, value to 0.
     # @param [String] text  new label for the subprogress
+    #
+    # FIXME: Obsolete published method
     def SubProgressStart(text); end
 
     # Updates status of the sub-progress in slide show. The new value and label
@@ -210,12 +212,16 @@ module Yast
     #
     # @param [Fixnum] value  new value for the subprogress
     # @param [String] label  new label for the subprogress
+    #
+    # FIXME: Obsolete published method
     def SubProgress(value, label); end
 
     # Restart the global progress of the slideshow. This means the
     # label will be set to given text, value to 0.
     #
     # @param [String] text  new label for the global progress
+    #
+    # FIXME: Obsolete published method
     def GlobalProgressStart(text)
       UpdateGlobalProgress(0, text)
     end
@@ -230,15 +236,15 @@ module Yast
       value ||= @total_progress_value
       label ||= @total_progress_label
 
-      if UI.WidgetExists(UI_ID::TOTAL_PROGRESS)
+      if UI.WidgetExists(:progressTotal)
         if @total_progress_value != value
           @total_progress_value = value
-          UI.ChangeWidget(UI_ID::TOTAL_PROGRESS, :Value, value)
+          UI.ChangeWidget(:progressTotal, :Value, value)
         end
 
         if @total_progress_label != label
           @total_progress_label = label
-          UI.ChangeWidget(UI_ID::TOTAL_PROGRESS, :Label, label)
+          UI.ChangeWidget(:progressTotal, :Label, label)
         end
       else
         log.warn "progressTotal widget missing"
@@ -329,6 +335,7 @@ module Yast
     # Check if the slide show is available. This must be called before trying
     # to access any slides; some late initialization is done here.
     #
+    # FIXME: Obsolete
     def CheckForSlides
       nil
     end
@@ -336,6 +343,7 @@ module Yast
     # Set the slide show text.
     # @param [String] text
     #
+    # FIXME: Obsolete
     def SetSlideText(_text)
       nil
     end
@@ -351,6 +359,7 @@ module Yast
 
     # Create one single item for the CD statistics table
     #
+    # FIXME: Obsolete published method
     def TableItem(id, col1, col2, col3, col4)
       Item(Id(id), col1, col2, col3, col4)
     end
@@ -358,6 +367,7 @@ module Yast
     # Load a slide image + text.
     # @param [Fixnum] slide_no number of slide to load
     #
+    # FIXME: Obsolete
     def LoadSlide(_slide_no)
       nil
     end
@@ -365,29 +375,56 @@ module Yast
     # Check if the current slide needs to be changed and do that if
     # necessary.
     #
+    # FIXME: Obsolete
     def ChangeSlideIfNecessary
       nil
     end
 
-    # widgets for progress bar
-    # @return      A term describing the widgets
+    # Widgets for the progress bar tab
+    # @return  A term describing the widgets
     #
     def progress_widgets
-      HBox(
-        Id(:progress_bar),
-        HSpacing(1),
+      MarginBox(
+        4, 1, # hor/vert
         VBox(
+          product_name_widgets,
           VCenter(
             ProgressBar(
-              Id(UI_ID::TOTAL_PROGRESS),
+              Id(:progressTotal),
               @total_progress_label,
               100,
               @total_progress_value
             )
           )
-        ),
-        HSpacing(0.5)
+        )
       )
+    end
+
+    # Widgets for the product name
+    # @return A term describing the widgets
+    def product_name_widgets
+      text = product_name
+      return Empty() if text.nil? || text.empty?
+
+      MarginBox(
+        0, 1, # hor/vert
+        Left(
+          Label(Id(:productName), text)
+        )
+      )
+    end
+
+    # Name of the base product that is or will be installed
+    # @return [String,nil] Display name of the base product
+    def product_name
+      # Avoid expensive operation in the installed system where this will
+      # always return 'nil' anyway.
+      return nil if Mode.normal
+
+      product = Y2Packager::ProductSpec.selected_base
+      return nil if product.nil?
+
+      product.display_name
     end
 
     # Construct widgets describing a page with the real slide show
@@ -413,6 +450,7 @@ module Yast
 
     # Switch from the 'details' view to the 'slide show' view.
     #
+    # FIXME: Obsolete
     def SwitchToSlideView
       return if ShowingSlide()
 
@@ -426,12 +464,14 @@ module Yast
     end
 
     # Rebuild the details page.
+    # FIXME: Obsolete
     def RebuildDetailsView
       nil
     end
 
     # Switch from the 'slide show' view to the 'details' view.
     #
+    # FIXME: Obsolete
     def SwitchToDetailsView
       nil
     end

--- a/library/packages/test/slide_show_test.rb
+++ b/library/packages/test/slide_show_test.rb
@@ -12,7 +12,7 @@ describe "Yast::SlideShow" do
     allow(::File).to receive(:exist?).and_return(true)
   end
 
-  TOTAL_PROGRESS_ID = Yast::SlideShowClass::UI_ID::TOTAL_PROGRESS
+  TOTAL_PROGRESS_ID = :progressTotal
 
   describe "#UpdateGlobalProgress" do
     before(:each) do

--- a/library/packages/test/slide_show_test.rb
+++ b/library/packages/test/slide_show_test.rb
@@ -6,6 +6,26 @@ Yast.import "SlideShow"
 Yast.import "Slides"
 Yast.import "UI"
 
+# Avoid testing product_name() and the methods that are using it:
+# This will break because we needed to suppress
+#
+#   require "y2packager/product_spec"
+#
+# by overloading Kernel::require in ./test_helper.rb to avoid a cyclic
+# dependency between this package and yast2-packager.
+#
+# It will work when running the unit tests locally, but it will break in an
+# autobuild environment ("rake osc:build", "rake osc:sr") which is called in
+# Jenkins because unlike any real-life system using YaST, an AutoBuild
+# environment will NOT install yast2-packager anyway to satisfy other
+# requirements. So this problem is hard to spot.
+#
+# It might be possible to force it to work with some heavy monkey-patching and
+# instance_double, but for the extent of useful testing that it might bring,
+# this is simply not worthwhile.
+#
+# 2022-05-04 shundhammer
+#
 describe "Yast::SlideShow" do
   before(:each) do
     Yast.y2milestone "--------- Running test ---------"

--- a/library/packages/test/test_helper.rb
+++ b/library/packages/test/test_helper.rb
@@ -2,3 +2,29 @@ require_relative "../../../test/test_helper"
 require "pathname"
 
 PACKAGES_FIXTURES_PATH = Pathname.new(File.dirname(__FILE__)).join("data")
+
+LIBS_TO_SKIP = [
+  "y2packager/product_spec" # used in SlideShow.rb
+].freeze
+
+# Hack to avoid to require some files. Stolen from
+# https://github.com/yast/yast-storage-ng/blob/master/test/spec_helper.rb#L32-L50
+#
+# This is here to avoid a cyclic dependency with yast2-packager at build time.
+# yast2.spec does build-require yast2-packager, so the (Ruby) require for files
+# defined by that package must be avoided.
+#
+# Of course that means that tests might need to use instance() or
+# instance_double() to make the missing classes and methods from those
+# libraries available.
+#
+# Notice that the problem might be hidden for locally running the unit tests,
+# but not when calling them in an Autobuild environment (e.g. "rake osc:build"
+# or "rake osc:sr").
+module Kernel
+  alias_method :old_require, :require
+
+  def require(path)
+    old_require(path) unless LIBS_TO_SKIP.include?(path)
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May  3 14:05:10 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Show what product is being installed (bsc#1196674)
+- 4.5.2
+
+-------------------------------------------------------------------
 Thu Apr  7 11:43:15 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Show file conflict checking progress in delayed popup (bsc#1195608)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.1
+Version:        4.5.2
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -64,6 +64,16 @@ BuildRequires:  yast2-ycp-ui-bindings >= 4.3.3
 BuildRequires:  cpio
 BuildRequires:  rpm
 
+# Intentionally NOT requiring or build-requiring yast2-packager
+# to avoid a cyclic dependency.
+#
+# For the BuildRequires, see test_helper.rb and slide_show_test.rb
+# in library/packages/test/ .
+#
+# For the runtime Requires, it can safely be assumed that every system that
+# does any package installation has yast2-packager from the dependencies of the
+# client module that does that.
+
 # for ag_tty (/bin/stty)
 # for /usr/bin/md5sum
 Requires:       coreutils


### PR DESCRIPTION
## Trello

https://trello.com/c/CeYLzrD1/


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1196674


## Problem

Users installing many machines, especially with AutoYaST, might not be sure which product they are installing when almost everything is automated. They (or some automatism) might or might not have picked the correct AutoYaST profile, but they can't verify that.


## Fix

Show the name of the base product while packages are being installed in the new unified installation progress step, but only during system installation or upgrade (no matter if using AutoYaST or not); not in the installed system.


## Limitations

Only the _base_ product is shown, not any add-on products. This is in line with the reduction of this progress reporting to one single progress bar with only the overall progress, not individual packages.

Notice that many SLE-based products still show their own product name (e.g. "SUSE Linux Enterprise Server 15 Service Pack 4 for SAP"), not just the product they are derived from (just "SUSE Linux Enterprise Server 15 Service Pack 4") because they are genuine base products.


## Test

Manual tests:

- In an installed TW VM: Installing packages in the installed system
- Leap 15.4 installation
- SLE-15 SP4 installation

## Screenshots

![Installing-product-Leap-15 4](https://user-images.githubusercontent.com/11538225/166466600-1b938298-0295-4277-b07c-782d2ba06e0c.png)

_Leap 15.4 installation_

Change since this screenshot: No more bold font for the product name. If we want that, it should be done via QSS which is a lot more flexible.


![Installing-product-SLE-HPC-15-SP4](https://user-images.githubusercontent.com/11538225/166466647-087d4bda-1e03-4482-bac5-35416014b8e8.png)

_SLE-15 SP4 installation (Qt)_

Notice that it really displays the HPC product, not just SLE-15 SP4 which it is based on.


![Installing-product-SLE-HPC-15-SP4-NCurses](https://user-images.githubusercontent.com/11538225/166466797-e7af08ed-0d22-44cd-8723-cc7e90589ad8.png)

_SLE-15 SP4 installation (NCurses)_


## Related PRs

- PR for SLE-15-SP4: https://github.com/yast/yast-yast2/pull/1253
- Fix for the unit tests in AutoBuild (OBS/IBS): https://github.com/yast/yast-yast2/pull/1255