### PR TITLE
remove #postprocess_url from RelURL class

### DIFF
--- a/library/general/src/lib/yast2/rel_url.rb
+++ b/library/general/src/lib/yast2/rel_url.rb
@@ -104,7 +104,6 @@ module Yast2
         ret.path = absolute_path
       end
 
-      postprocess_url(ret)
       ret
     end
 
@@ -118,18 +117,6 @@ module Yast2
       # URI requires absolute path
       url.path = File.join("/", url.host, url.path)
       url.host = nil
-    end
-
-    # a reverse method to "preprocess_url", fix the URL if it is a "file://" URL
-    def postprocess_url(url)
-      return if url.scheme != "file" && !url.host.nil? && !url.host.empty?
-
-      path = url.path.sub(/\A\/+/, "").split("/")
-      url.host = path.shift
-
-      rest = File.join(path)
-      rest.prepend("/") unless rest.empty?
-      url.path = rest
     end
   end
 end

--- a/library/general/test/yast2/rel_url_test.rb
+++ b/library/general/test/yast2/rel_url_test.rb
@@ -64,7 +64,22 @@ describe Yast2::RelURL do
 
     it "returns the relative URL if the base URL is empty" do
       relurl = Yast2::RelURL.new("", "relurl://test")
-      expect(relurl.absolute_url.to_s).to eq("relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("relurl:/test")
+    end
+
+    it "relurl can have 1 slash (relurl:/)" do
+      relurl = Yast2::RelURL.new("", "relurl:/test")
+      expect(relurl.absolute_url.to_s).to eq("relurl:/test")
+    end
+
+    it "relurl can have 2 slashes (relurl://)" do
+      relurl = Yast2::RelURL.new("", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("relurl:/test")
+    end
+
+    it "relurl can have 3 slashes (relurl:///)" do
+      relurl = Yast2::RelURL.new("", "relurl:///test")
+      expect(relurl.absolute_url.to_s).to eq("relurl:/test")
     end
 
     it "returns empty URL if both relative and base URLs are empty" do
@@ -179,9 +194,14 @@ describe Yast2::RelURL do
       expect(relurl.absolute_url.to_s).to eq("ftp://example.com/test")
     end
 
-    it "works with cd:// URL" do
-      relurl = Yast2::RelURL.new("cd://", "relurl://test")
-      expect(relurl.absolute_url.to_s).to eq("cd://test")
+    it "works with cd:/ URL" do
+      relurl = Yast2::RelURL.new("cd:/", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("cd:/test")
+    end
+
+    it "corrects cd:// URL to cd:/" do
+      relurl = Yast2::RelURL.new("cd:/", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("cd:/test")
     end
 
     it "works with cifs:// URL" do
@@ -194,19 +214,24 @@ describe Yast2::RelURL do
       expect(relurl.absolute_url.to_s).to eq("nfs://server/export/path/test")
     end
 
-    it "works with file:// base URL" do
+    it "works with file:/ base URL" do
+      relurl = Yast2::RelURL.new("file:/foo/bar", "relurl://test")
+      expect(relurl.absolute_url.to_s).to eq("file:///foo/bar/test")
+    end
+
+    it "corrects file:// base URL to file:///" do
       relurl = Yast2::RelURL.new("file://foo/bar", "relurl://test")
-      expect(relurl.absolute_url.to_s).to eq("file://foo/bar/test")
+      expect(relurl.absolute_url.to_s).to eq("file:///foo/bar/test")
     end
 
     it "works with file:/// base URL" do
       relurl = Yast2::RelURL.new("file:///", "relurl://test")
-      expect(relurl.absolute_url.to_s).to eq("file://test")
+      expect(relurl.absolute_url.to_s).to eq("file:///test")
     end
 
-    it "goes up with file:// base URL properly" do
-      relurl = Yast2::RelURL.new("file://foo/bar", "relurl://../../test")
-      expect(relurl.absolute_url.to_s).to eq("file://test")
+    it "follows '..' with file:/ base URL properly" do
+      relurl = Yast2::RelURL.new("file:/foo/bar", "relurl://../../test")
+      expect(relurl.absolute_url.to_s).to eq("file:///test")
     end
 
     it "adds the requested path to the absolute URL" do
@@ -229,7 +254,7 @@ describe Yast2::RelURL do
       # might not be exactly what you would expect as the result but this is a corner
       # case, do not overengineer the code, the most important fact is that it does
       # not crash and the result is a valid file path
-      expect(relurl.absolute_url("foo/bar").to_s).to eq("//foo/bar")
+      expect(relurl.absolute_url("foo/bar").to_s).to eq("/foo/bar")
     end
   end
 
@@ -238,7 +263,7 @@ describe Yast2::RelURL do
       allow(Yast::InstURL).to receive(:installInf2Url).and_return(inst_url)
     end
 
-    let(:rel_url) { "relurl://test" }
+    let(:rel_url) { "relurl:/test" }
     subject { Yast2::RelURL.from_installation_repository(rel_url) }
 
     context "during installation" do

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Oct 14 14:54:58 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
+
+- remove #postprocess_url from RelURL class (jsc#SLE-22578, jsc#SLE-24584)
+- 4.5.17
+
+-------------------------------------------------------------------
 Thu Oct  6 13:48:28 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - add Yast::ReducedRecorder for Cheetah to filter out certain streams to

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.16
+Version:        4.5.17
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

- https://trello.com/c/CAytlL3W
- https://jira.suse.com/browse/SLE-22578
- https://jira.suse.com/browse/SLE-24584

`Yast2::RelURL` does a nice handling of relative URLs. But `#postprocess_url` messes up the results and always returns URLs starting with `//` (exactly two slashes). This is wrong.

Ruby's URI class works just fine. Just leave it at that. If YaST really relies on something like `file://foo/bar` this should be fixed in YaST (but I don't think this is the case).

## See also

- https://github.com/openSUSE/linuxrc/pull/299
- https://github.com/yast/yast-installation/pull/1063
- https://github.com/yast/yast-autoinstallation/pull/852