### PR TITLE
Checking for valid TPM2 devices

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -433,7 +433,7 @@ module Yast
     #
     # @return [Boolean] true if a TPM2 chip is available; false otherwise
     def has_tpm2
-      @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version").strip == "2.0" if @_has_tpm2.nil?
+      @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version")&.strip == "2.0" if @_has_tpm2.nil?
       @_has_tpm2
     end
 

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -45,6 +45,8 @@ module Yast
 
       @_has_pcmcia = nil
 
+      @_has_tpm2 = nil
+
       @_is_laptop = nil
 
       @_is_uml = nil
@@ -427,6 +429,14 @@ module Yast
       SCR.Read(path(".target.string"), "/sys/hypervisor/guest_type").strip == "PV"
     end
 
+    # Whether a TPM2 chip is available or not.
+    #
+    # @return [Boolean] true if a TPM2 chip is available; false otherwise
+    def has_tpm2
+      @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version").strip == "2.0" if @_has_tpm2.nil?
+      @_has_tpm2
+    end
+
     # Convenience method to retrieve the /proc/xen/capabilities content
     #
     # @return [String]
@@ -577,6 +587,7 @@ module Yast
     publish function: :board_pegasos, type: "boolean ()"
     publish function: :board_wintel, type: "boolean ()"
     publish function: :has_pcmcia, type: "boolean ()"
+    publish function: :has_tpm2, type: "boolean ()"
     publish function: :is_laptop, type: "boolean ()"
     publish function: :is_uml, type: "boolean ()"
     publish function: :is_xen, type: "boolean ()"

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -339,7 +339,7 @@ describe Yast::Arch do
       expect(has_tpm2).to eq(false)
     end
 
-    it "returns false if /sys/module/tpm/version does not exists" do
+    it "returns false if /sys/module/tpm/version does not exist" do
       allow(Yast::SCR).to receive(:Read)
         .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return(nil)
 

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -319,4 +319,33 @@ describe Yast::Arch do
       end
     end
   end
+
+  describe ".has_tpm2" do
+    it "returns true if /sys/module/tpm/version is set correctly" do
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return("2.0")
+
+      has_tpm2 = Yast::Arch.has_tpm2
+
+      expect(has_tpm2).to eq(true)
+    end
+
+    it "returns false if /sys/module/tpm/version has wrong version" do
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return("1.0")
+
+      has_tpm2 = Yast::Arch.has_tpm2
+
+      expect(has_tpm2).to eq(false)
+    end
+
+    it "returns false if /sys/module/tpm/version does not exists" do
+      allow(Yast::SCR).to receive(:Read)
+        .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return(nil)
+
+      has_tpm2 = Yast::Arch.has_tpm2
+
+      expect(has_tpm2).to eq(false)
+    end
+  end
 end

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar 12 11:48:52 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Checking if a TPM2 device is available (has_tpm2). (jsc#PED-10703)
+- 5.0.13
+
+-------------------------------------------------------------------
 Thu Feb 20 16:09:57 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - respect kernel parameter filtering from agama if found

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.12
+Version:        5.0.13
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

Encryptions with LUKS2 should also be supported by TPM2 devices. Further steps will be done in yast-storage-ng and yast-bootloader.
We need a general call which evaluates if TPM2 is available at all.

## Solution

New Call "Arch.has_tpm2"

## Testing

- Added a new unit test
- Tested manually

