### PR TITLE
Improve recognition of TPM devices

### DIFF
--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -433,8 +433,10 @@ module Yast
     #
     # @return [Boolean] true if a TPM2 chip is available; false otherwise
     def has_tpm2
-      @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version")&.strip == "2.0" if @_has_tpm2.nil?
-      @_has_tpm2
+      if @_has_tpm2.nil?
+        @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version")&.strip == "2.0"
+        @_has_tpm2 = @_has_tpm2 && Dir['/dev/tpm*'].any?
+      end
     end
 
     # Convenience method to retrieve the /proc/xen/capabilities content

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -435,8 +435,9 @@ module Yast
     def has_tpm2
       if @_has_tpm2.nil?
         @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version")&.strip == "2.0"
-        @_has_tpm2 = @_has_tpm2 && Dir.glob('/dev/tpm*').any?
+        @_has_tpm2 &&= Dir.glob("/dev/tpm*").any?
       end
+      @has_tpm2
     end
 
     # Convenience method to retrieve the /proc/xen/capabilities content

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -434,10 +434,10 @@ module Yast
     # @return [Boolean] true if a TPM2 chip is available; false otherwise
     def has_tpm2
       if @_has_tpm2.nil?
-        @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version")&.strip == "2.0"
-        @_has_tpm2 &&= Dir.glob("/dev/tpm*").any?
+        @_has_tpm2 = SCR.Read(path(".target.string"),
+          "/sys/class/tpm/tpm0/tpm_version_major")&.strip == "2"
       end
-      @has_tpm2
+      @_has_tpm2
     end
 
     # Convenience method to retrieve the /proc/xen/capabilities content

--- a/library/general/src/modules/Arch.rb
+++ b/library/general/src/modules/Arch.rb
@@ -435,7 +435,7 @@ module Yast
     def has_tpm2
       if @_has_tpm2.nil?
         @_has_tpm2 = SCR.Read(path(".target.string"), "/sys/module/tpm/version")&.strip == "2.0"
-        @_has_tpm2 = @_has_tpm2 && Dir['/dev/tpm*'].any?
+        @_has_tpm2 = @_has_tpm2 && Dir.glob('/dev/tpm*').any?
       end
     end
 

--- a/library/general/test/arch_test.rb
+++ b/library/general/test/arch_test.rb
@@ -321,27 +321,30 @@ describe Yast::Arch do
   end
 
   describe ".has_tpm2" do
-    it "returns true if /sys/module/tpm/version is set correctly" do
+    it "returns true if /sys/class/tpm/tpm0/tpm_version_major is set correctly" do
       allow(Yast::SCR).to receive(:Read)
-        .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return("2.0")
+        .with(Yast::Path.new(".target.string"),
+          "/sys/class/tpm/tpm0/tpm_version_major").and_return("2")
 
       has_tpm2 = Yast::Arch.has_tpm2
 
       expect(has_tpm2).to eq(true)
     end
 
-    it "returns false if /sys/module/tpm/version has wrong version" do
+    it "returns false if /sys/class/tpm/tpm0/tpm_version_major has wrong version" do
       allow(Yast::SCR).to receive(:Read)
-        .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return("1.0")
+        .with(Yast::Path.new(".target.string"),
+          "/sys/class/tpm/tpm0/tpm_version_major").and_return("1")
 
       has_tpm2 = Yast::Arch.has_tpm2
 
       expect(has_tpm2).to eq(false)
     end
 
-    it "returns false if /sys/module/tpm/version does not exist" do
+    it "returns false if /sys/class/tpm/tpm0/tpm_version_major does not exist" do
       allow(Yast::SCR).to receive(:Read)
-        .with(Yast::Path.new(".target.string"), "/sys/module/tpm/version").and_return(nil)
+        .with(Yast::Path.new(".target.string"),
+          "/sys/class/tpm/tpm0/tpm_version_major").and_return(nil)
 
       has_tpm2 = Yast::Arch.has_tpm2
 

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul  7 09:49:51 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Improved checking TPM2 device. (bsc#1245247)
+- 5.0.14
+
+-------------------------------------------------------------------
 Wed Mar 12 11:48:52 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Checking if a TPM2 device is available (has_tpm2). (jsc#PED-10703)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -2101,7 +2101,6 @@ Wed Oct  3 07:48:30 UTC 2018 - knut.anderssen@suse.com
   (fate#324662)
 
 -------------------------------------------------------------------
-
 Tue Oct  2 11:11:26 UTC 2018 - lslezak@suse.cz
 
 - Make the service status label stretchable so the updated status
@@ -3120,7 +3119,6 @@ Fri Mar 24 09:37:44 UTC 2017 - lslezak@suse.cz
 - 3.2.22
 
 -------------------------------------------------------------------
-
 Wed Mar 22 16:53:07 UTC 2017 - jreidinger@suse.com
 
 - Use for Yast::TargetFile and Yast::Execute real path where scr

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.13
+Version:        5.0.14
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

*Short description of the original problem.*
- bsc#1245247
- /sys/module/tpm/version includes the version of the kernel module only.

## Solution

Checking /sys/class/tpm/tpm0/tpm_version_major instead of /sys/module/tpm/version

## Testing

- *Updated unit test*
- *Tested manually*



