### PR TITLE
Properly close popups for nested progress callbacks (bsc#1223281)

### DIFF
--- a/library/packages/src/modules/PackageCallbacks.rb
+++ b/library/packages/src/modules/PackageCallbacks.rb
@@ -2397,7 +2397,7 @@ module Yast
       )
 
       if !Mode.commandline && IsProgressPopup()
-        UI.CloseDialog if Builtins.size(@progress_stack) == 0
+        UI.CloseDialog if Builtins.size(@progress_stack) >= 0
       elsif full_screen
         if Ops.greater_than(Builtins.size(@progress_stack), 0)
           progress_type = Ops.get_symbol(

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May  6 13:08:32 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
+
+- Properly close nested progress callbacks (bsc#1223281)
+- 4.5.27
+
+-------------------------------------------------------------------
 Thu Feb 15 11:55:58 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Allow host/domain names starting with an underscore (bsc#1219920)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.5.26
+Version:        4.5.27
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1223281
- After deleting the old repositories a progress popup stays open and blocks the following UI calls

![no_widget_error](https://github.com/yast/yast-yast2/assets/907998/02521f17-7c24-47d1-8361-35b2d0995440)

## Details

- The problem happens only when the self-update is enabled, with disabled self-update it works fine
-  It turned out that with updated libzypp the start and end callbacks are called twice:
  ```
  modules/PackageCallbacks.rb(ProgressStart):2338 ProgressStart: 992
  modules/PackageCallbacks.rb(ProgressStart):2338 ProgressStart: 992
  modules/PackageCallbacks.rb(ProgressEnd):2391 ProgressFinish: 992
  modules/PackageCallbacks.rb(ProgressEnd):2391 ProgressFinish: 992
  ```
- The code is actually prepared for this situation, it counts the nesting level for the start and end calls
- But unfortunately there was a bug when closing the nested callback, it closed only one (the last) popup

## Solution

- Properly close the open popup when there are nested callbacks (multiple open popups)

## Testing

- Tested manually
- All popups are closed, the workflow properly continues to the next step