### PR TITLE
Backport sp6

### DIFF
--- a/library/system/src/modules/Initrd.rb
+++ b/library/system/src/modules/Initrd.rb
@@ -47,7 +47,6 @@ module Yast
       Yast.import "Label"
       Yast.import "Misc"
       Yast.import "Mode"
-      Yast.import "Report"
       Yast.import "Stage"
       Yast.import "Directory"
 
@@ -69,11 +68,6 @@ module Yast
       @changed = false
       # true if settings were already read, flase otherwise
       @was_read = false
-      # parametr for mkinitrd because of splash screen
-      # used for choosing right size of splash
-      @splash = ""
-      # Additional parameters for mkinitrd
-      @additional_parameters = ""
       # List of modules which should be not added/removed to/from initrd
       @modules_to_skip = nil
 
@@ -111,53 +105,6 @@ module Yast
 
     # module functions
 
-    # Get the list of modules which don't belong to initrd
-    # Initialize the list if was not initialized before according to the
-    # architecture
-    # @return a list of modules
-    def getModulesToSkip
-      if @modules_to_skip.nil?
-        # usb and cdrom modules dont belong to initrd,
-        # they're loaded by hotplug
-        @modules_to_skip = [
-          "input",
-          "hid",
-          "keybdev",
-          "mousedev",
-          "cdrom",
-          "ide-cd",
-          "sr_mod",
-          "xfs_support",
-          "xfs_dmapi",
-          "ide-scsi"
-        ]
-        # some other modules don't belong to initrd on PPC
-        if Arch.ppc
-          ppc_modules_to_skip = ["reiserfs", "ext3", "jbd"]
-          @modules_to_skip = Convert.convert(
-            Builtins.merge(@modules_to_skip, ppc_modules_to_skip),
-            from: "list",
-            to:   "list <string>"
-          )
-        end
-        # currently no disk controller modules are known to fail in initrd (bnc#719696), list removed
-      end
-      deep_copy(@modules_to_skip)
-    end
-
-    # reset settings to empty list of modules
-    def Reset
-      Builtins.y2milestone("Reseting initrd settings")
-      @was_read = false
-      @changed = false
-      @modules = []
-      @modules_to_store = {}
-      @read_modules = []
-      @modules_settings = {}
-
-      nil
-    end
-
     # read seettings from sysconfig
     # @return true on success
     def Read
@@ -183,142 +130,6 @@ module Yast
       end
       @read_modules = deep_copy(@modules)
       true
-    end
-
-    # List modules included in initrd
-    # @return [Array] of strings with modulenames
-    def ListModules
-      Read() if !(@was_read || Mode.config)
-      Builtins.filter(@modules) { |m| Ops.get(@modules_to_store, m, false) }
-    end
-
-    # add module to ramdisk
-    # @param [String] modname name of module
-    # @param [String] modargs arguments to be passes to module
-    def AddModule(modname, modargs)
-      log.warn "Initrd.AddModule() is deprecated, do not use (sysconfig.kernel.INITRD_MODULES " \
-               "is not written anymore, see bnc#895084)"
-
-      if Stage.initial && Builtins.size(@modules) == 0
-        tmp_mods = Convert.to_string(
-          SCR.Read(path(".etc.install_inf.InitrdModules"))
-        )
-        @modules = Builtins.splitstring(tmp_mods, " ") if !tmp_mods.nil? && tmp_mods != ""
-        @was_read = true
-      elsif !(@was_read || Mode.config)
-        Read()
-      end
-      if !Builtins.contains(ListModules(), modname) ||
-          (modname == "aic7xxx" &&
-              !Builtins.contains(ListModules(), "aic7xxx_old")) ||
-          (modname == "aic7xxx_old" &&
-              !Builtins.contains(ListModules(), "aic7xxx"))
-        if Builtins.contains(getModulesToSkip, modname)
-          Builtins.y2milestone(
-            "Module %1 is in list of modules not to insert to initrd",
-            modname
-          )
-        else
-          @changed = true
-          Ops.set(@modules_to_store, modname, true)
-          Ops.set(@modules_settings, modname, Misc.SplitOptions(modargs, {}))
-          if Builtins.contains(@modules, modname)
-            Builtins.y2milestone(
-              "Module %1 from initial list added to initrd, now contains %2",
-              modname,
-              ListModules()
-            )
-          else
-            @modules = Builtins.add(@modules, modname)
-            Builtins.y2milestone(
-              "Module %1 added to initrd, now contains %2",
-              modname,
-              ListModules()
-            )
-          end
-        end
-      else
-        Builtins.y2milestone("Module %1 already present in initrd", modname)
-      end
-      nil
-    end
-
-    # Export settigs to variable
-    # @return [Hash] of initrd settings
-    def Export
-      Read() if !(@was_read || Mode.config)
-      { "list" => Builtins.filter(@modules) do |m|
-        Ops.get(@modules_to_store, m, false)
-      end, "settings" => @modules_settings }
-    end
-
-    # import settings of initrd
-    # @param [Hash] settings map of initrd settings
-    def Import(settings)
-      settings = deep_copy(settings)
-      Read() if !Mode.config # to set modules that were read
-      # and not add them to the list
-      @modules = Ops.get_list(settings, "list", [])
-      @modules_settings = Ops.get_map(settings, "settings", {})
-      Builtins.foreach(@modules) { |m| Ops.set(@modules_to_store, m, true) }
-      @was_read = true
-      @changed = true
-
-      nil
-    end
-
-    # remove module from list of initrd modules
-    # @param [String] modname string name of module to remove
-    def RemoveModule(modname)
-      Read() if !(@was_read || Mode.config)
-      @modules = Builtins.filter(@modules) { |k| k != modname }
-      @modules_settings = Builtins.filter(@modules_settings) do |k, _v|
-        k != modname
-      end
-      @changed = true
-
-      nil
-    end
-
-    # Update read settings to new version of configuration files
-    def Update
-      # add other required changes here
-      @modules = Builtins.filter(@modules) do |m|
-        !Builtins.contains(getModulesToSkip, m)
-      end
-      @modules_settings = Builtins.filter(@modules_settings) do |k, _v|
-        !Builtins.contains(getModulesToSkip, k)
-      end
-      @changed = true
-
-      nil
-    end
-
-    # Display error popup with log
-    # FIXME: this is copy-paste from ../routines/popups.ycp
-    # @param [String] header string error header
-    # @param [String] log string logfile contents
-    def errorWithLogPopup(header, log)
-      log = "" if log.nil?
-      text = RichText(Opt(:plainText), log)
-      UI.OpenDialog(
-        Opt(:decorated),
-        VBox(
-          HSpacing(75),
-          # heading
-          Heading(header),
-          text, # e.g. `Richtext()
-          ButtonBox(
-            PushButton(Id(:ok_help), Opt(:default, :okButton), Label.OKButton)
-          )
-        )
-      )
-
-      UI.SetFocus(Id(:ok_help))
-      UI.UserInput
-      UI.CloseDialog
-
-      nil
     end
 
     # write settings to sysconfig, rebuild initrd images
@@ -380,28 +191,10 @@ module Yast
       mods = Builtins.mergestring(ListModules(), " ")
       log.warn "Ignoring configured kernel modules: #{mods}" unless mods.empty?
 
-      # recreate initrd
-      param = ""
-      if @splash != "" && !@splash.nil? &&
-          Ops.less_than(
-            0,
-            Convert.to_integer(
-              SCR.Read(
-                path(".target.size"),
-                "/lib/mkinitrd/scripts/setup-splash.sh"
-              )
-            )
-          )
-        param = "-s #{@splash.shellescape}"
-      end
       if SCR.Execute(
         path(".target.bash"),
         Builtins.sformat(
-          "/sbin/mkinitrd %1 %2 >> %3 2>&1",
-          param, # escaped already above
-          # cannot escape it as it can contain multiple params and
-          # shell escape makes it single broken param
-          @additional_parameters,
+          "/usr/bin/dracut --force --regenerate-all >> %1 2>&1",
           File.join(Directory.logdir, "y2logmkinitrd").shellescape
         )
       ) != 0
@@ -431,65 +224,158 @@ module Yast
       deep_copy(all_modes)
     end
 
-    # Set the -s parameter of mkinitrd
-    # @param [String] vga string the vga kernel parameter
-    def setSplash(vga)
-      if !Arch.s390
-        @changed = true
-        # bnc#292013 - Grub-tool does not recreate initrd if the vga-mode changed
-        if vga == "normal"
-          @splash = "off"
-        else
-          mode = Builtins.tointeger(vga)
-          all_modes = VgaModes()
-          Builtins.foreach(all_modes) do |m|
-            if Ops.get_integer(m, "mode", 0) == mode &&
-                Ops.get_integer(m, "height", 0) != 0 &&
-                Ops.get_integer(m, "width", 0) != 0
-              @splash = Builtins.sformat(
-                "%2x%1",
-                Ops.get_integer(m, "height", 0),
-                Ops.get_integer(m, "width", 0)
-              )
-            end
-          end
-        end
-        Builtins.y2milestone("Setting splash resolution to %1", @splash)
-      end
-
-      nil
-    end
-
-    # Get additional parameters for mkinitrd
-    # @return [String] additional mkinitrd parameters
-    def AdditionalParameters
-      @additional_parameters
-    end
-
-    # Set additional parameters for mkinitrd
-    # @param [String] params string additional mkinitrd parameters
-    def SetAdditionalParameters(params)
-      @additional_parameters = params
-
-      nil
-    end
-
     publish variable: :changed, type: "boolean"
-    publish function: :getModulesToSkip, type: "list <string> ()"
-    publish function: :Reset, type: "void ()"
     publish function: :Read, type: "boolean ()"
-    publish function: :ListModules, type: "list <string> ()"
-    publish function: :AddModule, type: "void (string, string)"
-    publish function: :Export, type: "map ()"
-    publish function: :Import, type: "void (map)"
-    publish function: :RemoveModule, type: "void (string)"
-    publish function: :Update, type: "void ()"
-    publish function: :errorWithLogPopup, type: "void (string, string)"
     publish function: :Write, type: "boolean ()"
     publish function: :VgaModes, type: "list <map> ()"
-    publish function: :setSplash, type: "void (string)"
-    publish function: :AdditionalParameters, type: "string ()"
-    publish function: :SetAdditionalParameters, type: "void (string)"
+
+  private
+
+    # Display error popup with log
+    # FIXME: this is copy-paste from ../routines/popups.ycp
+    # @param [String] header string error header
+    # @param [String] log string logfile contents
+    def errorWithLogPopup(header, log)
+      log = "" if log.nil?
+      text = RichText(Opt(:plainText), log)
+      UI.OpenDialog(
+        Opt(:decorated),
+        VBox(
+          HSpacing(75),
+          # heading
+          Heading(header),
+          text, # e.g. `Richtext()
+          ButtonBox(
+            PushButton(Id(:ok_help), Opt(:default, :okButton), Label.OKButton)
+          )
+        )
+      )
+
+      UI.SetFocus(Id(:ok_help))
+      UI.UserInput
+      UI.CloseDialog
+
+      nil
+    end
+
+    # Get the list of modules which don't belong to initrd
+    # Initialize the list if was not initialized before according to the
+    # architecture
+    # @return a list of modules
+    def getModulesToSkip
+      if @modules_to_skip.nil?
+        # usb and cdrom modules dont belong to initrd,
+        # they're loaded by hotplug
+        @modules_to_skip = [
+          "input",
+          "hid",
+          "keybdev",
+          "mousedev",
+          "cdrom",
+          "ide-cd",
+          "sr_mod",
+          "xfs_support",
+          "xfs_dmapi",
+          "ide-scsi"
+        ]
+        # some other modules don't belong to initrd on PPC
+        if Arch.ppc
+          ppc_modules_to_skip = ["reiserfs", "ext3", "jbd"]
+          @modules_to_skip = Convert.convert(
+            Builtins.merge(@modules_to_skip, ppc_modules_to_skip),
+            from: "list",
+            to:   "list <string>"
+          )
+        end
+        # currently no disk controller modules are known to fail in initrd (bnc#719696), list removed
+      end
+      deep_copy(@modules_to_skip)
+    end
+
+    # reset settings to empty list of modules
+    def Reset
+      Builtins.y2milestone("Reseting initrd settings")
+      @was_read = false
+      @changed = false
+      @modules = []
+      @modules_to_store = {}
+      @read_modules = []
+      @modules_settings = {}
+
+      nil
+    end
+
+    # List modules included in initrd
+    # @return [Array] of strings with modulenames
+    def ListModules
+      Read() if !(@was_read || Mode.config)
+      Builtins.filter(@modules) { |m| Ops.get(@modules_to_store, m, false) }
+    end
+
+    # add module to ramdisk
+    # @param [String] modname name of module
+    # @param [String] modargs arguments to be passes to module
+    def AddModule(modname, modargs)
+      log.warn "Initrd.AddModule() is deprecated, do not use (sysconfig.kernel.INITRD_MODULES " \
+               "is not written anymore, see bnc#895084)"
+
+      if Stage.initial && Builtins.size(@modules) == 0
+        tmp_mods = Convert.to_string(
+          SCR.Read(path(".etc.install_inf.InitrdModules"))
+        )
+        @modules = Builtins.splitstring(tmp_mods, " ") if !tmp_mods.nil? && tmp_mods != ""
+        @was_read = true
+      elsif !(@was_read || Mode.config)
+        Read()
+      end
+      if !Builtins.contains(ListModules(), modname) ||
+          (modname == "aic7xxx" &&
+              !Builtins.contains(ListModules(), "aic7xxx_old")) ||
+          (modname == "aic7xxx_old" &&
+              !Builtins.contains(ListModules(), "aic7xxx"))
+        if Builtins.contains(getModulesToSkip, modname)
+          Builtins.y2milestone(
+            "Module %1 is in list of modules not to insert to initrd",
+            modname
+          )
+        else
+          @changed = true
+          Ops.set(@modules_to_store, modname, true)
+          Ops.set(@modules_settings, modname, Misc.SplitOptions(modargs, {}))
+          if Builtins.contains(@modules, modname)
+            Builtins.y2milestone(
+              "Module %1 from initial list added to initrd, now contains %2",
+              modname,
+              ListModules()
+            )
+          else
+            @modules = Builtins.add(@modules, modname)
+            Builtins.y2milestone(
+              "Module %1 added to initrd, now contains %2",
+              modname,
+              ListModules()
+            )
+          end
+        end
+      else
+        Builtins.y2milestone("Module %1 already present in initrd", modname)
+      end
+      nil
+    end
+
+    # Update read settings to new version of configuration files
+    def Update
+      # add other required changes here
+      @modules = Builtins.filter(@modules) do |m|
+        !Builtins.contains(getModulesToSkip, m)
+      end
+      @modules_settings = Builtins.filter(@modules_settings) do |k, _v|
+        !Builtins.contains(getModulesToSkip, k)
+      end
+      @changed = true
+
+      nil
+    end
   end
 
   Initrd = InitrdClass.new

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2,6 +2,10 @@
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)
+- backport:
+-- Replace calls to mkinitrd with dracut as mkinitrd will be
+   dropped (bsc#1203019)
+- 4.6.3
 
 -------------------------------------------------------------------
 Mon Mar  6 13:09:12 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.6.0
+Version:        4.6.3
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

Skip reapply of DNS drop as it is needed in SLE15. Backport mkinitrd drop (#1289).