### PR TITLE
Small fix in documentation of ProposalClient

### DIFF
--- a/library/general/src/lib/installation/proposal_client.rb
+++ b/library/general/src/lib/installation/proposal_client.rb
@@ -172,10 +172,6 @@ module Installation
     #     This module just caused a change of the root partition.
     #     This is only relevant for the "root part" module.
     #
-    #   * **`"help"`** [String, nil] ---
-    #     Help text for this module which appears in the standard dialog
-    #     help (particular helps for modules sorted by presentation order).
-    #
     #   * **`"trigger"`** [Hash, nil] defines circumstances when the proposal
     #     should be called again at the end. For instance, when partitioning or
     #     software selection changes. Mandatory keys of the trigger are:
@@ -272,6 +268,10 @@ module Installation
     #   * **`"id"`** [String] ---
     #     A programmer-readable unique identifier for this section. This is not
     #     auto-generated to keep the log file readable.
+    #
+    #   * **`"help"`** [String, nil] ---
+    #     Help text for this module which appears in the standard dialog
+    #     help (particular helps for modules sorted by presentation order).
     #
     #   This map may be empty. In this case, this proposal section will silently
     #   be ignored. Proposal modules may use this if there is no useful proposal


### PR DESCRIPTION
## Problem

In theory, the different proposal clients displayed in the installation summary have the option to incorporate their own help texts to the general help of the summary screen. The mechanism, which BTW was broken (fixed in a separate pull request, see below), is based on the hashes provided by the corresponding proposal clients. But the documentation at `Installation::ProposalClient` was wrong. The "help" element should be part of the "description" hash, not of the "make_proposal" one.

## Solution

Fix the documentation by moving the "help" keyword to the right place.

## Related Pull Requests

- https://github.com/yast/yast-installation/pull/1060 fixes the broken mechanism, which has always used the "description" hash (the pull request does not change that).