### PR TITLE
RSpec keywords vs hash, second round

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+/.bundle/
+/vendor/
+/Gemfile
+/Gemfile.lock
+/.ruby-version*
+
 *.pot
 *.log
 *.trs

--- a/library/control/test/workflow_manager_test.rb
+++ b/library/control/test/workflow_manager_test.rb
@@ -313,9 +313,9 @@ describe Yast::WorkflowManager do
 
     before do
       # generic mocks, can be are overriden in the tests
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product).and_return([product])
-      allow(Y2Packager::Resolvable).to receive(:find).with(name: product_package, kind: :package).and_return([release])
-      allow(Y2Packager::Resolvable).to receive(:find).with(name: ext_package, kind: :package).and_return([extension])
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }).and_return([product])
+      allow(Y2Packager::Resolvable).to receive(:find).with({ name: product_package, kind: :package }).and_return([release])
+      allow(Y2Packager::Resolvable).to receive(:find).with({ name: ext_package, kind: :package }).and_return([extension])
       allow_any_instance_of(Packages::PackageDownloader).to receive(:download)
       allow_any_instance_of(Packages::PackageExtractor).to receive(:extract)
       # allow using it at other places
@@ -324,46 +324,48 @@ describe Yast::WorkflowManager do
 
     context "when repository id is passed" do
       it "returns nil if the repository does not provide any product" do
-        expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product).and_return([])
+        params = { kind: :product }
+        expect(Y2Packager::Resolvable).to receive(:find).with(params).and_return([])
         expect(subject.control_file(repo_id)).to be nil
       end
 
       it "returns nil if the product does not refer to a release package" do
         product = Y2Packager::Resolvable.new("kind" => :product, "name" => "foo", "source" => repo_id,
           "version" => "1.0", "arch" => "x86_64", "product_package" => product_package)
-        expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product).and_return([product])
+        expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }).and_return([product])
         expect(subject.control_file(repo_id)).to be nil
       end
 
       it "returns nil if the product belongs to a different repository" do
         product = Y2Packager::Resolvable.new("kind" => :product, "name" => "foo", "source" => repo_id + 1,
           "version" => "1.0", "arch" => "x86_64", "product_package" => product_package)
-        expect(Y2Packager::Resolvable).to receive(:find).with(kind: :product).and_return([product])
+        expect(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }).and_return([product])
         expect(subject.control_file(repo_id)).to be nil
       end
 
       it "returns nil if the release package cannot be found" do
-        expect(Y2Packager::Resolvable).to receive(:find).with(name: product_package, kind: :package).and_return([])
+        expect(Y2Packager::Resolvable).to receive(:find).with({ name: product_package, kind: :package }).and_return([])
         expect(subject.control_file(repo_id)).to be nil
       end
 
       it "returns nil if the release package does not have any dependencies" do
         release = Y2Packager::Resolvable.new("kind" => :package, "name" => "foo", "source" => repo_id,
           "version" => "1.0", "arch" => "x86_64", "deps" => [])
-        expect(Y2Packager::Resolvable).to receive(:find).with(name: product_package, kind: :package).and_return([release])
+        expect(Y2Packager::Resolvable).to receive(:find).with({ name: product_package, kind: :package }).and_return([release])
         expect(subject.control_file(repo_id)).to be nil
       end
 
       it "returns nil if the release package does not have any installerextension() provides" do
         release = Y2Packager::Resolvable.new("kind" => :package, "name" => "foo", "source" => repo_id,
           "version" => "1.0", "arch" => "x86_64", "deps" => ["provides" => "foo"])
-        expect(Y2Packager::Resolvable).to receive(:find).with(name: product_package, kind: :package).and_return([release])
+        expect(Y2Packager::Resolvable).to receive(:find).with({ name: product_package, kind: :package }).and_return([release])
         expect(subject.control_file(repo_id)).to be nil
       end
     end
 
     it "returns nil if the installer extension package is not found" do
-      expect(Y2Packager::Resolvable).to receive(:find).with(name: ext_package, kind: :package).and_return([])
+      params = { name: ext_package, kind: :package }
+      expect(Y2Packager::Resolvable).to receive(:find).with(params).and_return([])
       expect(subject.control_file(repo_id)).to be nil
     end
 

--- a/library/packages/test/product_test.rb
+++ b/library/packages/test/product_test.rb
@@ -27,7 +27,7 @@ def stub_defaults
   allow(Yast::PackageSystem).to receive(:EnsureSourceInit).and_return(true)
   allow(Yast::Pkg).to receive(:PkgSolve).and_return(true)
   allow(Yast::PackageLock).to receive(:Check).and_return(true)
-  allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product).and_return(product_from_zypp)
+  allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }).and_return(product_from_zypp)
 end
 
 # Describes Product handling as a whole (due to lazy loading and internal caching),
@@ -274,7 +274,7 @@ describe Yast::Product do
   context "while called on a broken system (no os-release, no zypp information)" do
     before(:each) do
       allow(Yast::OSRelease).to receive(:os_release_exists?).and_return(false)
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product).and_return([])
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product }).and_return([])
     end
 
     context "in installation" do

--- a/library/packages/test/repository_test.rb
+++ b/library/packages/test/repository_test.rb
@@ -301,7 +301,7 @@ describe Y2Packager::Repository do
     end
 
     it "returns products available in the repository" do
-      allow(Y2Packager::Resolvable).to receive(:find).with(kind: :product, source: repo_id)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ kind: :product, source: repo_id })
         .and_return(products_data)
       product = repo.products.first
       expect(product.name).to eq("openSUSE")

--- a/library/packages/test/y2packager/product_test.rb
+++ b/library/packages/test/y2packager/product_test.rb
@@ -101,7 +101,7 @@ describe Y2Packager::Product do
 
   describe "#selected?" do
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(name: product.name, kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ name: product.name, kind: :product })
         .and_return([Y2Packager::Resolvable.new("kind" => :product,
           "name" => product.name, "status" => status,
           "source" => 1, "short_name" => "short_name",
@@ -129,7 +129,7 @@ describe Y2Packager::Product do
 
   describe "#installed?" do
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(name: product.name, kind: :product)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ name: product.name, kind: :product })
         .and_return([Y2Packager::Resolvable.new("kind" => :product,
           "name" => product.name, "status" => status,
           "source" => 1, "short_name" => "short_name",
@@ -383,7 +383,7 @@ describe Y2Packager::Product do
 
     before do
       allow(Y2Packager::Resolvable).to receive(:find)
-        .with(name: "openSUSE", kind: :product).and_return(properties)
+        .with({ name: "openSUSE", kind: :product }).and_return(properties)
     end
 
     context "when given status is within product statuses" do
@@ -403,8 +403,8 @@ describe Y2Packager::Product do
     let(:relnotes_url) { "http://doc.opensuse.org/openSUSE/release-notes-openSUSE.rpm" }
 
     before do
-      allow(Y2Packager::Resolvable).to receive(:find).with(name: product.name,
-        kind: :product, version: product.version)
+      allow(Y2Packager::Resolvable).to receive(:find).with({ name: product.name,
+        kind: :product, version: product.version })
         .and_return([Y2Packager::Resolvable.new("kind" => :product,
           "name" => "openSUSE", "status" => :selected,
           "source" => 1, "short_name" => "short_name",
@@ -428,8 +428,8 @@ describe Y2Packager::Product do
 
     context "when product properties are not found" do
       before do
-        allow(Y2Packager::Resolvable).to receive(:find).with(name: product.name,
-          kind: :product, version: product.version).and_return([])
+        allow(Y2Packager::Resolvable).to receive(:find).with({ name: product.name,
+          kind: :product, version: product.version }).and_return([])
       end
 
       it "returns nil" do

--- a/library/packages/test/y2packager/release_notes_fetchers/rpm_test.rb
+++ b/library/packages/test/y2packager/release_notes_fetchers/rpm_test.rb
@@ -32,7 +32,7 @@ describe Y2Packager::ReleaseNotesFetchers::Rpm do
     allow(Yast::Pkg).to receive(:PkgQueryProvides).with("release-notes()")
       .and_return(provides)
     allow(Y2Packager::Resolvable).to receive(:find)
-      .with(name: "release-notes-dummy", kind: :package).and_return(dependencies)
+      .with({ name: "release-notes-dummy", kind: :package }).and_return(dependencies)
     allow(Y2Packager::Package).to receive(:find).with(package.name)
       .and_return(packages)
     allow(package).to receive(:download_to) do |path|


### PR DESCRIPTION
## Problem

- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1206419


## Solution

- ~~fix more expectations to correctly use a hash where the method really accepts a hash~~ No longer needed after the upstream fix
- it is an upstream bug, look at https://github.com/rspec/rspec-mocks/pull/1514
    - and here's my OBS submission to d:l:r:e https://build.opensuse.org/request/show/1057124

## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

