### PR TITLE
Fix packager dep

### DIFF
--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -427,7 +427,7 @@ module Yast
 
       product.display_name
     rescue LoadError
-      log.info "product spec not available. Probably packager missing"
+      log.info "product spec not available. Probably yast2-packager is missing"
 
       nil
     end

--- a/library/packages/src/modules/SlideShow.rb
+++ b/library/packages/src/modules/SlideShow.rb
@@ -100,7 +100,6 @@
 # - release notes viewer
 require "yast"
 require "yast2/system_time"
-require "y2packager/product_spec"
 
 module Yast
   class SlideShowClass < Module
@@ -421,10 +420,16 @@ module Yast
       # always return 'nil' anyway.
       return nil if Mode.normal
 
+      # lazy load product spec as it lives in packager and maybe is not available
+      require "y2packager/product_spec"
       product = Y2Packager::ProductSpec.selected_base
       return nil if product.nil?
 
       product.display_name
+    rescue LoadError
+      log.info "product spec not available. Probably packager missing"
+
+      nil
     end
 
     # Construct widgets describing a page with the real slide show

--- a/library/packages/test/test_helper.rb
+++ b/library/packages/test/test_helper.rb
@@ -2,29 +2,3 @@ require_relative "../../../test/test_helper"
 require "pathname"
 
 PACKAGES_FIXTURES_PATH = Pathname.new(File.dirname(__FILE__)).join("data")
-
-LIBS_TO_SKIP = [
-  "y2packager/product_spec" # used in SlideShow.rb
-].freeze
-
-# Hack to avoid to require some files. Stolen from
-# https://github.com/yast/yast-storage-ng/blob/master/test/spec_helper.rb#L32-L50
-#
-# This is here to avoid a cyclic dependency with yast2-packager at build time.
-# yast2.spec does build-require yast2-packager, so the (Ruby) require for files
-# defined by that package must be avoided.
-#
-# Of course that means that tests might need to use instance() or
-# instance_double() to make the missing classes and methods from those
-# libraries available.
-#
-# Notice that the problem might be hidden for locally running the unit tests,
-# but not when calling them in an Autobuild environment (e.g. "rake osc:build"
-# or "rake osc:sr").
-module Kernel
-  alias_method :old_require, :require
-
-  def require(path)
-    old_require(path) unless LIBS_TO_SKIP.include?(path)
-  end
-end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri May  6 15:23:06 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Avoid build failures when packager is not available (related to
+  bsc#1196674)
+- 4.4.50
+
+-------------------------------------------------------------------
 Tue May  3 14:05:10 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Show what product is being installed (bsc#1196674)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.49
+Version:        4.4.50
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -64,16 +64,6 @@ BuildRequires:  yast2-ycp-ui-bindings >= 4.3.3
 BuildRequires:  cpio
 BuildRequires:  rpm
 
-# Intentionally NOT requiring or build-requiring yast2-packager
-# to avoid a cyclic dependency.
-#
-# For the BuildRequires, see test_helper.rb and slide_show_test.rb
-# in library/packages/test/ .
-#
-# For the runtime Requires, it can safely be assumed that every system that
-# does any package installation has yast2-packager from the dependencies of the
-# client module that does that.
-
 # for ag_tty (/bin/stty)
 # for /usr/bin/md5sum
 Requires:       coreutils


### PR DESCRIPTION
## Problem

pull request https://github.com/yast/yast-yast2/pull/1253 cause several build failures when module even transitively need SlideShow, but does not need packager to build itself.


## Solution

Load packager library only dynamic and handle if it is not available.

## Testing

- adapted unit tests to demonstrate that mocking of packager is not needed


## Screenshots

not affected

