### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/library/cwm/test/cwm_test.rb
+++ b/library/cwm/test/cwm_test.rb
@@ -48,6 +48,7 @@ describe Yast::CWMClass do
 
   let(:test_stringterm) { VBox(HBox("w1")) }
   let(:widget_names) { ["w1", "w2"] }
+  let(:event) { { "ID" => :my_event_id } }
   let(:test_widgets) do
     {
       "w1" => {
@@ -158,9 +159,9 @@ describe Yast::CWMClass do
   # used by CWMTab and CWM::ReplacePoint
   describe "#saveWidgets" do
     it "calls store methods" do
-      expect(self).to receive(:generic_save).with("w1", "ID" => :event)
-      expect(self).to receive(:w2_store).with("w2", "ID" => :event)
-      subject.saveWidgets(run_widgets, "ID" => :event)
+      expect(self).to receive(:generic_save).with("w1", event)
+      expect(self).to receive(:w2_store).with("w2", event)
+      subject.saveWidgets(run_widgets, event)
     end
 
     # used via GetProcessedWidget by yast2-slp-server and yast2
@@ -168,29 +169,29 @@ describe Yast::CWMClass do
       allow(self).to receive(:generic_save)
       allow(self).to receive(:w2_store)
       expect(subject).to receive(:processed_widget=).twice
-      subject.saveWidgets(run_widgets, "ID" => :event)
+      subject.saveWidgets(run_widgets, event)
     end
   end
 
   # used by CWMTab and CWM::ReplacePoint
   describe "#handleWidgets" do
     it "calls the handle methods" do
-      expect(self).to receive(:w1_handle).with("w1", "ID" => :event).and_return(nil)
-      expect(self).to receive(:w2_handle).with("w2", "ID" => :event).and_return(nil)
-      expect(subject.handleWidgets(run_widgets, "ID" => :event)).to eq(nil)
+      expect(self).to receive(:w1_handle).with("w1", event).and_return(nil)
+      expect(self).to receive(:w2_handle).with("w2", event).and_return(nil)
+      expect(subject.handleWidgets(run_widgets, event)).to eq(nil)
     end
 
     it "breaks the loop if a handler returns non-nil" do
-      expect(self).to receive(:w1_handle).with("w1", "ID" => :event).and_return(:foo)
+      expect(self).to receive(:w1_handle).with("w1", event).and_return(:foo)
       expect(self).to_not receive(:w2_handle)
-      expect(subject.handleWidgets(run_widgets, "ID" => :event)).to eq(:foo)
+      expect(subject.handleWidgets(run_widgets, event)).to eq(:foo)
     end
 
     it "sets @processed_widget" do
       allow(self).to receive(:w1_handle).and_return(nil)
       allow(self).to receive(:w2_handle).and_return(nil)
       expect(subject).to receive(:processed_widget=).twice
-      subject.handleWidgets(run_widgets, "ID" => :event)
+      subject.handleWidgets(run_widgets, event)
     end
 
     it "filters the events if 'handle_events' is specified" do
@@ -198,25 +199,25 @@ describe Yast::CWMClass do
       allow(self).to receive(:w2_handle)
       widgets = deep_copy(run_widgets)
       widgets[0]["handle_events"] = [:special_event]
-      subject.handleWidgets(widgets, "ID" => :event)
+      subject.handleWidgets(widgets, event)
     end
   end
 
   describe "#validateWidgets" do
     it "calls the validate methods" do
-      expect(self).to receive(:w1_validate).with("w1", "ID" => :event).and_return(true)
-      expect(self).to receive(:w2_validate).with("w2", "ID" => :event).and_return(true)
-      expect(subject.validateWidgets(run_widgets, "ID" => :event)).to eq(true)
+      expect(self).to receive(:w1_validate).with("w1", event).and_return(true)
+      expect(self).to receive(:w2_validate).with("w2", event).and_return(true)
+      expect(subject.validateWidgets(run_widgets, event)).to eq(true)
     end
 
     context "if a handler returns false" do
       before do
-        expect(self).to receive(:w1_validate).with("w1", "ID" => :event).and_return(false)
+        expect(self).to receive(:w1_validate).with("w1", event).and_return(false)
       end
 
       it "breaks the loop if a handler returns false" do
         expect(self).to_not receive(:w2_validate)
-        expect(subject.validateWidgets(run_widgets, "ID" => :event)).to eq(false)
+        expect(subject.validateWidgets(run_widgets, event)).to eq(false)
       end
 
       # SetValidationFailedHandler
@@ -225,7 +226,7 @@ describe Yast::CWMClass do
         handler = -> { called = true }
         subject.SetValidationFailedHandler(handler)
 
-        subject.validateWidgets(run_widgets, "ID" => :event)
+        subject.validateWidgets(run_widgets, event)
         # we cannot set an expectation on `handler` because a copy is made
         expect(called).to eq(true)
       end

--- a/library/system/test/execute_test.rb
+++ b/library/system/test/execute_test.rb
@@ -58,7 +58,8 @@ describe Yast::Execute do
 
     it "adds to passed arguments chroot option if scr chrooted" do
       allow(Yast::WFM).to receive(:scr_root).and_return("/mnt")
-      expect(Cheetah).to receive(:run).with("ls", "-a", chroot: "/mnt")
+      opts = { chroot: "/mnt" }
+      expect(Cheetah).to receive(:run).with("ls", "-a", opts)
 
       subject.on_target("ls", "-a")
     end
@@ -80,7 +81,8 @@ describe Yast::Execute do
 
     it "adds to passed arguments chroot option if scr chrooted" do
       allow(Yast::WFM).to receive(:scr_root).and_return("/mnt")
-      expect(Cheetah).to receive(:run).with("ls", "-a", chroot: "/mnt")
+      opts = { chroot: "/mnt" }
+      expect(Cheetah).to receive(:run).with("ls", "-a", opts)
 
       subject.on_target("ls", "-a")
     end
@@ -96,7 +98,8 @@ describe Yast::Execute do
     end
 
     it "captures stdout of the command" do
-      expect(Cheetah).to receive(:run).with("ls", "-a", stdout: :capture)
+      opts = { stdout: :capture }
+      expect(Cheetah).to receive(:run).with("ls", "-a", opts)
 
       subject.stdout("ls", "-a")
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Oct 31 13:07:35 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.19
+
+-------------------------------------------------------------------
 Tue Oct 25 08:32:48 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Improve logging in the ProductControl module, use the new

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.18
+Version:        4.5.19
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- this description is copied from https://github.com/yast/yast-registration/pull/584 as this is a base library. Further PRs will just link here

New rspec-mocks distinguish between hash and keyword arguments passed to `with`.

The tested code does use hashes but we've used keywords in tests because
it's shorter to write. Fixed.

rspec-mocks 3.11.2 / 2022-10-25:

> Bug Fixes: Support keyword argument semantics when constraining argument
> expectations using with on Ruby 3.0+ with instance_double
> https://github.com/rspec/rspec-mocks/pull/1473

## Solution

Use hashes in tests instead of keywords

## Testing

- [x] Red-green tested with manually installed rspec 3.12.0

## Screenshots

Not affected
