### PR TITLE
read agama kernel params if available (bsc#1234678)

### DIFF
--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -174,7 +174,10 @@ module Yast
         # not using dedicated agent in order to use the same parser for cmdline
         # independently on whether it comes from /proc/cmdline or /etc/install.inf
         # use local read as it does not make sense to depend on binding it to chroot
-        WFM.Read(path(".local.string"), "/proc/cmdline").to_s
+        # and first check if there is dedicated agama filtered kernel parameters (bsc#1234678)
+        agama_path = "/run/agama/cmdline.d/kernel"
+        file_path = File.exist?(agama_path) ? agama_path : "/proc/cmdline"
+        WFM.Read(path(".local.string"), file_path).to_s
       else
         SCR.Read(path(".etc.install_inf.Cmdline")).to_s
       end


### PR DESCRIPTION
## Problem

Agama when proposing bootloader configuration getting all agama related parameters without any filtering.

[bsc 1234678](https://bugzilla.suse.com/show_bug.cgi?id=1234678)

## Solution

Use specific agama cmdline file that contain only kernel related arguments without any agama specific ones.
It needs also https://github.com/agama-project/agama/pull/1896 . But it does not crash without it, just will again fallback to /proc/cmdline.

## Testing

- *Added a new unit test*
- *Tested manually*

