### PR TITLE
Allow Host / Domain Names starting with an Underscore [SLE-15-SP6]

### DIFF
--- a/library/types/src/modules/Hostname.rb
+++ b/library/types/src/modules/Hostname.rb
@@ -81,7 +81,7 @@ module Yast
     def Check(host)
       return false if host.nil? || host == "" || Ops.greater_than(Builtins.size(host), 63)
 
-      Builtins.regexpmatch(host, "^[[:alnum:]]([[:alnum:]-]*[[:alnum:]])?$")
+      Builtins.regexpmatch(host, "^[[:alnum:]_]([[:alnum:]-]*[[:alnum:]])?$")
     end
 
     # Check syntax of domain entry

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Feb 15 11:55:58 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Allow host/domain names starting with an underscore (bsc#1219920)
+- 4.6.5
+
+-------------------------------------------------------------------
 Wed Oct 25 11:16:21 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix firewalld zones reader adapting it to the new firewall-cmd

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.6.4
+Version:        4.6.5
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Target Branch

**This is the merge PR for SLE-15-SP6** of PR #1301 .

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1219920


## Problem

Modern DNS setups require using a leading underscore for hostnames in some situations, e.g. `_mydomain.example.com`. But that is not possible to enter in the YaST DNS Server module: Underscores are generally rejected.


## Fix

Allow a leading underscore for host and domain names. Not just anywhere, just as the leading character.

Since the check is in `Hostname.rb` which belongs to the _yast2_ package (repo _yast-yast2_), this is not in the `yast2-dns-server` package where it might be expected.


## Known Limitation

This allows a leading underscore for _all_ components of a FQDN in all circumstances. Users need to have some expertise to know when that is suitable.


## The Error Message

The error message quoted in the bug remains the same; we are not changing it, so not all translations will be broken, resulting in purely English error messages for all international users. The message does not contain anything about the leading underscore. But the message should not appear when this is used correctly.


## Screenshot

![yast-dns-server](https://github.com/yast/yast-yast2/assets/11538225/938f0f4e-8d32-4d82-815c-574a5593aa4a)

Notice that leading underscores are now allowed, while underscores in other places are not.



## Testing

Manual testing with `sudo yast2 dns-server` after a manual `sudo rake install`.


## Reference

- https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/email-authentication-dkim-configure?view=o365-worldwide#syntax-for-dkim-cname-records


## Related PRs

- Original PR for SLE-15-SP5: #1301 
- master / Factory: _TO DO_