### PR TITLE
Re-add Missing Error class

### DIFF
--- a/library/systemd/src/lib/yast2/systemd/target.rb
+++ b/library/systemd/src/lib/yast2/systemd/target.rb
@@ -10,6 +10,14 @@ module Yast2
       end
     end
 
+    # Exception when systemctl command failed
+    class SystemctlError < StandardError
+      # @param details [#to_s]
+      def initialize(details)
+        super "Systemctl command failed: #{details}"
+      end
+    end
+
     # API to manage a systemd.target unit
     #
     # @example How to find a custom systemd target

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Jul 10 12:19:16 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Re-added missing error class (bsc#1227580) 
+- 5.0.9
+
+-------------------------------------------------------------------
 Mon May  6 13:08:32 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Properly close nested progress callbacks (bsc#1223281)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.8
+Version:        5.0.9
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1227580


## Problem

yast2-services-manager fails to build in its unit tests with the latest systemd V256.


## Cause

A very rare error condition was met, and it turned out that a refactoring in August 2018, 6 years ago (!), removed an error class; an error that was raised only once in all the YaST code, so the unit tests didn't cover it.

That happens when the `systemctl get-default` command fails.

## The Change that Caused This

https://github.com/yast/yast-yast2/commit/e4ab10035ba30f739175009344872c4062c26db6#diff-8ddc7418f9da5ef96888a536c77c9e4c3330414a4b9a14f4ad95830dd00547ae

part of #799 


## Fix

This only fixes the unit tests failing because of the Ruby `NameError`: It adds the missing error class again. This does **not** fix the part that this problem appears in the first place: That the `systemctl get-default` command fails.

Is that an intentional and well-documented change in the systemd behavior? Probably not. So the unit tests may still fail, but now it will give a much clearer error that includes what the `systemctl` command complained about.