### PR TITLE
do not test exact wording in xml exception

### DIFF
--- a/library/xml/test/xml_test.rb
+++ b/library/xml/test/xml_test.rb
@@ -129,7 +129,7 @@ describe "Yast::XML" do
       it "raises XMLSerializationError when key is not string" do
         input = { "test" => { "a" => "b", "lest" => :lest, 1 => 2, nil => "t", :symbol => "symbol" } }
 
-        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError, /non-string key.*nil=>"t"/)
+        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError)
       end
 
       it "places keys in alphabetic sorting" do
@@ -150,13 +150,13 @@ describe "Yast::XML" do
       it "raises XMLSerializationError when entry has nil as value" do
         input = { "test" => { "a" => "b", "b" => "c", "c" => nil, "d" => "e", "e" => "f" } }
 
-        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError, /represent nil, part of .*"c"=>nil/)
+        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError)
       end
 
       it "raises XMLSerializationError when entry has a weird value" do
         input = { "test" => /I am a Regexp/ }
 
-        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError, /represent .*Regexp\//)
+        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError)
       end
     end
 
@@ -193,7 +193,7 @@ describe "Yast::XML" do
       it "raises XMLSerializationError when list contains nil" do
         input = { "test" => ["a", "b", nil, "d", "e", "f"] }
 
-        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError, /represent nil, part of .*"b", nil/)
+        expect { subject.YCPToXMLString("test", input) }.to raise_error(Yast::XMLSerializationError)
       end
     end
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan  2 06:51:16 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix failing tests with ruby 3.4 (gh#yast/yast-yast2#1314)
+- 5.0.11
+
+-------------------------------------------------------------------
 Tue Oct  1 13:28:34 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Removed obsolete USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD,

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.10
+Version:        5.0.11
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

Ruby 3.4 use nicer formatting in inspect. And Yast2.rpm tests failing. with something like

```
expected Yast::XMLSerializationError with message matching /represent nil, part of .*"c"=>nil/, got #<Yast::XMLSerializationError: Cannot represent nil, part of {"a" => "b", "b" => "c", "c" => nil, "d" => "e", "e" => "f"}>
```


## Solution

Do not test exact wording in yast exception and test just that exception is properly raised with proper type.
