### PR TITLE
Fix zones reader (bsc#1216534)

### DIFF
--- a/library/network/src/lib/y2firewall/firewalld/zone_reader.rb
+++ b/library/network/src/lib/y2firewall/firewalld/zone_reader.rb
@@ -91,8 +91,8 @@ module Y2Firewall
       end
 
       def current_zone_from(line)
-        attribute, _value = line.split(/\s*\(active\)\s*$/)
-        zone_names.include?(attribute) ? attribute : nil
+        name, *_status = line.split
+        zone_names.include?(name) ? name : nil
       end
 
       ATTRIBUTE_MAPPING = { "summary" => "short" }.freeze

--- a/library/network/test/y2firewall/firewalld/zone_reader_test.rb
+++ b/library/network/test/y2firewall/firewalld/zone_reader_test.rb
@@ -43,11 +43,11 @@ describe Y2Firewall::Firewalld::ZoneReader do
         "  rich rules: ",
         "\t",
         "",
-        "public (active)",
+        "public (default, active)",
         "  summary: Public",
-        "  description: For use in public areas. You do not trust the other" \
-        " computers on networks to not harm your computer." \
-        " Only selected incoming connections are accepted.",
+        "  description: For use in public areas. You do not trust the other " \
+        "computers on networks to not harm your computer. " \
+        "Only selected incoming connections are accepted.",
         "  target: default",
         "  icmp-block-inversion: no",
         "  interfaces: eth0 ens3",

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Oct 25 11:16:21 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix firewalld zones reader adapting it to the new firewall-cmd
+  --list-all-zones output format (bsc#1216534)
+- 4.6.4
+
+-------------------------------------------------------------------
 Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
 - Branch package for SP6 (bsc#1208913)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.6.3
+Version:        4.6.4
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

A recent change in firewall-cmd --list-all-zones output is breaking the zones reader as the default zone is not read properly and therefore it is considered to be deleted.

- https://bugzilla.suse.com/show_bug.cgi?id=1216534


## Solution

Adapted the firewalld zones reader ignoring anything after the zone name.


## Testing

- *Adapted current unit test*
- *Tested manually*
