### PR TITLE
Reduced recorder

### DIFF
--- a/library/system/src/lib/yast2/execute.rb
+++ b/library/system/src/lib/yast2/execute.rb
@@ -1,4 +1,3 @@
-
 # ***************************************************************************
 #
 # Copyright (c) 2015 SUSE LLC
@@ -250,7 +249,6 @@ module Yast
   # specific recorder which can be used when some sensitive information that
   # should not go to log
   class ReducedRecorder < Cheetah::DefaultRecorder
-
     # @param skip [Array<Symbol>|Symbol] possible symbols are `:stdin`,
     #   `:stdout`, `:stderr` and `:args`. Those streams won't be recorded.
     def initialize(skip: [], logger: Y2Logger.instance)
@@ -261,16 +259,17 @@ module Yast
       skip.each do |m|
         method = PARAM_MAPPING[m]
         raise ArgumentError, "Invalid value '#{m.inspect}'" unless method
-        self.define_singleton_method(method) {|_|}
+
+        define_singleton_method(method) { |_| } # intentionally empty
       end
     end
 
     PARAM_MAPPING = {
-      stdin: :record_stdin,
+      stdin:  :record_stdin,
       stdout: :record_stdout,
       stderr: :record_stderr,
-      args: :record_commands
-    }
+      args:   :record_commands
+    }.freeze
     private_constant :PARAM_MAPPING
   end
 end

--- a/library/system/src/lib/yast2/execute.rb
+++ b/library/system/src/lib/yast2/execute.rb
@@ -32,6 +32,9 @@ module Yast
   # It also globally switches the default Cheetah logger to
   # {http://www.rubydoc.info/github/yast/yast-ruby-bindings/Yast%2FLogger Y2Logger}.
   #
+  # To limit logging sensitive input/output/arguments,
+  # you can pass a {ReducedRecorder} as the *recorder* option.
+  #
   # @example Methods of this class can be chained.
   #
   #   Yast::Execute.locally!.stdout("ls", "-l")

--- a/library/system/src/lib/yast2/execute.rb
+++ b/library/system/src/lib/yast2/execute.rb
@@ -254,7 +254,7 @@ module Yast
     def initialize(skip: [], logger: Y2Logger.instance)
       super(logger)
 
-      skip = [skip] unless skip.is_a?(Array)
+      skip = Array(skip)
 
       skip.each do |m|
         method = PARAM_MAPPING[m]

--- a/library/system/test/execute_test.rb
+++ b/library/system/test/execute_test.rb
@@ -148,3 +148,37 @@ describe Yast::Execute do
     end
   end
 end
+
+describe Yast::ReducedRecorder do
+  let(:logger) { double(debug: nil, info: nil, warn: nil, error: nil) }
+
+  it "skips logging stdin if :stdin is passed" do
+    expect(logger).to_not receive(:info).with(/secret/i)
+    recorder = described_class.new(skip: :stdin, logger: logger)
+
+    Yast::Execute.locally!("echo", stdin: "secret", recorder: recorder)
+  end
+
+  it "skips logging stdout if :stdout is passed" do
+    expect(logger).to_not receive(:info).with(/secret/i)
+    recorder = described_class.new(skip: [:stdout, :args], logger: logger)
+
+    Yast::Execute.locally!("echo", "secret", recorder: recorder)
+  end
+
+  it "skips logging stderr if :stderr is passed" do
+    expect(logger).to_not receive(:error).with(/secret/i)
+    recorder = described_class.new(skip: [:stderr, :args], logger: logger)
+
+    Yast::Execute.locally!("cat", "/dev/supersecretfile", recorder: recorder,
+      allowed_exitstatus: 1)
+  end
+
+  it "skips logging of arguments if :args are passed" do
+    expect(logger).to_not receive(:info).with(/secret/i)
+    recorder = described_class.new(skip: [:args], logger: logger)
+
+    Yast::Execute.locally!("false", "secret", recorder: recorder,
+      allowed_exitstatus: 1)
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Thu Oct  6 13:48:28 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
-- add Cheetah recorder class that can filter out certain streams to
+- add Yast::ReducedRecorder for Cheetah to filter out certain streams to
   be able to not log sensitive information (bsc#1201962)
 - 4.5.16
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct  6 13:48:28 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- add Cheetah recorder class that can filter out certain streams to
+  be able to not log sensitive information (bsc#1201962)
+- 4.5.16
+
+-------------------------------------------------------------------
 Wed Sep 28 12:22:59 UTC 2022 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Better detection of YaST2 Journal (related to bsc#1199840).

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.15
+Version:        4.5.16
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

Cheetah by default logs all input and output from commands and also arguments. It can contain sensitive information.

- https://bugzilla.suse.com/show_bug.cgi?id=1201962


## Solution

Add specific cheetah logger class that can filter out certain streams.

## Testing

- *Added a new unit test*
- *Tested manually*

