### PR TITLE
Fixed libzypp initialization (related to bsc#1199840)

### DIFF
--- a/library/packages/src/modules/PackageSystem.rb
+++ b/library/packages/src/modules/PackageSystem.rb
@@ -154,8 +154,8 @@ module Yast
       Builtins.y2debug("toinstall: %1, toremove: %2", toinstall, toremove)
       return false if !PackageLock.Check
 
-      EnsureSourceInit()
       EnsureTargetInit()
+      EnsureSourceInit()
       ok = true
 
       Yast.import "Label"
@@ -272,9 +272,20 @@ module Yast
       true
     end
 
+    # Install and remove requested packages
+    # @note The packages are by default installed also with soft dependencies
+    #   (like Recommends or Supplements)
+    # @param toinstall [Array<String>] the list of package to install (package names)
+    # @param toremove [Array<String>] the list of package to remove (package names)
+    # @return [Boolean] `true`` on success, `false` on error
     def DoInstallAndRemove(toinstall, toremove)
-      toinstall = deep_copy(toinstall)
-      toremove = deep_copy(toremove)
+      return false if !PackageLock.Check
+
+      # the DoInstallAndRemoveInt() call initializes the libzypp internally
+      # but we need initialized libzypp earlier to change the solver settings
+      EnsureTargetInit()
+      EnsureSourceInit()
+
       # remember the current solver flags
       solver_flags = Pkg.GetSolverFlags
 
@@ -292,6 +303,7 @@ module Yast
     # Is a package available?
     # @return true if yes (nil = no package source available)
     def Available(package)
+      EnsureTargetInit()
       EnsureSourceInit()
 
       # at least one enabled repository present?
@@ -362,6 +374,7 @@ module Yast
     # Is a package available? Checks only package name, not list of provides.
     # @return true if yes (nil = no package source available)
     def PackageAvailable(package)
+      EnsureTargetInit()
       EnsureSourceInit()
 
       # at least one enabled repository present?

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 27 13:41:45 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed libzypp initialization, in the YaST container read the
+  configured repositories from the host (related to bsc#1199840)
+- 4.5.8
+
+-------------------------------------------------------------------
 Fri Jul 22 12:13:13 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Text mode control center: always display the YaST modules

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.7
+Version:        4.5.8
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

- YaSt when running in a container fails installing the needed packages
- The problem is that it uses the repositories configured in the container, not the repositories from the host

## Details

It turned out that the problem is in the `Pkg.GetSolverFlags` call which is called *before* initializing libzypp. In that case libzypp automatically initializes itself, but it uses by default the system root (`/`) which is the container. The libzypp initialization later done from YaST does not change anything as libzypp is already initialized.

Also it initialized the libzypp in a wrong order. The libzypp target always needs to be initialized *before* initializing the libzypp sources. The reason is that the target defines which GPG keys and config file (`zypp.conf`) are used. When initializing in wrong order you might get GPG signature errors.


## Solution

- Explicitly initialize libzypp before setting the solver flags
- Additionally I added some missing target initialization calls to ensure the target is always properly initialized.


## Testing

- Tested manually, now running `yast2-kdump` properly finds and installs the `kdump` package into the host system
- Also manually tested the `Available` and `PackageAvailable` calls in the debugger session

