### PR TITLE
Sle 15 sp6

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 21 10:22:26 UTC 2024 - Michal Filka <mfilka@suse.com>
+
+- replaced "journalctl --dmesg" with "journalctl -b"
+- 4.6.6
+
+-------------------------------------------------------------------
 Thu Feb 15 11:55:58 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Allow host/domain names starting with an underscore (bsc#1219920)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.6.5
+Version:        4.6.6
 
 Release:        0
 Summary:        YaST2 Main Package

--- a/scripts/save_y2logs
+++ b/scripts/save_y2logs
@@ -82,7 +82,9 @@ fi
 
 if [ "$(type -p journalctl)" ]; then
   journalctl --dmesg > $TMPDIR/journalctl-dmesg
+  journalctl -b > $TMPDIR/journalctl-b
   LIST_TMP="$LIST_TMP journalctl-dmesg"
+  LIST_TMP="$LIST_TMP journalctl-b"
 fi
 
 # strip sensitive information
@@ -139,6 +141,7 @@ done
 
 
 echo "Saving YaST logs to $TARGET" >&2
+echo "The archive is root readable only" >&2
 
 [ -n "$COMPRESSION" ] && COMPRESSION="--$COMPRESSION"
 


### PR DESCRIPTION
## Problem

https://github.com/yast/yast-yast2/issues/978 - Permissions/ownership of the resulting file. Leaded to this [yast-devel thread](https://lists.opensuse.org/yast-devel/2020-02/msg00005.html)

https://github.com/yast/yast-yast2/issues/970 Missing journalctl -b.


## Solution

added journalctl -b instead of journalctl --dmesg and a note about resulting archive permissions

## Testing

- *Tested manually*

