### PR TITLE
Drop libyui dependency in SLES (related to bsc#1254978)

### DIFF
--- a/package/yast2.changes
+++ b/package/yast2.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 15 08:26:47 UTC 2026 - Ladislav Slezák <lslezak@suse.com>
+
+- Drop libyui dependency in SLES (related to bsc#1254978)
+- 5.0.19
+
+-------------------------------------------------------------------
 Tue Jan  6 13:29:03 UTC 2026 - Martin Vidner <mvidner@suse.com>
 
 - save_y2logs: Do not use the legacy /var/lib/rpm database path

--- a/package/yast2.spec
+++ b/package/yast2.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2
-Version:        5.0.18
+Version:        5.0.19
 
 Release:        0
 Summary:        YaST2 Main Package
@@ -57,8 +57,19 @@ BuildRequires:  rubygem(%rb_default_ruby_abi:nokogiri)
 # log.group call
 BuildRequires:  yast2-ruby-bindings >= 4.5.4
 BuildRequires:  yast2-testsuite
+
+# use the standard UI in openSUSE Tumbleweed or Leap
+%if 0%{?suse_version} == 1699 || 0%{?is_opensuse}
+Requires:       yui_backend
 # Nested items in tables
 BuildRequires:  yast2-ycp-ui-bindings >= 4.3.3
+Requires:       yast2-ycp-ui-bindings >= 4.3.3
+%else
+# use dummy UI in SLES
+BuildRequires:  yast2-ycp-ui-bindings-dummy-devel
+Requires:       yast2-ycp-ui-bindings-dummy
+%endif
+
 # for the PackageExtractor tests, just make sure they are present,
 # these should be installed in the default build anyway
 BuildRequires:  cpio
@@ -92,9 +103,6 @@ Requires:       yast2-perl-bindings
 Requires:       yast2-pkg-bindings >= 4.3.7
 # log.group
 Requires:       yast2-ruby-bindings >= 4.5.4
-# Nested items in tables
-Requires:       yast2-ycp-ui-bindings >= 4.3.3
-Requires:       yui_backend
 # scripts for collecting YAST logs
 Requires:       yast2-logs
 # for the PackageExtractor class, just make sure they are present,


### PR DESCRIPTION
## Problem

- The YaST packages used by Agama still require libyui libraries, that means we have to maintain them in the SLES16 product
- Related PR https://github.com/yast/yast-ycp-ui-bindings-dummy/pull/1

## Solution

- Update the dependencies so in SLES the yast2-ycp-ui-bindings-dummy package is used instead of the regular bindings.

## Testing

- Tested manually
  - https://build.opensuse.org/project/show/systemsmanagement:Agama:branches:dummy-ui project builds the Agama installer ISO for openSUSE Tumbleweed ([build log](https://build.opensuse.org/build/systemsmanagement:Agama:branches:dummy-ui/images/x86_64/agama-installer:openSUSE/_log)) and openSUSE Leap([build log](https://build.opensuse.org/build/systemsmanagement:Agama:branches:dummy-ui/images_Leap_16.0/x86_64/agama-installer-Leap:Leap_16.0/_log)), both logs show that the libyui is installed in the images (that's expected as both contain full YaST so we cannot drop the UI there)

  - https://build.suse.de/project/show/Devel:YaST:Agama:dummy-ui project (internal link) builds the SLES image, the libyui packages are not included in the image
