### PR TITLE
Improve logging, use log.group in ProductControl (bsc#1204625)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Oct 25 08:32:48 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Improve logging in the ProductControl module, use the new
+  "log.group" call to group logs for each workflow step
+  (bsc#1204625)
+- 4.5.18
+
+-------------------------------------------------------------------
 Fri Oct 14 14:54:58 UTC 2022 - Steffen Winterfeldt <snwint@suse.com>
 
 - remove #postprocess_url from RelURL class (jsc#SLE-22578, jsc#SLE-24584)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -54,8 +54,8 @@ BuildRequires:  yast2-pkg-bindings >= 4.3.7
 BuildRequires:  rubygem(%rb_default_ruby_abi:yast-rake)
 # for XML module
 BuildRequires:  rubygem(%rb_default_ruby_abi:nokogiri)
-# yast/rspec/helpers.rb
-BuildRequires:  yast2-ruby-bindings >= 4.4.7
+# log.group call
+BuildRequires:  yast2-ruby-bindings >= 4.5.4
 BuildRequires:  yast2-testsuite
 # Nested items in tables
 BuildRequires:  yast2-ycp-ui-bindings >= 4.3.3
@@ -90,8 +90,8 @@ Requires:       yast2-hardware-detection
 Requires:       yast2-perl-bindings
 # Pkg.Resolvables() with "path" search support
 Requires:       yast2-pkg-bindings >= 4.3.7
-# for y2start
-Requires:       yast2-ruby-bindings >= 3.2.10
+# log.group
+Requires:       yast2-ruby-bindings >= 4.5.4
 # Nested items in tables
 Requires:       yast2-ycp-ui-bindings >= 4.3.3
 Requires:       yui_backend


### PR DESCRIPTION
## Problem

- The installation log is hardly readable, it is difficult to navigate, it is not clear where each installation step starts and finishes
- Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1204625
- Related PR: https://github.com/yast/yast-ruby-bindings/pull/287

## Review Notes

- Use the "Hide whitespace" diff option otherwise the diff is too long and harder to read.
- Simply use [this link]()

## Solution

- Use the new `log.group` call and group the logs for each executed step

## Testing

- Tested manually
- See the [example log from TW installation](https://lslezak.github.io/ylogviewer/?log_url=https%3A%2F%2Fgist.githubusercontent.com%2Flslezak%2Fd36a2a15b9ccd49f035c7e51b4818ee5%2Fraw%2Fa8f2822f608f7ae0bbabb3dbe457b5202e21da25%2Fy2log-tw-installation.tar.xz) how it works (click the "Load URL" button to load the example log then scroll to the bottom)


