### PR TITLE
Do not crash when checking file conflicts and delayed progress popup is not shown

### DIFF
--- a/library/packages/src/lib/packages/file_conflict_callbacks.rb
+++ b/library/packages/src/lib/packages/file_conflict_callbacks.rb
@@ -129,12 +129,14 @@ module Packages
 
         if Yast::Mode.commandline
           Yast::CommandLine.PrintVerboseNoCR("#{Yast::PackageCallbacksClass::CLEAR_PROGRESS_TEXT}#{progress}%")
-        else
-          delayed_progress_popup.progress(progress)
+          return true
         end
 
-        ui = Yast::UI.PollInput unless Yast::Mode.commandline
-        log.info "User input in file conflict progress (#{progress}%): #{ui}" if ui
+        delayed_progress_popup.progress(progress)
+        return true unless delayed_progress_popup.open?
+
+        ui = Yast::UI.PollInput
+        log.info "User input in file conflict progress (#{progress}%): #{ui}"
 
         ui != :abort && ui != :cancel
       end

--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -213,22 +213,38 @@ describe Packages::FileConflictCallbacks do
         progress_cb.call(progress)
       end
 
-      it "returns false to abort if user clicks Abort" do
-        expect(Yast::UI).to receive(:PollInput).and_return(:abort)
+      context "when the delayed progress popup is open" do
+        before do
+          allow_any_instance_of(Yast::DelayedProgressPopup).to receive(:open?).and_return(true)
+        end
 
-        expect(progress_cb.call(progress)).to eq(false)
+        it "returns false to abort if user clicks Abort" do
+          expect(Yast::UI).to receive(:PollInput).and_return(:abort)
+
+          expect(progress_cb.call(progress)).to eq(false)
+        end
+
+        it "returns true to continue when no user input" do
+          expect(Yast::UI).to receive(:PollInput).and_return(nil)
+
+          expect(progress_cb.call(progress)).to eq(true)
+        end
+
+        it "returns true to continue on unknown user input" do
+          expect(Yast::UI).to receive(:PollInput).and_return(:next)
+
+          expect(progress_cb.call(progress)).to eq(true)
+        end
       end
 
-      it "returns true to continue when no user input" do
-        expect(Yast::UI).to receive(:PollInput).and_return(nil)
+      context "when the delayed progress popup is NOT open" do
+        before do
+          allow_any_instance_of(Yast::DelayedProgressPopup).to receive(:open?).and_return(false)
+        end
 
-        expect(progress_cb.call(progress)).to eq(true)
-      end
-
-      it "returns true to continue on unknown user input" do
-        expect(Yast::UI).to receive(:PollInput).and_return(:next)
-
-        expect(progress_cb.call(progress)).to eq(true)
+        it "returns true to continue" do
+          expect(progress_cb.call(progress)).to eq(true)
+        end
       end
     end
   end

--- a/library/packages/test/file_conflict_callbacks_test.rb
+++ b/library/packages/test/file_conflict_callbacks_test.rb
@@ -242,6 +242,10 @@ describe Packages::FileConflictCallbacks do
           allow_any_instance_of(Yast::DelayedProgressPopup).to receive(:open?).and_return(false)
         end
 
+        it "does not ask for user input" do
+          expect(Yast::UI).to_not receive(:PollInput)
+        end
+
         it "returns true to continue" do
           expect(progress_cb.call(progress)).to eq(true)
         end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 28 09:40:31 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Do not ask for user input while checking file conflicts if the
+  delayed progress popup is not shown (bsc#1201924)
+- 4.5.10
+
+-------------------------------------------------------------------
 Thu Jul 28 07:57:14 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - bsc#1200016

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.9
+Version:        4.5.10
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

YaST crash when checking file conflicts because of a `Yast::UI.PollInput` call when there is no UI (the requirements for displaying the [Yast::DelayedProgressPopup](https://github.com/yast/yast-yast2/blob/c43b61f0fbb7c9a981f66de3b1c547e191552527/library/general/src/lib/ui/delayed_progress_popup.rb) were not fulfilled)

![nodialog](https://user-images.githubusercontent.com/1691872/181477162-95233bd1-f335-4860-8674-558d1bb9ebd3.png)


- https://bugzilla.suse.com/show_bug.cgi?id=1201924
- https://openqa.suse.de/tests/9223678#step/yast2_apparmor/11 (internal and temporary link)
- https://trello.com/c/JijjL7Fx (internal link)

## Solution

Fix the [Yast::FileConflictCallbacks#progress method](https://github.com/yast/yast-yast2/blob/161f0cc260acbc8d810657f380510e2c2be3f02d/library/packages/src/lib/packages/file_conflict_callbacks.rb#L127-L140) for polling user input only if the delayed progress popup dialog is open.

## Testing

- Added a new unit test
- Tested manually

---

Related to https://github.com/yast/yast-yast2/pull/1252

