### PR TITLE
Drop Obsolete login.defs Scripts USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD, USERADD_CMD

### DIFF
--- a/library/general/src/lib/cfa/login_defs.rb
+++ b/library/general/src/lib/cfa/login_defs.rb
@@ -51,7 +51,6 @@ module CFA
       :fail_delay,
       :gid_max,
       :gid_min,
-      :groupadd_cmd,
       :home_mode,
       :pass_max_days,
       :pass_min_days,

--- a/library/general/src/lib/cfa/login_defs.rb
+++ b/library/general/src/lib/cfa/login_defs.rb
@@ -69,9 +69,6 @@ module CFA
       :uid_max,
       :uid_min,
       :umask,
-      :useradd_cmd,
-      :userdel_postcmd,
-      :userdel_precmd,
       :usergroups_enab
     ].freeze
 

--- a/library/general/test/cfa/login_defs_test.rb
+++ b/library/general/test/cfa/login_defs_test.rb
@@ -77,10 +77,7 @@ describe CFA::LoginDefs do
     sys_uid_max:     "499",
     sys_uid_min:     "100",
     uid_max:         "60000",
-    uid_min:         "1000",
-    useradd_cmd:     "/usr/sbin/useradd.local",
-    userdel_postcmd: "/usr/sbin/userdel-post.local",
-    userdel_precmd:  "/usr/sbin/userdel-pre.local"
+    uid_min:         "1000"
   }.freeze
 
   ATTRS_VALUES.each do |attr, value|

--- a/library/general/test/cfa/login_defs_test.rb
+++ b/library/general/test/cfa/login_defs_test.rb
@@ -68,7 +68,6 @@ describe CFA::LoginDefs do
     fail_delay:      "3",
     gid_max:         "60000",
     gid_min:         "1000",
-    groupadd_cmd:    "/usr/sbin/groupadd.local",
     pass_max_days:   "99999",
     pass_min_days:   "0",
     pass_warn_age:   "7",

--- a/library/general/test/cfa/shadow_config_test.rb
+++ b/library/general/test/cfa/shadow_config_test.rb
@@ -125,11 +125,11 @@ describe CFA::ShadowConfig do
 
     context "when a conflict is detected" do
       before do
-        allow(config).to receive(:conflicts).and_return([:fail_delay, :useradd_cmd])
+        allow(config).to receive(:conflicts).and_return([:fail_delay, :encrypt_method])
       end
 
       it "logs conflicting attributes" do
-        expect(config.log).to receive(:warn).with(/overridden: fail_delay, useradd_cmd/)
+        expect(config.log).to receive(:warn).with(/overridden: fail_delay, encrypt_method/)
         config.save
       end
     end
@@ -139,7 +139,7 @@ describe CFA::ShadowConfig do
     before { config.load }
 
     it "returns override YaST settings" do
-      expect(config.conflicts).to eq([:useradd_cmd])
+      expect(config.conflicts).to eq([:encrypt_method])
     end
   end
 

--- a/library/general/test/data/login.defs-example
+++ b/library/general/test/data/login.defs-example
@@ -272,5 +272,3 @@ FORCE_SHADOW    no
 # but be aware that the result could depend on the locale settings.
 #
 CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*
-
-GROUPADD_CMD                   /usr/sbin/groupadd.local

--- a/library/general/test/data/login.defs-example
+++ b/library/general/test/data/login.defs-example
@@ -226,34 +226,11 @@ ENCRYPT_METHOD SHA512
 DEFAULT_HOME	yes
 
 #
-# If defined, this command is run when adding a user.
-# It should rebuild any NIS database etc. to add the
-# new created account.
-#
-USERADD_CMD             /usr/sbin/useradd.local
-
-#
 # If defined, this command is run when removing a user.
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
 #
-# See also USERDEL_PRECMD and USERDEL_POSTCMD below.
-#
 #USERDEL_CMD	/usr/sbin/userdel_local
-
-#
-# If defined, this command is run before removing a user.
-# It should remove any at/cron/print jobs etc. owned by
-# the user to be removed.
-#
-USERDEL_PRECMD          /usr/sbin/userdel-pre.local
-
-#
-# If defined, this command is run after removing a user.
-# It should rebuild any NIS database etc. to remove the
-# account from it.
-#
-USERDEL_POSTCMD         /usr/sbin/userdel-post.local
 
 #
 # Enable setting of the umask group bits to be the same as owner bits

--- a/library/general/test/data/login.defs/custom/etc/login.defs.d/70-yast.defs
+++ b/library/general/test/data/login.defs/custom/etc/login.defs.d/70-yast.defs
@@ -1,1 +1,2 @@
-USERADD_CMD             /usr/sbin/useradd.local
+UMASK 022
+ENCRYPT_METHOD          MD5

--- a/library/general/test/data/login.defs/custom/etc/login.defs.d/99-local.defs
+++ b/library/general/test/data/login.defs/custom/etc/login.defs.d/99-local.defs
@@ -1,2 +1,1 @@
 ENCRYPT_METHOD          SHA256
-USERADD_CMD             /usr/local/sbin/useradd.local

--- a/library/general/test/data/login.defs/custom/usr/etc/login.defs
+++ b/library/general/test/data/login.defs/custom/usr/etc/login.defs
@@ -226,34 +226,11 @@ ENCRYPT_METHOD SHA512
 DEFAULT_HOME	yes
 
 #
-# If defined, this command is run when adding a user.
-# It should rebuild any NIS database etc. to add the
-# new created account.
-#
-USERADD_CMD             /usr/sbin/useradd.local
-
-#
 # If defined, this command is run when removing a user.
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
 #
-# See also USERDEL_PRECMD and USERDEL_POSTCMD below.
-#
 #USERDEL_CMD	/usr/sbin/userdel_local
-
-#
-# If defined, this command is run before removing a user.
-# It should remove any at/cron/print jobs etc. owned by
-# the user to be removed.
-#
-USERDEL_PRECMD          /usr/sbin/userdel-pre.local
-
-#
-# If defined, this command is run after removing a user.
-# It should rebuild any NIS database etc. to remove the
-# account from it.
-#
-USERDEL_POSTCMD         /usr/sbin/userdel-post.local
 
 #
 # Enable setting of the umask group bits to be the same as owner bits

--- a/library/general/test/data/login.defs/vendor/usr/etc/login.defs
+++ b/library/general/test/data/login.defs/vendor/usr/etc/login.defs
@@ -183,7 +183,7 @@ LOGIN_TIMEOUT		60
 # any combination of letters "frwh" (full name, room number, work
 # phone, home phone).  If not defined, no changes are allowed.
 # For backward compatibility, "yes" = "rwh" and "no" = "frwh".
-# 
+#
 CHFN_RESTRICT		rwh
 
 #
@@ -273,5 +273,3 @@ FORCE_SHADOW    no
 #
 #CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?
 CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$-]\?
-
-GROUPADD_CMD            /usr/sbin/groupadd.local

--- a/library/general/test/data/login.defs/vendor/usr/etc/login.defs
+++ b/library/general/test/data/login.defs/vendor/usr/etc/login.defs
@@ -226,34 +226,11 @@ ENCRYPT_METHOD SHA512
 DEFAULT_HOME	yes
 
 #
-# If defined, this command is run when adding a user.
-# It should rebuild any NIS database etc. to add the
-# new created account.
-#
-USERADD_CMD             /usr/sbin/useradd.local
-
-#
 # If defined, this command is run when removing a user.
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
 #
-# See also USERDEL_PRECMD and USERDEL_POSTCMD below.
-#
 #USERDEL_CMD	/usr/sbin/userdel_local
-
-#
-# If defined, this command is run before removing a user.
-# It should remove any at/cron/print jobs etc. owned by
-# the user to be removed.
-#
-USERDEL_PRECMD          /usr/sbin/userdel-pre.local
-
-#
-# If defined, this command is run after removing a user.
-# It should rebuild any NIS database etc. to remove the
-# account from it.
-#
-USERDEL_POSTCMD         /usr/sbin/userdel-post.local
 
 #
 # Enable setting of the umask group bits to be the same as owner bits

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct  1 13:28:34 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Removed obsolete USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD,
+  GROUPADD_CMD (bsc#1231006)
+- 5.0.10
+
+-------------------------------------------------------------------
 Wed Jul 10 12:19:16 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Re-added missing error class (bsc#1227580) 

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.9
+Version:        5.0.10
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1231006


## Main PR

https://github.com/yast/yast-security/pull/160


## Details

This removes obsolete parameters from `/etc/login.defs`:

- USERADD_CMD
 - USERDEL_PRECMD
- USERDEL_POSTCMD
- USERADD_CMD

More details at the [main PR](https://github.com/yast/yast-security/pull/160).