### PR TITLE
add arch filter class to unify architectures specification

### DIFF
--- a/library/general/src/lib/yast2/arch_filter.rb
+++ b/library/general/src/lib/yast2/arch_filter.rb
@@ -1,0 +1,84 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+
+Yast.import "Arch"
+
+module Yast2
+  # Represents filtering based on hardware architecture like x86_64 or ppc64.
+  # Original code lived in Y2Storage::SubvolSpecification
+  # @example
+  #   Yast2::ArchFilter.from_string("x86_64,aarch64").match?
+  class ArchFilter
+    # Error when invalid specification for filter is used
+    class Invalid < RuntimeError
+      def initialize(spec)
+        super("Invalid part of architecture specification '#{spec}'")
+      end
+    end
+
+    # @return [Array<Hash>] list of specifications where each entry is hash with key `:method` and
+    #   `:negate`, where method is Yast::Arch method and negate specify if
+    #   method have to return false
+    attr_reader :specifications
+
+    # creates new architecture filter from passed list of individual specifications
+    # @param specs [Array<String>]
+    # @raise Invalid when architecture specification is invalid
+    def initialize(specs)
+      @specifications = []
+      specs.each do |spec|
+        method = spec.downcase
+        negate = spec.start_with?("!")
+        method = spec[1..-1] if negate
+        raise Invalid, spec unless Yast::Arch.respond_to?(method)
+
+        @specifications << { method: method.to_sym, negate: negate }
+      end
+    end
+
+    # parses architecture filter specification from string.
+    # supported values are methods from Yast::Arch with possible `!` in front of it.
+    # When "!" is used it is called negative method and without it is called positive.
+    # List of possible values are supported with comma separator. In list
+    # at least one positive specified method have to return true and all methods
+    # with `!` have to be false to return true as result. Whitespaces are allowed. Only `!` and method
+    # has to be without space. Also it is case insensitive, so acronyms can be in upper case.
+    # @example various format and how it behave in given situations
+    #   "x86_64,ppc64" # returns true on either x86_64 or ppc64
+    #   "ppc,!board_powernv" # returns false on powernv_board or non-ppc
+    #   "ppc, !board_powernv" # spaces are allowed
+    #   "!ppc64,!aarch64" # always returns false as there is none positive method
+    #   "s390, !is_zKVM" # return true on s390 when not running in zKVM hypervisor
+    #   "invalid" # raises ArchFilter::Invalid exception
+    def self.from_string(value)
+      new(value.split(",").map(&:strip))
+    end
+
+    # checks if filter match current hardware
+    # @return [Boolean]
+    def match?
+      negative, positive = @specifications.partition { |s| s[:negate] }
+      return false if negative.any? { |s| Yast::Arch.public_send(s[:method]) }
+
+      positive.any? { |s| Yast::Arch.public_send(s[:method]) }
+    end
+  end
+end

--- a/library/general/src/lib/yast2/arch_filter.rb
+++ b/library/general/src/lib/yast2/arch_filter.rb
@@ -85,16 +85,16 @@ module Yast2
 
   private
 
-    def invoke_method(m)
-      return true if m == :all
+    def invoke_method(name)
+      return true if name == :all
 
-      Yast::Arch.public_send(m)
+      Yast::Arch.public_send(name)
     end
 
-    def valid_method?(m)
-      return true if m.to_s == "all"
+    def valid_method?(name)
+      return true if name.to_s == "all"
 
-      Yast::Arch.respond_to?(m)
+      Yast::Arch.respond_to?(name)
     end
   end
 end

--- a/library/general/src/lib/yast2/arch_filter.rb
+++ b/library/general/src/lib/yast2/arch_filter.rb
@@ -55,14 +55,21 @@ module Yast2
       end
     end
 
-    # parses architecture filter specification from string.
-    # supported values are methods from Yast::Arch with possible `!` in front of it.
-    # When "!" is used it is called negative method and without it is called positive.
-    # List of possible values are supported with comma separator. In list
-    # at least one positive specified method have to return true and all methods
-    # with `!` have to be false to return true as result. If there are no positive methods
-    # then only negatives are evaluated. Whitespaces are allowed. Only `!` and method
-    # has to be without space. Also it is case insensitive, so acronyms can be in upper case.
+    # Parses architecture filter specification from a string.
+    #
+    # Supported values are methods from {Yast::ArchClass Arch} with possible `!` in front of it.
+    #
+    # When a `!` is used it is called a *negative* method and without it is a *positive* one.
+    #
+    # A list of methods is separated with commas `,`.
+    # To match,
+    # at least one positive specified method has to return true and
+    # all negative methods have to return false.
+    # If there are no positive methods then only negatives are evaluated.
+    #
+    # Whitespaces are allowed. Only `!` and method has to be without space.
+    # Also it is case insensitive, so acronyms can be in upper case.
+    #
     # @example various format and how it behave in given situations
     #   "x86_64,ppc64" # returns true on either x86_64 or ppc64
     #   "ppc,!board_powernv" # returns false on powernv_board or non-ppc

--- a/library/general/test/yast2/arch_filter_test.rb
+++ b/library/general/test/yast2/arch_filter_test.rb
@@ -88,10 +88,10 @@ describe Yast2::ArchFilter do
     end
 
     it "supports special 'all' method" do
-        filter = described_class.from_string("all,!x86_64")
-        allow(Yast::Arch).to receive(:x86_64).and_return(false)
+      filter = described_class.from_string("all,!x86_64")
+      allow(Yast::Arch).to receive(:x86_64).and_return(false)
 
-        expect(filter.match?).to eq true
+      expect(filter.match?).to eq true
     end
   end
 

--- a/library/general/test/yast2/arch_filter_test.rb
+++ b/library/general/test/yast2/arch_filter_test.rb
@@ -1,0 +1,138 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "yast2/arch_filter"
+
+describe Yast2::ArchFilter do
+  describe "#match?" do
+    context "at least one positive methods return true" do
+      context "all negative methods return false" do
+        it "returns true" do
+          filter = described_class.from_string("x86_64,ppc,!board_powernv")
+          allow(Yast::Arch).to receive(:x86_64).and_return(false)
+          allow(Yast::Arch).to receive(:ppc).and_return(true)
+          allow(Yast::Arch).to receive(:board_powernv).and_return(false)
+
+          expect(filter.match?).to eq true
+        end
+      end
+
+      context "there are no negative methods" do
+        it "returns true" do
+          filter = described_class.from_string("x86_64,board_powernv")
+          allow(Yast::Arch).to receive(:x86_64).and_return(false)
+          allow(Yast::Arch).to receive(:board_powernv).and_return(true)
+
+          expect(filter.match?).to eq true
+        end
+      end
+
+      context "at least one negative method returns true" do
+        it "returns false" do
+          filter = described_class.from_string("x86_64,ppc,!board_powernv")
+          allow(Yast::Arch).to receive(:x86_64).and_return(false)
+          allow(Yast::Arch).to receive(:ppc).and_return(true)
+          allow(Yast::Arch).to receive(:board_powernv).and_return(true)
+
+          expect(filter.match?).to eq false
+        end
+      end
+    end
+
+    context "all positive methods return false" do
+      it "returns false" do
+        filter = described_class.from_string("x86_64,ppc,!board_powernv")
+        allow(Yast::Arch).to receive(:x86_64).and_return(false)
+        allow(Yast::Arch).to receive(:ppc).and_return(false)
+        allow(Yast::Arch).to receive(:board_powernv).and_return(false)
+
+        expect(filter.match?).to eq false
+      end
+    end
+
+    context "there are no positive methods" do
+      it "returns false" do
+        filter = described_class.from_string("!x86_64,!board_powernv")
+        allow(Yast::Arch).to receive(:x86_64).and_return(false)
+        allow(Yast::Arch).to receive(:board_powernv).and_return(false)
+
+        expect(filter.match?).to eq false
+      end
+    end
+
+    context "there are no methods" do
+      it "returns false" do
+        filter = described_class.from_string("")
+
+        expect(filter.match?).to eq false
+      end
+    end
+  end
+
+  describe ".new" do
+    it "parses each element of list to specification" do
+      filter = described_class.new(["x86_64"])
+      expect(filter.specifications).to eq([{ method: :x86_64, negate: false }])
+    end
+
+    it "parses negative methods" do
+      filter = described_class.new(["!x86_64"])
+      expect(filter.specifications).to eq([{ method: :x86_64, negate: true }])
+    end
+
+    it "is case insensitive" do
+      filter = described_class.new(["PPC"])
+      expect(filter.specifications).to eq([{ method: :ppc, negate: false }])
+    end
+
+    it "raises Yast2::ArchFilter::Invalid for invalid methods" do
+      expect { described_class.new(["InvalidArch"]) }.to raise_error(Yast2::ArchFilter::Invalid)
+    end
+  end
+
+  describe ".from_string" do
+    it "parses string into list of specifications" do
+      filter = described_class.from_string("x86_64")
+      expect(filter.specifications).to eq([{ method: :x86_64, negate: false }])
+    end
+
+    it "parses list separated by comma" do
+      filter = described_class.from_string("x86_64,ppc")
+      expect(filter.specifications).to eq(
+        [
+          { method: :x86_64, negate: false },
+          { method: :ppc, negate: false }
+        ]
+      )
+    end
+
+    it "allows whitespaces" do
+      filter = described_class.from_string("x86_64, ppc")
+      expect(filter.specifications).to eq(
+        [
+          { method: :x86_64, negate: false },
+          { method: :ppc, negate: false }
+        ]
+      )
+    end
+  end
+end

--- a/library/general/test/yast2/arch_filter_test.rb
+++ b/library/general/test/yast2/arch_filter_test.rb
@@ -86,6 +86,13 @@ describe Yast2::ArchFilter do
         expect(filter.match?).to eq false
       end
     end
+
+    it "supports special 'all' method" do
+        filter = described_class.from_string("all,!x86_64")
+        allow(Yast::Arch).to receive(:x86_64).and_return(false)
+
+        expect(filter.match?).to eq true
+    end
   end
 
   describe ".new" do

--- a/library/general/test/yast2/arch_filter_test.rb
+++ b/library/general/test/yast2/arch_filter_test.rb
@@ -70,26 +70,37 @@ describe Yast2::ArchFilter do
     end
 
     context "there are no positive methods" do
-      it "returns false" do
-        filter = described_class.from_string("!x86_64,!board_powernv")
-        allow(Yast::Arch).to receive(:x86_64).and_return(false)
-        allow(Yast::Arch).to receive(:board_powernv).and_return(false)
+      context "all negative methods return false" do
+        it "returns true" do
+          filter = described_class.from_string("!x86_64,!board_powernv")
+          allow(Yast::Arch).to receive(:x86_64).and_return(false)
+          allow(Yast::Arch).to receive(:board_powernv).and_return(false)
 
-        expect(filter.match?).to eq false
+          expect(filter.match?).to eq true
+        end
+      end
+
+      context "at least one negative method returns true" do
+        it "returns false" do
+          filter = described_class.from_string("!x86_64,!board_powernv")
+          allow(Yast::Arch).to receive(:x86_64).and_return(false)
+          allow(Yast::Arch).to receive(:board_powernv).and_return(true)
+
+          expect(filter.match?).to eq false
+        end
       end
     end
 
     context "there are no methods" do
-      it "returns false" do
+      it "returns true" do
         filter = described_class.from_string("")
 
-        expect(filter.match?).to eq false
+        expect(filter.match?).to eq true
       end
     end
 
     it "supports special 'all' method" do
-      filter = described_class.from_string("all,!x86_64")
-      allow(Yast::Arch).to receive(:x86_64).and_return(false)
+      filter = described_class.from_string("all")
 
       expect(filter.match?).to eq true
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Dec  1 16:12:54 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- ArchFilter: Add new class to allow unified definition of hardware
+  architecture filter. The main use case is to read arch
+  specific configuration in various configuration files like
+  control.xml or d-installer.yml (gh#yast/d-installer#279)
+- 4.5.20
+
+-------------------------------------------------------------------
 Mon Oct 31 13:07:35 UTC 2022 - Martin Vidner <mvidner@suse.com>
 
 - Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.19
+Version:        4.5.20
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

There are multiple places where we need to specify in text form condition to apply only to certain hardware architectures and it is not unified so far.

Related to https://trello.com/c/C3apZtHv/3231-d-installer-support-for-dynamic-configuration

## Solution

Unified solution is based on specification of  subvolume handling https://github.com/yast/yast-storage-ng/blob/master/src/lib/y2storage/subvol_specification.rb#L119

There are some improvements to it:

- allowing white spaces
- case insensitivity
- support for 'all' method
- raise exception when invalid element of string  is used


## Testing

- new unit tests are added

## Open Questions

There is one more place which define architecture filtering - in workflows https://github.com/yast/yast-yast2/blob/master/library/control/src/modules/WorkflowManager.rb#L209 Question is if we want to use filter also here? If so, then we need to support `all` keyword to match everything and of course adapt that code.

