### PR TITLE
Added method to find a package according to a pattern

### DIFF
--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -231,10 +231,10 @@ module Yast
 
       init_packager
 
-      # NOTE:
-      # - Resolvable.find takes POSIX regexp, later select uses Ruby regexp
-      # - Resolvable.find supports regexps only for dependencies, so we need to
-      # filter result according to package name
+      # NOTE: Resolvable.find
+      # - takes POSIX regexp, later select uses Ruby regexp
+      # - supports regexps only for dependencies, so we need to filter result
+      # according to package name
       Y2Packager::Resolvable.find({ provides_regexp: "^#{pattern}$" }, [:name])
         .select { |p| p.name =~ /\A#{pattern}\z/ }
         .map(&:name)

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -236,7 +236,7 @@ module Yast
       # - Resolvable.find supports regexps only for dependencies, so we need to
       # filter result according to package name
       Y2Packager::Resolvable.find({ provides_regexp: "^#{pattern}$" }, [:name])
-        .select{|p| p.name =~ /\A#{pattern}\z/ }
+        .select { |p| p.name =~ /\A#{pattern}\z/ }
         .map(&:name)
         .uniq
     end

--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -32,6 +32,7 @@
 # <a href="../index.html">.../docs/index.html</a>.
 require "yast"
 require "forwardable"
+require "y2packager/resolvable"
 
 Yast.import "Mode"
 Yast.import "PackageAI"
@@ -219,6 +220,18 @@ module Yast
     def reset
       @installed_packages.clear
       @removed_packages.clear
+    end
+
+    # Tries to find a package according to the pattern
+    #
+    # @param pattern [String] a pattern to match, no escaping done
+    # @return list of matching package names
+    def by_pattern(pattern = "")
+      init_packager
+      Y2Packager::Resolvable.find(provides_regexp: "^#{pattern}$")
+        .select{|p| p.name =~ /\A#{pattern}\z/ }
+        .map(&:name)
+        .uniq
     end
 
     # Are all of these packages available?
@@ -432,6 +445,7 @@ module Yast
       @last_op_canceled
     end
 
+    publish function: :by_pattern, type: "list <string> (string)"
     publish function: :Available, type: "boolean (string)"
     publish function: :Installed, type: "boolean (string)"
     publish function: :DoInstall, type: "boolean (list <string>)"
@@ -457,6 +471,14 @@ module Yast
     publish function: :InstallKernel, type: "boolean (list <string>)"
 
   private
+
+    # Makes sure the package database is initialized.
+    def init_packager
+      Pkg.TargetInitialize(Installation.destdir)
+      Pkg.TargetLoad
+      Pkg.SourceRestore
+      Pkg.SourceLoad
+    end
 
     # If Yast is running in the autoyast configuration mode
     # no changes will be done on the target system by using

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 27 09:40:47 UTC 2022 - Michal Filka <mfilka@suse.com>
+
+- bsc#1200016
+  - added a method for finding a package according to a pattern
+- 4.5.8
+
+-------------------------------------------------------------------
 Fri Jul 22 12:13:13 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Text mode control center: always display the YaST modules

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.7
+Version:        4.5.8
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

The feature was not supported. Some packages do not have "default" placeholder but uses versions in name instead (php8), so simple patterns comes handy.

- https://bugzilla.suse.com/show_bug.cgi?id=1200016

## Solution

implemented simple wrapper which uses y2packager/resolvable


## Testing

- *Tested manually*


