### PR TITLE
Fixed text mode control center in container (bsc#1199840)

### DIFF
--- a/library/desktop/src/clients/menu.rb
+++ b/library/desktop/src/clients/menu.rb
@@ -66,6 +66,13 @@ module Yast
         "Hidden"
       ]
 
+      # always load the desktop files from the system root
+      if WFM.scr_chrooted?
+        # revert back the chrooting
+        handle = Yast::WFM.SCROpen("chroot=/:scr", false)
+        Yast::WFM.SCRSetDefault(handle)
+      end
+
       Desktop.Read(@Values)
       @Groups = deep_copy(Desktop.Groups)
       @Modules = deep_copy(Desktop.Modules)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jul 22 12:13:13 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Text mode control center: always display the YaST modules
+  installed in the system root (when running in a container
+  display the modules installed in the container) (bsc#1199840)
+- 4.5.7
+
+-------------------------------------------------------------------
 Fri Jun 24 12:08:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - save_y2logs - check both Packages and Packages.db in

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.6
+Version:        4.5.7
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Details

- Always display the YaST modules installed in the system root
- When running in a container display the modules installed in the container (originally it displayed the modules from the host system which might not contain any YaST module)
- 4.5.7

## Notes

- The Qt control center is not affected, it always loads the files from the system root.
- The started YaST modules run in a new separate process so they use the chrooting as expected, they correctly manage the host system

## Screenshots

#### The Original Behavior

![menu_broken](https://user-images.githubusercontent.com/907998/180442400-12cae0b1-71e9-45f0-988b-8b3758019ca5.png)


#### With the Fix Applied

![menu_fixed](https://user-images.githubusercontent.com/907998/180442422-53bca716-3099-4045-94fa-54b148cce0cb.png)

