### PR TITLE
[SLE15-SP3] Support migration from SLE_HPC to SLES SP6+ (bsc#1220567)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Mar 12 08:16:30 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Reimplemented the hardcoded product mapping to support also the
+  migration from SLE_HPC to SLES SP6+ (with the HPC module)
+  (bsc#1220567)
+- 4.3.70
+
+-------------------------------------------------------------------
 Thu Mar  3 14:11:43 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed refreshing old repositories during system upgrade

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.3.69
+Version:        4.3.70
 
 Release:        0
 Summary:        YaST2 Main Package
@@ -124,6 +124,8 @@ Conflicts:      yast2-packager < 4.3.2
 Conflicts:      yast2-update < 4.3.0
 # Older snapper does not provide machine-readable output
 Conflicts:	snapper < 0.8.6
+# changed API in Y2Packager::ProductUpgrade
+Conflicts:      yast2-registration < 4.3.29
 
 Obsoletes:      yast2-devel-doc
 


### PR DESCRIPTION
This is a partial backport of https://github.com/yast/yast-packager/pull/653 to SLE15-SP4.

In SP3 the `product_upgrade.rb` file was part of the `yast2.rpm` package, in SP4 it was moved to `yast2-packager`. So for SP3 we need to patch 3 packages instead of 2 as in SP4/SP5.