### PR TITLE
save_y2logs - check both Packages and Packages.db (bsc#1200831)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jun 24 12:08:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- save_y2logs - check both Packages and Packages.db in
+  /var/lib/rpm (bsc#1200831)
+- 4.5.6
+
+-------------------------------------------------------------------
 Thu Jun 16 11:06:09 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - Allow to install missing packages in chroot (bsc#1199840)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.5
+Version:        4.5.6
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/scripts/save_y2logs
+++ b/scripts/save_y2logs
@@ -98,7 +98,7 @@ if [ -f /mnt/var/log/pbl.log ]; then
 fi
 
 # installed packages
-if [ -f /var/lib/rpm/Packages -a "$(type -p rpm)" ]; then
+if [ -f /var/lib/rpm/Packages -o -f /var/lib/rpm/Packages.db ] && [ "$(type -p rpm)" ]; then
   rpm -qa --qf '%{NAME}-%{VERSION}-%{RELEASE}\t\t\t(%{VENDOR})\t%{DISTRIBUTION}\n' 2>/dev/null | sort >/$TMPDIR/rpm-qa
   LIST_TMP="$LIST_TMP rpm-qa"
 fi


### PR DESCRIPTION
## Problem

- `save_y2logs` might no save the list of installed packages when RPM stores the data in `Packages.db` file (instead of `Packages`). That depends on the RPM which is installed.

## Solution

- Check both file locations

## Testing

Asked @dgdavid for verifying the fix. :smile: 