### PR TITLE
Added usenbft and use fcoe to Linuxrc (jsc#PED-3138)

### DIFF
--- a/library/general/src/modules/Linuxrc.rb
+++ b/library/general/src/modules/Linuxrc.rb
@@ -142,9 +142,19 @@ module Yast
       InstallInf("UseSSH") == "1"
     end
 
+    # Returns if FCoE has been requested in Linuxrc.
+    def usefcoe
+      InstallInf("WithFCoE") == "1"
+    end
+
     # Returns if iSCSI has been requested in Linuxrc.
     def useiscsi
       InstallInf("WithiSCSI") == "1"
+    end
+
+    # Returns if using NBFT has been requested in Linuxrc.
+    def usenbft
+      InstallInf("UseNBFT") == "1"
     end
 
     # we're running in textmode (-> UI::GetDisplayInfo())

--- a/library/general/test/linuxrc_test.rb
+++ b/library/general/test/linuxrc_test.rb
@@ -140,6 +140,18 @@ describe Yast::Linuxrc do
     end
   end
 
+  describe "#usefcoe" do
+    it "returns true if 'WithFCoE' is set to '1' in install.inf" do
+      load_install_inf("WithFCoE" => "1")
+      expect(subject.usefcoe).to eq(true)
+    end
+
+    it "returns false if 'WithFCoE' is not set to '1' in install.inf" do
+      load_install_inf("WithFCoE" => "0")
+      expect(subject.usefcoe).to eq(false)
+    end
+  end
+
   describe "#useiscsi" do
     it "returns true if 'WithiSCSI' is set to '1' in install.inf" do
       load_install_inf("WithiSCSI" => "1")
@@ -149,6 +161,18 @@ describe Yast::Linuxrc do
     it "returns false if 'WithiSCSI' is not set to '1' in install.inf" do
       load_install_inf("WithiSCSI" => "0")
       expect(subject.useiscsi).to eq(false)
+    end
+  end
+
+  describe "#usenbft" do
+    it "returns true if 'UseNBFT' is set to '1' in install.inf" do
+      load_install_inf("UseNBFT" => "1")
+      expect(subject.usenbft).to eq(true)
+    end
+
+    it "returns false if 'UseNBFT' is not set to '1' in install.inf" do
+      load_install_inf("UseNBFT" => "0")
+      expect(subject.usenbft).to eq(false)
     end
   end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jan 26 13:43:43 UTC 2023 - Knut Alejandro Anderssen González <kanderssen@suse.com>
+
+- Aded Linuxrc.usenbft and Linuxrc.usefcoe convenience methods to
+  detects whether NBFT of FCoE disks activation should be called
+  (jsc#PED-3138, bsc#207573).
+- 4.5.23
+
+-------------------------------------------------------------------
 Wed Jan 18 12:52:10 UTC 2023 - Ludwig Nussel <lnussel@suse.com>
 
 - Replace transitional %usrmerged macro with regular version check (boo#1206798)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.22
+Version:        4.5.23
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
- https://trello.com/c/s4bMREX8

Added some convenience method for detecting whether **FCoE** or **NBFT** disks activation config should be used or not.

