### PR TITLE
[SLE-15-SP7] Do not install packages to inst-sys (bsc#1240867)

### DIFF
--- a/library/packages/src/modules/Package.rb
+++ b/library/packages/src/modules/Package.rb
@@ -39,6 +39,7 @@ Yast.import "Mode"
 Yast.import "PackageAI"
 Yast.import "PackageSystem"
 Yast.import "Popup"
+Yast.import "Stage"
 
 module Yast
   # This module implements support to query, install and remove packages.
@@ -146,7 +147,7 @@ module Yast
     # @return [Boolean] true if installation succeeded or packages were installed,
     # false otherwise
     def CheckAndInstallPackages(packages)
-      return true if Mode.config
+      return true if Mode.config || Stage.initial
       return true if InstalledAll(packages)
 
       InstallAll(packages)

--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Jul 18 09:38:48 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
+
+- Do not try installing packages into the inst-sys during
+  installation (bsc#1240867)
+- 4.7.1
+
+-------------------------------------------------------------------
 Thu Sep 05 08:36:09 UTC 2024 - Ladislav Slezák <lslezak@suse.com>
 
 - Branch package for SP7 (bsc#1208913)

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        4.7.0
+Version:        4.7.1
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

- When configuring iSCSI during installation YaST wants to install the `open-iscsi` package.
- But that's wrong, it is already present in the inst-sys, it should not try installing it.

## Details

- The bug is caused by [removing the `Stage.initial` condition](https://github.com/yast/yast-iscsi-client/pull/126/files#diff-c98c4ad79e5a73a1d5010e6ca8beeb0295c86cb0461acbc0ce9885cc1bb1359cL104) from the `yast2-iscsi-client` package.

## Solution

- Let's add the condition directly into the `Package` module to fix it globally.


## Testing

- Tested manually

## Screenshots

Originally the user was asked to confirm the package installation...

<img width="1280" height="800" alt="y2-iscsi-broken" src="https://github.com/user-attachments/assets/3c628642-1685-47c5-96c0-cb24b0496ffc" />

... which fails in the inst-sys:

<img width="1280" height="800" alt="y2-iscsi-broken2" src="https://github.com/user-attachments/assets/fd74451b-6193-49f2-a073-84edae6acdea" />

With the fix there is no question and the iSCSI configuration is displayed immediately:

<img width="1280" height="800" alt="y2-iscsi-fixed" src="https://github.com/user-attachments/assets/b30920d7-55d8-4857-813b-75a1300e3d14" />
