### PR TITLE
Container-compatible check for the journal client

### DIFF
--- a/library/system/src/lib/yast2/clients/view_anymsg.rb
+++ b/library/system/src/lib/yast2/clients/view_anymsg.rb
@@ -165,8 +165,14 @@ module Yast
           focus:   :no
         ) == :yes
 
-        res && Package.Install("yast2-journal")
+        res && journal_client?
       end
+    end
+
+    # Tries to ensure the 'journal' client is available, even installing additional
+    # packages if needed
+    def journal_client?
+      WFM.ClientExists("journal") || Package.Install("yast2-journal")
     end
 
     def dialog_content

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Sep 28 12:22:59 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
+
+- Better detection of YaST2 Journal (related to bsc#1199840).
+- 4.5.15
+
+-------------------------------------------------------------------
 Fri Sep 16 10:12:41 UTC 2022 - Michal Filka <mfilka@suse.com>
 
 - bsc#1200016

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.14
+Version:        4.5.15
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

When trying to open certain deprecated log files, the `view_anymsg` client may suggest to install `yast2-journal`. It basically does the following:

- It asks the user whether `journal` should be called instead.
- In case `journal` is not installed, it installs it (if possible).
- Open `journal` unless is not there and installation failed.

That mechanism is quite broken when `view_anymsg` is containerized. The root of the problem is that `view_anymsg` relies on `Package.Install("yast2-journal")` without previously checking whether the client is already there. Since YaST's package manager checks for packages in the host system, it concludes `yast2-journal` is not available and the whole process fails even if the `journal` client is actually part of the same container.

## Solution

Check for the existence of the `journal` client before resorting to `Package.Install`. If that client is included in the container (which is always the case in the official YaST containers), then everything will work. If the client is there then there is no need to check for the package.

NOTE: if the container does not contain the `journal` client then this pull request fixes nothing and the current (broken) behavior remains. But that's a theoretical problem because all the official YaST containers include `yast2-journal`.

## Testing

- Extended unit tests
- Manually tested in a non containerized YaST (nothing has changed).
- Manually tested with a containerized YaST on top of ALP (it fixes the problem, the `journal` client opens correctly).
