### PR TITLE
WIP: Drop YaST Command Line Interface Support

### DIFF
--- a/library/commandline/src/modules/CommandLine.rb
+++ b/library/commandline/src/modules/CommandLine.rb
@@ -1209,6 +1209,7 @@ module Yast
         return true
       else
         Mode.SetUI("commandline")
+        fatal_no_more_cli_support # This does not return
       end
 
       if !cmdline_supported
@@ -1722,6 +1723,15 @@ module Yast
       list[0..-2].map { |l| "'#{l}'" }.join(", ") + " " +
         Builtins.sformat(_("or '%1'"), list[-1])
     end
+  end
+
+  # Write a message that yast-cli is not supported anymore to stderr and
+  # to the log and exit with an error code.
+  def fatal_no_more_cli_support
+    msg = "FATAL: The YaST command line interface is not supported anymore. Exiting."
+    log.error(msg)
+    warn(msg)
+    exit(1)
   end
 
   CommandLine = CommandLineClass.new

--- a/library/commandline/test/commandline_test.rb
+++ b/library/commandline/test/commandline_test.rb
@@ -33,8 +33,7 @@ describe Yast::CommandLine do
   it "exits with an error message" do
     expect {
       begin
-        # Yast::WFM.CallFunction("dummy_cmdline", ["echo", "text=something"])
-        Yast::WFM.CallFunction("dummy_cmdline")
+        Yast::WFM.CallFunction("dummy_cmdline", ["echo", "text=something"])
       rescue Exception => ex
         # puts "Caught #{ex.class}"
       end

--- a/library/commandline/test/commandline_test.rb
+++ b/library/commandline/test/commandline_test.rb
@@ -30,6 +30,17 @@ describe Yast::CommandLine do
   # all "expect($stdout)" lines otherwise the byebug output will be
   # lost in the rspec mocks and you won't see anything.
 
+  it "exits with an error message" do
+    expect {
+      begin
+        # Yast::WFM.CallFunction("dummy_cmdline", ["echo", "text=something"])
+        Yast::WFM.CallFunction("dummy_cmdline")
+      rescue Exception => ex
+        # puts "Caught #{ex.class}"
+      end
+    }.to output(/FATAL.*not supported anymore/).to_stderr
+  end
+
   it "invokes initialize, handler and finish" do
     expect($stdout).to receive(:puts).with("Initialize called").ordered
     expect($stdout).to receive(:puts).with("something").ordered


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1243018


## Problem / Motivation

YaST is only used as a library for the Agama backend in SLES-16 / Leap 16.

The functionality of YaST goes much further, but  we cannot guarantee that all the details and all the behavior in YaST are compatible in every detail with SLES-16 / Leap 16. This will create pitfalls for users who may find a way to still use YaST functionality that will then increasingly be outdated.

In long run, this will be true for Factory / Tumbleweed as well.

So we are starting to prevent pitfalls with this: The YaST command line  interface (CLI) should not be accessible anymore. This is even more important because this is an aspect of YaST that is less commonly used and thus less thoroughly tested.


## Fix

This PR makes the YaST  CLI unaccessible: When trying to use it, it will simply exit with an error message in the log and on stderr.

```console
sh@balrog:~> sudo yast2 lan list
FATAL: The YaST command line interface is not supported anymore. Exiting.
sh@balrog:~>
```

```console
sh@balrog:~> sudo yast2 lan
```
(-> The YaST lan module starts normally)
