### PR TITLE
NetworkService enforce selected network service is enabled during installation (bsc#1202479)

### DIFF
--- a/library/network/src/modules/NetworkService.rb
+++ b/library/network/src/modules/NetworkService.rb
@@ -238,10 +238,11 @@ module Yast
     end
 
     # Helper to apply a change of the network service
-    def EnableDisableNow
-      return if !Modified()
+    # @param force [Boolean] whether the service should forced to be enabled or not
+    def EnableDisableNow(force: false)
+      return if !force && !Modified()
 
-      if current_name
+      if current_name && Modified()
         stop_service(current_name)
         disable_service(current_name)
       end

--- a/library/network/src/modules/NetworkService.rb
+++ b/library/network/src/modules/NetworkService.rb
@@ -240,7 +240,7 @@ module Yast
     # Helper to apply a change of the network service
     # @param force [Boolean] whether the service should forced to be enabled or not
     def EnableDisableNow(force: false)
-      return if !force && !Modified()
+      return unless force || Modified()
 
       if current_name && Modified()
         stop_service(current_name)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep  1 08:08:30 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Allow to force an enablement of the selected network service even
+  when the selected service has not been modified (bsc#1202479)
+- 4.4.52
+
+-------------------------------------------------------------------
 Wed Aug 31 06:47:29 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - Do not ask for user input while checking file conflicts if the

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,8 +1,9 @@
 -------------------------------------------------------------------
 Thu Sep  1 08:08:30 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
-- Allow to force an enablement of the selected network service even
-  when the selected service has not been modified (bsc#1202479)
+- Added a parameter to NetworkService.EnableDisableNow method in
+  order to ensure that the selected network service is enabled even
+  when the selection has not been modified (bsc#1202479)
 - 4.4.52
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.4.51
+Version:        4.4.52
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

During installation, if apparently the selected network service has not been modified (wicked is default backend) the service is not enabled explicitly in the target system which could end with it disabled. 

- https://bugzilla.suse.com/show_bug.cgi?id=1202479


## Solution

Added a parameter in order to force an enablement of the selected network service even when if has not been modified.

## Testing

- *Added a new unit test*
- *Tested manually*

