### PR TITLE
Checking for TPM version. TPM2 < 1.38 will not be supported. (WIP)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 30 18:23:45 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Checking for TPM version. TPM2 < 1.38 will not be supported
+  (bsc#1250403).
+- 5.0.17
+
+-------------------------------------------------------------------
 Fri Jul 18 09:38:48 UTC 2025 - Ladislav Slezák <lslezak@suse.com>
 
 - Do not try installing packages into the inst-sys during

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.15
+Version:        5.0.16
 
 Release:        0
 Summary:        YaST2 Main Package


### PR DESCRIPTION
## Problem

systemd-pcrlock is using PolicyAuthorizeNV to store the policy inside
the TPM2's non volatile RAM.  This feature is supported after TPM2 1.38
revision, and without it systemd-pcrlock will fail. These PR checks
for version > 1.38 (bsc#1250403)
tpm_fde is not affected because it is using it's own tool to recognize TPM.

- https://bugzilla.opensuse.org/show_bug.cgi?id=1250403

## Solution

Checking for version > 1.38

## Testing

- Added a new unit test
- Tested manually


