### PR TITLE
Respect Agama kernel parameters

### DIFF
--- a/library/system/src/modules/Kernel.rb
+++ b/library/system/src/modules/Kernel.rb
@@ -170,13 +170,16 @@ module Yast
       return if !(Stage.initial || Stage.cont)
 
       # Check if /etc/install.inf exists
-      tmp = if SCR.Dir(path(".etc.install_inf")).empty?
+      tmp = if !SCR.Dir(path(".etc.install_inf")).empty?
+        SCR.Read(path(".etc.install_inf.Cmdline")).to_s
+      # else check if there is agama specific filtered kernel options
+      elsif ::File.exist?("/run/agama/cmdline.d/kernel.conf")
+        WFM.Read(path(".local.string"), "/run/agama/cmdline.d/kernel.conf").to_s
+      else
         # not using dedicated agent in order to use the same parser for cmdline
         # independently on whether it comes from /proc/cmdline or /etc/install.inf
         # use local read as it does not make sense to depend on binding it to chroot
         WFM.Read(path(".local.string"), "/proc/cmdline").to_s
-      else
-        SCR.Read(path(".etc.install_inf.Cmdline")).to_s
       end
 
       Builtins.y2milestone(

--- a/library/system/test/kernel_test.rb
+++ b/library/system/test/kernel_test.rb
@@ -152,6 +152,7 @@ describe Yast::Kernel do
     before do
       allow(Yast::SCR).to receive(:Dir).with(path(".etc.install_inf")).and_return(["CmdLine"])
       allow(Yast::SCR).to receive(:Read).with(path(".etc.install_inf.Cmdline")).and_return(cmdline)
+      allow(::File).to receive(:exist?).and_return(false)
       allow(Yast::Stage).to receive(:initial).and_return(true)
       allow(Yast::Arch).to receive(:architecture).and_return("x86_64")
     end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb 20 16:09:57 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- respect kernel parameter filtering from agama if found
+  (bsc#1237390,bsc#1234678)
+- 5.0.12
+
+-------------------------------------------------------------------
 Thu Jan  2 06:51:16 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix failing tests with ruby 3.4 (gh#yast/yast-yast2#1314)
@@ -14,7 +21,7 @@ Tue Oct  1 13:28:34 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 -------------------------------------------------------------------
 Wed Jul 10 12:19:16 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
-- Re-added missing error class (bsc#1227580) 
+- Re-added missing error class (bsc#1227580)
 - 5.0.9
 
 -------------------------------------------------------------------

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.11
+Version:        5.0.12
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

Agama do not use linuxrc for kernel parameters filtering. Result is that even installation parameters are proposed to target system.

bsc: 
- [1234678](https://bugzilla.suse.com/show_bug.cgi?id=1234678)
- https://bugzilla.suse.com/show_bug.cgi?id=1237390


## Solution

Read kernel parameters from agama file if it is available.


## Testing

- *Tested manually*
