### PR TITLE
Adapt kernel

### DIFF
--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -169,13 +169,13 @@ module Yast
       @cmdline_parsed = true
       return if !(Stage.initial || Stage.cont)
 
-      # live installation does not create /etc/install.inf (bsc#793065)
-      tmp = if Mode.live_installation
+      # Check if /etc/install.inf exists
+      tmp = if SCR.Dir(path(".etc.install_inf")).empty?
         # not using dedicated agent in order to use the same parser for cmdline
         # independently on whether it comes from /proc/cmdline or /etc/install.inf
-        Convert.to_string(SCR.Read(path(".target.string"), "/proc/cmdline"))
+        SCR.Read(path(".target.string"), "/proc/cmdline").to_s
       else
-        Convert.to_string(SCR.Read(path(".etc.install_inf.Cmdline")))
+        SCR.Read(path(".etc.install_inf.Cmdline")).to_s
       end
 
       Builtins.y2milestone(

--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -173,7 +173,8 @@ module Yast
       tmp = if SCR.Dir(path(".etc.install_inf")).empty?
         # not using dedicated agent in order to use the same parser for cmdline
         # independently on whether it comes from /proc/cmdline or /etc/install.inf
-        SCR.Read(path(".target.string"), "/proc/cmdline").to_s
+        # use local read as it does not make sense to depend on binding it to chroot
+        WFM.Read(path(".local.string"), "/proc/cmdline").to_s
       else
         SCR.Read(path(".etc.install_inf.Cmdline")).to_s
       end

--- a/library/system/test/kernel_test.rb
+++ b/library/system/test/kernel_test.rb
@@ -150,6 +150,7 @@ describe Yast::Kernel do
 
   describe ".ParseInstallationKernelCmdline" do
     before do
+      allow(Yast::SCR).to receive(:Dir).with(path(".etc.install_inf")).and_return(["CmdLine"])
       allow(Yast::SCR).to receive(:Read).with(path(".etc.install_inf.Cmdline")).and_return(cmdline)
       allow(Yast::Stage).to receive(:initial).and_return(true)
       allow(Yast::Arch).to receive(:architecture).and_return("x86_64")

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 23 12:52:08 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Reading Kernel Params: Use kernel cmdline when install.inf is not
+  available (bsc#1216408)
+- 5.0.4
+
+-------------------------------------------------------------------
 Wed Nov  1 08:35:38 UTC 2023 - Ladislav Slezák <lslezak@suse.com>
 
 - Added Repository#refresh method (related to bsc#1215884)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.3
+Version:        5.0.4
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

In agama there are no /etc/install.inf, but kernel parsing depends on it. Result is that kernel parameters are not properly passed to installed system.


## Solution

Read /proc/cmdline when /etc/install.inf is not available.


## Testing

- *Tested manually*


