### PR TITLE
Support managing system in a chroot (bsc#1199840)

### DIFF
--- a/library/control/src/modules/Installation.rb
+++ b/library/control/src/modules/Installation.rb
@@ -214,6 +214,16 @@ module Yast
         @scr_destdir = "/mnt"
       end
 
+      # managing another system in a chroot
+      target_dir = ENV["YAST_TARGET_DIR"] || ""
+      if !target_dir.empty?
+        if File.directory?(target_dir)
+          @destdir = target_dir
+        else
+          abort "Cannot set the target, directory #{target_dir} not found"
+        end
+      end
+
       nil
     end
 

--- a/library/control/test/installation_test.rb
+++ b/library/control/test/installation_test.rb
@@ -23,4 +23,58 @@ describe Yast::Installation do
       subject.sourcedir
     end
   end
+
+  # test the module constructor
+  describe "#Installation (module constructor)" do
+    before do
+      # mock a running system
+      allow(Yast::Stage).to receive(:cont).and_return(false)
+      allow(Yast::Stage).to receive(:initial).and_return(false)
+    end
+
+    before(:each) do
+      # reset the value before each run
+      subject.destdir = "/"
+    end
+
+    context "YAST_TARGET_DIR is not set" do
+      before do
+        expect(ENV).to receive(:[]).with("YAST_TARGET_DIR").and_return(nil)
+      end
+
+      it "sets the 'destdir' to /" do
+        subject.Installation
+        expect(subject.destdir).to eq("/")
+      end
+    end
+
+    context "YAST_TARGET_DIR is set" do
+      let(:target_dir) { "/mnt" }
+      before do
+        expect(ENV).to receive(:[]).with("YAST_TARGET_DIR").and_return(target_dir)
+      end
+
+      context "the target directory exists" do
+        before do
+          expect(File).to receive(:directory?).with(target_dir).and_return(true)
+        end
+
+        it "sets the 'destdir' to the target directory" do
+          subject.Installation
+          expect(subject.destdir).to eq(target_dir)
+        end
+      end
+
+      context "the target directory does not exist" do
+        before do
+          expect(File).to receive(:directory?).with(target_dir).and_return(false)
+        end
+
+        it "aborts with an error" do
+          expect(subject).to receive(:abort)
+          subject.Installation
+        end
+      end
+    end
+  end
 end

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -516,6 +516,23 @@ module Yast
       SCR.Read(path(".target.string"), "/proc/sys/kernel/osrelease").to_s.downcase.include?("-microsoft")
     end
 
+    # Check whether managing another target system. The target system location
+    # is then specified in the Installation.destdir value.
+    #
+    # @note Technically the management can run in a chroot or in a Linux
+    #   container (Docker, Podman,...), or using a Live medium... It does not
+    #   check how it is implemented.
+    #
+    #   The main goal is to distinguish between running in a container and managing
+    #   the container itself or running in a container and managing the host
+    #   system which runs the container.
+    #
+    # @return [Boolean] true if managing another system in chroot/container
+    def chroot_management
+      target_dir = ENV["YAST_TARGET_DIR"] || ""
+      File.directory?(target_dir)
+    end
+
     # map the Arch.architecture to the arch expected by SCC
     RPM_ARCH = {
       "s390_32" => "s390",

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -290,4 +290,42 @@ describe Yast::Arch do
       end
     end
   end
+
+  describe ".chroot_management" do
+    before do
+      expect(ENV).to receive(:[]).with("YAST_TARGET_DIR").and_return(target_dir)
+    end
+
+    context "YAST_TARGET_DIR is set" do
+      let(:target_dir) { "/mnt" }
+
+      before do
+        expect(File).to receive(:directory?).with(target_dir).and_return(target_exists)
+      end
+
+      context "the target directory exists" do
+        let(:target_exists) { true }
+
+        it "returns true" do
+          expect(subject.chroot_management).to eq(true)
+        end
+      end
+
+      context "the target directory does not exist" do
+        let(:target_exists) { false }
+
+        it "returns false" do
+          expect(subject.chroot_management).to eq(false)
+        end
+      end
+    end
+
+    context "YAST_TARGET_DIR is not set" do
+      let(:target_dir) { nil }
+
+      it "returns false" do
+        expect(subject.chroot_management).to eq(false)
+      end
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon May 23 15:10:38 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added experimental infrastructure for managing system in
+  a chroot (bsc#1199840)
+- 4.5.4
+
+-------------------------------------------------------------------
 Fri May  6 15:23:06 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Avoid build failures when packager is not available (related to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.3
+Version:        4.5.4
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

When running YaST in a container we need to somehow detect that YaST should manage the system mounted in the `/mnt` and not the container itself.

## Details

Originally I wanted to detect that we are running in a container, but that's too specific. It should be more generic, in theory you could run YaST in a chroot or using a Live medium. Or you could manage the container itself, not the host system.

## Solution

The target system needs to be set from the outside, YaST itself cannot detect that easily and reliably. The easiest way is to set an environment variable with the location of the mounted target system.

Lets use `YAST_TARGET_DIR` for that.

- Update the `Installation` module constructor to initialize `destdir` according to `YAST_TARGET_DIR`
- Added `Arch.chroot_management` to detect that the `YAST_TARGET_DIR` is set

## Testing

- Tested manually
- The change will be followed by updated `yast2-registration` package which will use the new methods
