### PR TITLE
Allow dir:///foo to equal dir:/foo (bsc#1207239)

### DIFF
--- a/library/packages/src/lib/y2packager/zypp_url.rb
+++ b/library/packages/src/lib/y2packager/zypp_url.rb
@@ -136,7 +136,7 @@ module Y2Packager
     # @return [String]
     def inspect
       # Prevent SimpleDelegator from forwarding this to the wrapped URI object
-      "#<#{self.class}:#{object_id}} @uri=#{uri.inspect}>"
+      "#<#{self.class}:#{object_id} @uri=#{uri.inspect}>"
     end
 
     # Compares two URLs
@@ -146,7 +146,10 @@ module Y2Packager
     # object is introduced to replace an existing URI one.
     def ==(other)
       if other.is_a?(URI::Generic)
-        uri == other
+        uri == other ||
+          # zypp will normalize dir:///foo to dir:/foo
+          # https://github.com/openSUSE/libzypp/issues/441
+          uri == URI(other.to_s.sub(":///", ":/"))
       elsif other.class == self.class
         uri == other.uri
       else

--- a/library/packages/test/y2packager/zypp_url_test.rb
+++ b/library/packages/test/y2packager/zypp_url_test.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env rspec
+
+require_relative "../test_helper"
+require "uri"
+require "y2packager/zypp_url"
+
+describe Y2Packager::ZyppUrl do
+  let(:https_s) { "https://example.com/path" }
+
+  describe "#==" do
+    it "returns true for the same ZyppUrl" do
+      z = described_class.new(https_s)
+      z2 = described_class.new(https_s.dup)
+      expect(z == z2).to eq(true)
+    end
+
+    it "returns false for a different ZyppUrl" do
+      z = described_class.new(https_s)
+      z2 = described_class.new("https://example.com/different")
+      expect(z == z2).to eq(false)
+    end
+
+    it "returns true for the same URI::Generic" do
+      z = described_class.new(https_s)
+      u = URI(https_s.dup)
+      expect(z == u).to eq(true)
+    end
+
+    it "returns true for URI::Generic if the only difference is undefine/empty authority" do
+      s1 = "dir:/foo"
+      s3 = "dir:///foo"
+      u1 = URI(s1)
+      u3 = URI(s3)
+      z1 = described_class.new(s1)
+
+      expect(z1 == u1).to eq(true)
+      expect(z1 == u3).to eq(true)
+    end
+
+    it "returns false for a different URI::Generic" do
+      z = described_class.new(https_s)
+      u = URI("https://example.com/different")
+      expect(z == u).to eq(false)
+    end
+
+    # NOTE: even a String which looks the same will return false
+    it "returns false for a different class" do
+      u = described_class.new(https_s)
+
+      expect(u == https_s).to eq(false)
+    end
+  end
+
+  describe "#inspect" do
+    it "returns a string" do
+      z = described_class.new(https_s)
+      expect(z.inspect).to be_a(String)
+    end
+  end
+end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Feb 14 10:28:30 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Allow dir:///foo to equal dir:/foo (bsc#1207239)
+- 4.5.24
+
+-------------------------------------------------------------------
 Wed Feb  8 21:46:04 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - DnsServerApi: drop module. It should never be in yast2 as it

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.23
+Version:        4.5.24
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION


## Problem

Since Ruby 3.2, URI("dir:///foo").to_s no longer returns "dir:/foo" and it makes tests fail in yast2-packager:

If we route the 3-slash form via C++ zypp::Url, it gets normalized to a single slash, see also
https://github.com/openSUSE/libzypp/issues/441


- https://trello.com/c/jRe5bWVE
- https://bugzilla.suse.com/show_bug.cgi?id=1207239

## Solution

In the class that wraps zypp::Url, consider those equal

It fixes a comparison in PkgFinishClient#added_by_installer?

## Testing

- Added a new unit test

## Screenshots

N/A
