### PR TITLE
Fix help button in YaST Control Center

### DIFF
--- a/library/desktop/src/clients/menu.rb
+++ b/library/desktop/src/clients/menu.rb
@@ -264,7 +264,7 @@ module Yast
           VSpacing(1.0),
           HBox(
             HSpacing(1),
-            PushButton(Id(:help), Opt(:key_F1, :helpButton), Label.HelpButton),
+            PushButton(Id(:help), Opt(:key_F1), Label.HelpButton),
             HStretch(),
             PushButton(Id(:run), Opt(:defaultButton), _("Run")),
             PushButton(Id(:quit), Opt(:key_F9, :cancelButton), Label.QuitButton),

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jan 10 11:38:40 UTC 2023 - José Iván López González <jlopez@suse.com>
+
+- Show help text in YaST Control Center (bsc#1206919).
+- 4.5.21
+
+-------------------------------------------------------------------
 Thu Dec  1 16:12:54 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
 
 - ArchFilter: Add new class to allow unified definition of hardware

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.20
+Version:        4.5.21
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

With ncurses UI, the YaST Control Center shows a help button which opens an empty popup (help texts provided by the client are missing).

Note: this problem only affects to the ncurses UI because the help button is not offered in the Qt UI.

* https://bugzilla.suse.com/show_bug.cgi?id=1206919

## Solution

The help button's option `:helpButton` was used in a wrong way: if it is used, the click/activate event of that button is handled purely internal in libyui. In that case, libyui traverses up the widget hierarchy to find the next widget that has a property `:helpText` set and uses that text for a (UI internal) help window's content.

In this case, the button has that option, but the application wants to handle the event itself (there is no widget with`:helpText` property in the hierarchy).

Removing the `:helpButton` option on the help button fixes the problem.

## Testing

* Tested manually

## Screenshots

![Screenshot from 2023-01-10 11-58-00](https://user-images.githubusercontent.com/1112304/211545896-9f02aee7-7fb8-4a22-a6af-66eaeef6a906.png)
