### PR TITLE
Fix Unit Tests in AutoBuild

### DIFF
--- a/library/packages/test/slide_show_test.rb
+++ b/library/packages/test/slide_show_test.rb
@@ -6,6 +6,26 @@ Yast.import "SlideShow"
 Yast.import "Slides"
 Yast.import "UI"
 
+# Avoid testing product_name() and the methods that are using it:
+# This will break because we needed to suppress
+#
+#   require "y2packager/product_spec"
+#
+# by overloading Kernel::require in ./test_helper.rb to avoid a cyclic
+# dependency between this package and yast2-packager.
+#
+# It will work when running the unit tests locally, but it will break in an
+# autobuild environment ("rake osc:build", "rake osc:sr") which is called in
+# Jenkins because unlike any real-life system using YaST, an AutoBuild
+# environment will NOT install yast2-packager anyway to satisfy other
+# requirements. So this problem is hard to spot.
+#
+# It might be possible to force it to work with some heavy monkey-patching and
+# instance_double, but for the extent of useful testing that it might bring,
+# this is simply not worthwhile.
+#
+# 2022-05-04 shundhammer
+#
 describe "Yast::SlideShow" do
   before(:each) do
     Yast.y2milestone "--------- Running test ---------"

--- a/library/packages/test/test_helper.rb
+++ b/library/packages/test/test_helper.rb
@@ -2,3 +2,29 @@ require_relative "../../../test/test_helper"
 require "pathname"
 
 PACKAGES_FIXTURES_PATH = Pathname.new(File.dirname(__FILE__)).join("data")
+
+LIBS_TO_SKIP = [
+  "y2packager/product_spec" # used in SlideShow.rb
+].freeze
+
+# Hack to avoid to require some files. Stolen from
+# https://github.com/yast/yast-storage-ng/blob/master/test/spec_helper.rb#L32-L50
+#
+# This is here to avoid a cyclic dependency with yast2-packager at build time.
+# yast2.spec does build-require yast2-packager, so the (Ruby) require for files
+# defined by that package must be avoided.
+#
+# Of course that means that tests might need to use instance() or
+# instance_double() to make the missing classes and methods from those
+# libraries available.
+#
+# Notice that the problem might be hidden for locally running the unit tests,
+# but not when calling them in an Autobuild environment (e.g. "rake osc:build"
+# or "rake osc:sr").
+module Kernel
+  alias_method :old_require, :require
+
+  def require(path)
+    old_require(path) unless LIBS_TO_SKIP.include?(path)
+  end
+end

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -64,6 +64,16 @@ BuildRequires:  yast2-ycp-ui-bindings >= 4.3.3
 BuildRequires:  cpio
 BuildRequires:  rpm
 
+# Intentionally NOT requiring or build-requiring yast2-packager
+# to avoid a cyclic dependency.
+#
+# For the BuildRequires, see test_helper.rb and slide_show_test.rb
+# in library/packages/test/ .
+#
+# For the runtime Requires, it can safely be assumed that every system that
+# does any package installation has yast2-packager from the dependencies of the
+# client module that does that.
+
 # for ag_tty (/bin/stty)
 # for /usr/bin/md5sum
 Requires:       coreutils


### PR DESCRIPTION
## Problem

Autobuild for this package fails with unit tests:

```
Failed to load Module 'SlideShow' due to: cannot load such file -- y2packager/product_spec
```

https://ci.suse.de/job/yast-yast-yast2-SLE-15-SP4/4/console

## Cause

The .spec file of this package (yast2.spec) does not _require_ or _buildrequire_ yast2-packager, so AutoBuild does not install it in the build environment. But adding it would mean a cyclic dependency between packages _yast2_ (this package) and _yast2-packager_.


## Solution

This adds a workaround for the real-world problem, disregarding the academic problem that a system using the SlideShow does indeed not install _yast2-packager_:

This overrides Ruby `Kernel::require` with a custom version that skips loading some few predefined Ruby libraries; like the one that could not be loaded here.


## Does this Cause Problems?

Not in real life. That SlideShow.rb module that caused the error is only called by YaST clients that install packages, and those clients will all RPM-require _yast2-packager_ anyway.


## Version Bump?

No since it was `rake osc:sr` that failed here as the very last step in Jenkins. The last version never arrived in OBS. This PR is to make that possible.