### PR TITLE
Package system container

### DIFF
--- a/library/packages/src/modules/PackageSystem.rb
+++ b/library/packages/src/modules/PackageSystem.rb
@@ -49,6 +49,7 @@ module Yast
       Yast.import "Report"
       Yast.import "Stage"
       Yast.import "CommandLine"
+      Yast.import "Installation"
 
       # Was last operation canceled?
       #
@@ -82,7 +83,7 @@ module Yast
 
       PackageLock.Check
       # always initizalize target, it should be cheap according to #45356
-      @target_initialized = Pkg.TargetInit("/", false)
+      @target_initialized = Pkg.TargetInit(Installation.destdir, false)
 
       nil
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jun 16 11:06:09 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Allow to install missing packages in chroot (bsc#1199840)
+- 4.5.5
+
+-------------------------------------------------------------------
 Mon May 23 15:10:38 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added experimental infrastructure for managing system in

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.4
+Version:        4.5.5
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

When running dns-server in container it wants to install bind. But install it to container and not machine itself, so named cannot run.


## Solution

Init properly PackageSystem when root is changed.


## Testing

- *Tested manually*

